### PR TITLE
Add malloc async functionality to ROCm

### DIFF
--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -528,7 +528,9 @@ tsl_gpu_library(
     srcs = [
         "gpu_cudamallocasync_allocator.cc",
     ],
-    hdrs = ["gpu_cudamallocasync_allocator.h"],
+    hdrs = ["gpu_cudamallocasync_allocator.h",
+	        "gpu_types.h",
+	       ], 
     cuda_deps = [
         "//xla/stream_executor/cuda:cuda_activation",
         "//xla/stream_executor/cuda:cuda_executor",
@@ -545,7 +547,8 @@ tsl_gpu_library(
         "@tsl//tsl/platform:macros",
         "@tsl//tsl/platform:mutex",
         "@tsl//tsl/util:env_var",
-    ],
+    ] + if_rocm_is_configured([
+		         "//xla/stream_executor/rocm:rocm_activation"]),
 )
 
 cc_library(

--- a/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
+++ b/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
@@ -27,11 +27,12 @@ limitations under the License.
 #include "tsl/framework/device_id.h"
 #include "tsl/platform/macros.h"
 #include "tsl/platform/mutex.h"
+#include "xla/stream_executor/gpu/gpu_types.h"
 
 #if GOOGLE_CUDA
-#include "third_party/gpus/cuda/include/cuda.h"
-
 #define TF_CUDA_MALLOC_ASYNC_SUPPORTED CUDA_VERSION >= 11020
+#elif TENSORFLOW_USE_ROCM
+#define TF_CUDA_MALLOC_ASYNC_SUPPORTED TF_ROCM_VERSION >= 50300
 #endif  // GOOGLE_CUDA
 
 
@@ -105,12 +106,12 @@ class GpuCudaMallocAsyncAllocator : public tsl::Allocator {
   // stream. So we do not need to ask cudaMallocAsync to add extra
   // synchronization.
   // Not owned.
-  CUstream cuda_stream_;
+  GpuStreamHandle cuda_stream_;
 
   // Not owned. The default pool of the associated GPU.
   // If null, then the instanciation failed and the first allocation
   // will return an error.
-  CUmemoryPool pool_;
+  GpuMemoryPoolHandle pool_;
 #endif  // TF_CUDA_MALLOC_ASYNC_SUPPORTED
 
   // Just a counter for the number of time this class is instantiated.

--- a/xla/stream_executor/gpu/gpu_types.h
+++ b/xla/stream_executor/gpu/gpu_types.h
@@ -62,6 +62,8 @@ using GpuGraphHandle = hipGraph_t;
 using GpuGraphExecHandle = hipGraphExec_t;
 using GpuGraphNodeHandle = hipGraphNode_t;
 using GpuGraphConditionalHandle = UnsupportedGpuFeature;
+using GpuMemoryPoolHandle = hipMemPool_t;
+using GpuMemAccessDesc = hipMemAccessDesc;
 #else  // CUDA
 
 using GpuContextHandle = CUcontext;
@@ -82,6 +84,8 @@ using GpuDoubleComplexType = cuDoubleComplex;
 using GpuGraphHandle = CUgraph;
 using GpuGraphExecHandle = CUgraphExec;
 using GpuGraphNodeHandle = CUgraphNode;
+using GpuMemoryPoolHandle = CUmemoryPool;
+using GpuMemAccessDesc = CUmemAccessDesc;
 
 #if CUDA_VERSION >= 12030
 using GpuGraphConditionalHandle = CUgraphConditionalHandle;


### PR DESCRIPTION
The xla upstream put the source files implementing platform dependent (CUDA) malloc async in the directory `xla/stream_executor/gpu/.` This directory is not supposed to have platform dependent implementation.<mark> Not sure why the upstream is doing this.</mark> I think that the canonical way is adding APIs in `gpu_driver.h` and putting the platform dependent implementation in the corresponding vendor directories, i.e. `cuda` or `rocm`. The macros in current implementation will be largely reduced if the canonical implementation is adopted.  The existing APIs in the driver can be reused. 

The current implementation does not change macros defined in the original implementation. Those macros contain the acronym CUDA. The macros will not affect other parts of the code base if handled properly. 