### PR TITLE
changes for spack

### DIFF
--- a/third_party/tsl/tsl/platform/default/rocm_rocdl_path.cc
+++ b/third_party/tsl/tsl/platform/default/rocm_rocdl_path.cc
@@ -40,6 +40,13 @@ string RocmRoot() {
 #endif
 }
 
-string RocdlRoot() { return io::JoinPath(RocmRoot(), "amdgcn/bitcode"); }
+string RocdlRoot() {
+  if (const char* device_lib_path_env = std::getenv("HIP_DEVICE_LIB_PATH")) {
+   return device_lib_path_env;
+  }
+  else{
+   return io::JoinPath(RocmRoot(), "amdgcn/bitcode");
+  }
+}
 
 }  // namespace tsl

--- a/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -854,7 +854,13 @@ absl::StatusOr<std::vector<uint8_t>> EmitModuleToHsaco(
     ir_fs->flush();
   }
   // Locate lld.
-  std::string lld_path = tsl::io::JoinPath(tsl::RocmRoot(), "llvm/bin");
+  std::string lld_path;
+  if (std::getenv("LLVM_PATH")) {
+    lld_path = tsl::io::JoinPath(std::getenv("LLVM_PATH"), "bin");
+  }
+  else{
+    lld_path = tsl::io::JoinPath(tsl::RocmRoot(), "llvm/bin");
+  }
   auto lld_program = llvm::sys::findProgramByName("ld.lld", {lld_path});
   if (!lld_program) {
     return xla::Internal("unable to find ld.lld in PATH: %s",


### PR DESCRIPTION
Add conditions to check if HIP_DEVICE_LIB_PATH and LLVM_PATH are set because the bitcode and LLVM bin directories are not contained in the ROCM_PATH when using spack built ROCm. These changes are requred to build tensorflow on spack with spack built ROCm binaries. These changes are also being pushed to TF upstream(https://github.com/ROCm/tensorflow-upstream/pull/2578)