### PR TITLE
Fixing gemm_algorithm_picker_test due to missing commit

### DIFF
--- a/xla/service/gpu/gemm_algorithm_picker_test.cc
+++ b/xla/service/gpu/gemm_algorithm_picker_test.cc
@@ -106,7 +106,7 @@ TF_ASSERT_OK_AND_ASSIGN(auto module,
     TF_ASSERT_OK_AND_ASSIGN(
       bool changed,
       RunHloPass(
-          GemmRewriter(gpu_comp(), /*toolkit_version=*/12040),
+          GemmRewriter(gpu_comp()),
           module.get()));
 
     AutotuneConfig cfg{DeviceConfig{stream_exec(), nullptr}, debug_opts};
@@ -135,7 +135,7 @@ TF_ASSERT_OK_AND_ASSIGN(auto module,
     TF_ASSERT_OK_AND_ASSIGN(
       bool changed,
       RunHloPass(
-          GemmRewriter(gpu_comp(), /*toolkit_version=*/12040),
+          GemmRewriter(gpu_comp()),
           module.get()));
 
     AutotuneConfig cfg{DeviceConfig{stream_exec(), nullptr}, debug_opts};
@@ -165,7 +165,7 @@ ENTRY main {
   TF_ASSERT_OK_AND_ASSIGN(
       changed,
       RunHloPass(
-          GemmRewriter(gpu_comp(), /*toolkit_version=*/12040),
+          GemmRewriter(gpu_comp()),
           m.get()));
   changed = false;
   DebugOptions opts;
@@ -192,7 +192,7 @@ ENTRY main {
   TF_ASSERT_OK_AND_ASSIGN(
       changed,
       RunHloPass(
-          GemmRewriter(gpu_comp(), /*toolkit_version=*/12040),
+          GemmRewriter(gpu_comp()),
           m.get()));
   changed = false;
   TF_ASSERT_OK_AND_ASSIGN(changed,
@@ -226,7 +226,7 @@ ENTRY main {
   TF_ASSERT_OK_AND_ASSIGN(
       changed,
       RunHloPass(
-          GemmRewriter(gpu_comp(), /*toolkit_version=*/12040),
+          GemmRewriter(gpu_comp()),
           m.get()));
   changed = false;
 
@@ -260,8 +260,7 @@ ENTRY main {
   TF_ASSERT_OK_AND_ASSIGN(
       changed,
       RunHloPass(
-          GemmRewriter(gpu_comp(),
-              /*toolkit_version=*/12040),
+          GemmRewriter(gpu_comp()),
           m.get()));
   changed = false;
   TF_ASSERT_OK_AND_ASSIGN(


### PR DESCRIPTION
There was a missing GemmRewriter commit: https://github.com/openxla/xla/commit/4b7f6ebbcd9bc06da7d56d568638434d58f7f251 which caused this test to fail at runtime (but it builds fine due to default argument **f8_rewrite**) 

Original cherry-picked commit: https://github.com/ROCm/xla/commit/7ba611d343c5806c21c22cb93efc9977b5dfa786 
