### PR TITLE
draft of rocprofiler-sdk into XLA

### DIFF
--- a/third_party/tsl/third_party/gpus/rocm_configure.bzl
+++ b/third_party/tsl/third_party/gpus/rocm_configure.bzl
@@ -206,6 +206,9 @@ def _rocm_include_path(repository_ctx, rocm_config, bash_bin):
     inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/17/include")
     inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/18/include")
 
+    if int(rocm_config.rocm_version_number) >= 60200:
+        inc_dirs.append(rocm_toolkit_path + "/lib/llvm/lib/clang/18/include")
+
     # Support hcc based off clang 10.0.0 (for ROCm 3.3)
     inc_dirs.append(rocm_toolkit_path + "/hcc/compiler/lib/clang/10.0.0/include/")
     inc_dirs.append(rocm_toolkit_path + "/hcc/lib/clang/10.0.0/include")

--- a/third_party/tsl/tsl/platform/default/dso_loader.cc
+++ b/third_party/tsl/tsl/platform/default/dso_loader.cc
@@ -170,7 +170,8 @@ absl::StatusOr<void*> GetHipsolverDsoHandle() {
 #endif
 
 absl::StatusOr<void*> GetRoctracerDsoHandle() {
-  return GetDsoHandle("roctracer64", "");
+  // return GetDsoHandle("roctracer64", "");
+  return GetDsoHandle("rocprofiler-sdk", "");
 }
 
 absl::StatusOr<void*> GetHipsparseDsoHandle() {

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -31,7 +31,7 @@ tsl_gpu_library(
         ":cupti_collector",
         ":cupti_tracer",
         ":cupti_wrapper",
-        ":rocm_collector",
+        # ":rocm_collector",
         ":rocm_tracer",
     ],
     deps = [
@@ -213,6 +213,7 @@ tsl_gpu_library(
     ],
 )
 
+"""
 tsl_gpu_library(
     name = "rocm_collector",
     srcs = if_rocm(["rocm_collector.cc"]),
@@ -247,6 +248,7 @@ tsl_gpu_library(
         "@tsl//tsl/profiler/utils:xplane_utils",
     ],
 )
+"""
 
 tsl_gpu_library(
     name = "rocm_tracer",
@@ -255,7 +257,8 @@ tsl_gpu_library(
     copts = tf_profiler_copts() + tsl_copts(),
     visibility = ["//visibility:public"],
     deps = [
-        ":rocm_collector",
+        #":rocm_collector",
+        "//xla/backends/profiler/gpu/common:common_headers",
         "//xla/stream_executor/rocm:roctracer_wrapper",
         "@com_google_absl//absl/container:fixed_array",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -213,7 +213,7 @@ tsl_gpu_library(
     ],
 )
 
-"""
+
 tsl_gpu_library(
     name = "rocm_collector",
     srcs = if_rocm(["rocm_collector.cc"]),
@@ -248,7 +248,6 @@ tsl_gpu_library(
         "@tsl//tsl/profiler/utils:xplane_utils",
     ],
 )
-"""
 
 tsl_gpu_library(
     name = "rocm_tracer",
@@ -257,7 +256,7 @@ tsl_gpu_library(
     copts = tf_profiler_copts() + tsl_copts(),
     visibility = ["//visibility:public"],
     deps = [
-        #":rocm_collector",
+        ":rocm_collector",
         "//xla/backends/profiler/gpu/common:common_headers",
         "//xla/stream_executor/rocm:roctracer_wrapper",
         "@com_google_absl//absl/container:fixed_array",

--- a/xla/backends/profiler/gpu/common/BUILD
+++ b/xla/backends/profiler/gpu/common/BUILD
@@ -1,0 +1,32 @@
+load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
+load(
+    "@tsl//tsl/platform:build_config.bzl",
+    "tf_additional_device_tracer_srcs",
+)
+load(
+    "@tsl//tsl/platform/default:cuda_build_defs.bzl",
+    "if_cuda_is_configured",
+)
+load("@tsl//tsl/profiler/builds:build_config.bzl", "tf_profiler_copts")
+load("//xla/tests:build_defs.bzl", "xla_test")
+load(
+    "//xla/tsl:tsl.bzl",
+    "internal_visibility",
+    "tsl_copts",
+    "tsl_gpu_library",
+)
+
+
+cc_library(
+    name = "common_headers",
+    hdrs = [
+        "call_stack.hpp",
+        "defines.hpp",
+        "filesystem.hpp",
+        "name_info.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//xla/stream_executor/rocm:roctracer_wrapper"]
+)

--- a/xla/backends/profiler/gpu/common/BUILD
+++ b/xla/backends/profiler/gpu/common/BUILD
@@ -1,12 +1,7 @@
-load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library", "if_cuda")
 load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load(
     "@tsl//tsl/platform:build_config.bzl",
     "tf_additional_device_tracer_srcs",
-)
-load(
-    "@tsl//tsl/platform/default:cuda_build_defs.bzl",
-    "if_cuda_is_configured",
 )
 load("@tsl//tsl/profiler/builds:build_config.bzl", "tf_profiler_copts")
 load("//xla/tests:build_defs.bzl", "xla_test")
@@ -16,7 +11,6 @@ load(
     "tsl_copts",
     "tsl_gpu_library",
 )
-
 
 cc_library(
     name = "common_headers",

--- a/xla/backends/profiler/gpu/common/call_stack.hpp
+++ b/xla/backends/profiler/gpu/common/call_stack.hpp
@@ -32,6 +32,12 @@
 #include <string>
 #include <vector>
 
+#include "tsl/platform/env.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/logging.h"
+#include "tsl/platform/macros.h"
+
+
 namespace xla {
 namespace common {
 struct source_location
@@ -71,7 +77,7 @@ print_call_stack(std::string         ofname,
         }
     }
 
-    std::cout << "Outputting collected data to " << ofname << "...\n" << std::flush;
+    // LOG(INFO) << "Outputting collected data to " << ofname;
 
     size_t n = 0;
     for(const auto& itr : _call_stack)

--- a/xla/backends/profiler/gpu/common/call_stack.hpp
+++ b/xla/backends/profiler/gpu/common/call_stack.hpp
@@ -1,0 +1,91 @@
+// MIT License
+//
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "filesystem.hpp"
+
+#include <cstdint>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace xla {
+namespace common {
+struct source_location
+{
+    std::string function = {};
+    std::string file     = {};
+    uint32_t    line     = 0;
+    std::string context  = {};
+};
+
+using call_stack_t = std::vector<source_location>;
+
+inline void
+print_call_stack(std::string         ofname,
+                 const call_stack_t& _call_stack,
+                 const char*         env_variable = "ROCPROFILER_SAMPLE_OUTPUT_FILE")
+{
+    if(auto* eofname = getenv(env_variable)) ofname = eofname;
+
+    std::ostream* ofs     = nullptr;
+    auto          cleanup = std::function<void(std::ostream*&)>{};
+
+    if(ofname == "stdout")
+        ofs = &std::cout;
+    else if(ofname == "stderr")
+        ofs = &std::cerr;
+    else
+    {
+        ofs = new std::ofstream{ofname};
+        if(ofs && *ofs)
+            cleanup = [](std::ostream*& _os) { delete _os; };
+        else
+        {
+            std::cerr << "Error outputting to " << ofname << ". Redirecting to stderr...\n";
+            ofname = "stderr";
+            ofs    = &std::cerr;
+        }
+    }
+
+    std::cout << "Outputting collected data to " << ofname << "...\n" << std::flush;
+
+    size_t n = 0;
+    for(const auto& itr : _call_stack)
+    {
+        *ofs << std::left << std::setw(2) << ++n << "/" << std::setw(2) << _call_stack.size()
+             << " [" << common::fs::path{itr.file}.filename() << ":" << itr.line << "] "
+             << std::setw(20) << itr.function;
+        if(!itr.context.empty()) *ofs << " :: " << itr.context;
+        *ofs << "\n";
+    }
+
+    *ofs << std::flush;
+
+    if(cleanup) cleanup(ofs);
+}
+}  // namespace common
+}  // namespace xla

--- a/xla/backends/profiler/gpu/common/defines.hpp
+++ b/xla/backends/profiler/gpu/common/defines.hpp
@@ -1,0 +1,83 @@
+// MIT License
+//
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "xla/stream_executor/rocm/roctracer_wrapper.h"
+namespace se = ::stream_executor;
+
+#define ROCPROFILER_VAR_NAME_COMBINE(X, Y) X##Y
+#define ROCPROFILER_VARIABLE(X, Y)         ROCPROFILER_VAR_NAME_COMBINE(X, Y)
+
+#define ROCPROFILER_WARN(result)                                                                   \
+    {                                                                                              \
+        rocprofiler_status_t ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) = result;                 \
+        if(ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) != ROCPROFILER_STATUS_SUCCESS)              \
+        {                                                                                          \
+            std::string status_msg =                                                               \
+                se::wrap::rocprofiler_get_status_string(ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__));        \
+            std::cerr << "[" << __FILE__ << ":" << __LINE__ << "] " << #result                     \
+                      << " returned error code " << ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__)    \
+                      << ": " << status_msg << ". This is just a warning!" << std::endl;           \
+        }                                                                                          \
+    }
+
+#define ROCPROFILER_CHECK(result)                                                                  \
+    {                                                                                              \
+        rocprofiler_status_t ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) = result;                 \
+        if(ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) != ROCPROFILER_STATUS_SUCCESS)              \
+        {                                                                                          \
+            std::string status_msg =                                                               \
+                se::wrap::rocprofiler_get_status_string(ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__));        \
+            std::stringstream errmsg{};                                                            \
+            errmsg << "[" << __FILE__ << ":" << __LINE__ << "] " << #result                        \
+                   << " failed with error code " << ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__)    \
+                   << " :: " << status_msg;                                                        \
+            throw std::runtime_error(errmsg.str());                                                \
+        }                                                                                          \
+    }
+
+#define ROCPROFILER_CALL(result, msg)                                                              \
+    {                                                                                              \
+        rocprofiler_status_t ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) = result;                 \
+        if(ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) != ROCPROFILER_STATUS_SUCCESS)              \
+        {                                                                                          \
+            std::string status_msg =                                                               \
+                se::wrap::rocprofiler_get_status_string(ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__));        \
+            std::cerr << "[" #result "][" << __FILE__ << ":" << __LINE__ << "] " << msg            \
+                      << " failed with error code " << ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) \
+                      << ": " << status_msg << std::endl;                                          \
+            std::stringstream errmsg{};                                                            \
+            errmsg << "[" #result "][" << __FILE__ << ":" << __LINE__ << "] " << msg " failure ("  \
+                   << status_msg << ")";                                                           \
+        }                                                                                          \
+    }
+
+#if HIP_VERSION >= 60300000
+#    define HIP_HOST_ALLOC_FUNC hipExtHostAlloc
+#    define HIP_HOST_FREE_FUNC  hipFreeHost
+#else
+#    define HIP_HOST_ALLOC_FUNC hipHostMalloc
+#    define HIP_HOST_FREE_FUNC  hipHostFree
+#endif
+
+// throw std::runtime_error(errmsg.str());

--- a/xla/backends/profiler/gpu/common/filesystem.hpp
+++ b/xla/backends/profiler/gpu/common/filesystem.hpp
@@ -1,0 +1,78 @@
+// MIT License
+//
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#if !defined(ROCPROFILER_SAMPLES_HAS_GHC_LIB_FILESYSTEM)
+#    if defined __has_include
+#        if __has_include(<ghc/filesystem.hpp>)
+#            define ROCPROFILER_SAMPLES_HAS_GHC_LIB_FILESYSTEM 1
+#        else
+#            define ROCPROFILER_SAMPLES_HAS_GHC_LIB_FILESYSTEM 0
+#        endif
+#    else
+#        define ROCPROFILER_SAMPLES_HAS_GHC_LIB_FILESYSTEM 0
+#    endif
+#endif
+
+#if ROCPROFILER_SAMPLES_HAS_GHC_LIB_FILESYSTEM == 0
+#    if defined __has_include
+#        if __has_include(<version>)
+#            include <version>
+#        endif
+#    endif
+
+#    if defined(__cpp_lib_filesystem)
+#        define ROCPROFILER_SAMPLES_HAS_CPP_LIB_FILESYSTEM 1
+#    else
+#        if defined __has_include
+#            if __has_include(<filesystem>)
+#                define ROCPROFILER_SAMPLES_HAS_CPP_LIB_FILESYSTEM 1
+#            endif
+#        endif
+#    endif
+#endif
+
+// include the correct filesystem header
+#if defined(ROCPROFILER_SAMPLES_HAS_GHC_LIB_FILESYSTEM) &&                                         \
+    ROCPROFILER_SAMPLES_HAS_GHC_LIB_FILESYSTEM > 0
+#    include <ghc/filesystem.hpp>
+#elif defined(ROCPROFILER_SAMPLES_HAS_CPP_LIB_FILESYSTEM) &&                                       \
+    ROCPROFILER_SAMPLES_HAS_CPP_LIB_FILESYSTEM > 0
+#    include <filesystem>
+#else
+#    include <experimental/filesystem>
+#endif
+
+namespace xla {
+namespace common {
+#if defined(ROCPROFILER_SAMPLES_HAS_GHC_LIB_FILESYSTEM) &&                                         \
+    ROCPROFILER_SAMPLES_HAS_GHC_LIB_FILESYSTEM > 0
+namespace fs = ::ghc::filesystem;  // NOLINT(misc-unused-alias-decls)
+#elif defined(ROCPROFILER_SAMPLES_HAS_CPP_LIB_FILESYSTEM) &&                                       \
+    ROCPROFILER_SAMPLES_HAS_CPP_LIB_FILESYSTEM > 0
+namespace fs = ::std::filesystem;  // NOLINT(misc-unused-alias-decls)
+#else
+namespace fs = ::std::experimental::filesystem;  // NOLINT(misc-unused-alias-decls)
+#endif
+}  // namespace common
+}  // namespace xla

--- a/xla/backends/profiler/gpu/common/name_info.hpp
+++ b/xla/backends/profiler/gpu/common/name_info.hpp
@@ -1,0 +1,54 @@
+// MIT License
+//
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "xla/stream_executor/rocm/roctracer_wrapper.h"
+
+#include "defines.hpp"
+
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace xla {
+namespace common {
+using callback_name_info = rocprofiler::sdk::callback_name_info;
+using buffer_name_info   = rocprofiler::sdk::buffer_name_info;
+
+inline auto
+get_buffer_tracing_names()
+{
+    return rocprofiler::sdk::get_buffer_tracing_names();
+}
+
+inline auto
+get_callback_id_names()
+{
+    return rocprofiler::sdk::get_callback_tracing_names();
+}
+}  // namespace common
+}  // namespace xla

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -65,11 +65,13 @@ using tsl::profiler::XLineBuilder;
 using tsl::profiler::XPlaneBuilder;
 using tsl::profiler::XSpace;
 
+namespace se = ::stream_executor;
 
 // GpuTracer for ROCm GPU.
 class GpuTracer : public profiler::ProfilerInterface {
  public:
-  GpuTracer(RocmTracer* rocm_tracer) : rocm_tracer_(rocm_tracer) {
+  GpuTracer() {
+    // se::rocprofiler_force_configure
     LOG(ERROR) << "GpuTrace with rocprofv3...\n";
     Start();
     LOG(INFO) << "GpuTracer created...";
@@ -125,6 +127,7 @@ absl::Status GpuTracer::DoStart() {
   */
   // AnnotationStack::Enable(true);
 
+/*
   RocmTraceCollectorOptions trace_collector_options =
       GetRocmTraceCollectorOptions(rocm_tracer_->NumGpus());
   uint64_t start_gputime_ns = rocm_tracer_->GetTimestamp();
@@ -134,11 +137,20 @@ absl::Status GpuTracer::DoStart() {
 
   RocmTracerOptions tracer_options = GetRocmTracerOptions();
   rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get());
+  */
   LOG(ERROR) << "cj rocm_tracer_collector = " << rocm_trace_collector_.get();
   LOG(ERROR) << "cj rocm_tracer_ collector = " << rocm_tracer_->get_collector();
   // LOG(ERROR) << "cj check XSpace = " << space;
   LOG(ERROR) << "DO START ...";
 
+  /*
+  RocmTracer* rocm_tracer_ =
+      profiler::RocmTracer::GetRocmTracerSingleton();
+  LOG(ERROR) << "cj rocm_tracer is available = " << rocm_tracer_->IsAvailable();
+  if (!rocm_tracer_->IsAvailable()) {
+    return absel::;
+  }
+  */
   rocm_tracer_->setup();
   rocm_tracer_->start();
   return absl::OkStatus();
@@ -199,13 +211,15 @@ std::unique_ptr<profiler::ProfilerInterface> CreateGpuTracer(
     return nullptr;
   }
 
+  /*
   profiler::RocmTracer* rocm_tracer =
       profiler::RocmTracer::GetRocmTracerSingleton();
   LOG(ERROR) << "cj rocm_tracer is available = " << rocm_tracer->IsAvailable();
   if (!rocm_tracer->IsAvailable()) {
     return nullptr;
   }
-  return std::make_unique<profiler::GpuTracer>(rocm_tracer);
+  */
+  return std::make_unique<profiler::GpuTracer>();
 }
 
 auto register_rocm_gpu_tracer_factory = [] {

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -80,14 +80,10 @@ class GpuTracer : public profiler::ProfilerInterface {
   absl::Status Start() override;
   absl::Status Stop() override;
   absl::Status CollectData(XSpace* space) override;
-
+  
  private:
   absl::Status DoStart();
   absl::Status DoStop();
-
-  RocmTracerOptions GetRocmTracerOptions();
-
-  RocmTraceCollectorOptions GetRocmTraceCollectorOptions(uint32_t num_gpus);
 
   enum State {
     kNotStarted,
@@ -99,124 +95,17 @@ class GpuTracer : public profiler::ProfilerInterface {
   State profiling_state_ = State::kNotStarted;
 
   RocmTracer* rocm_tracer_;
-  std::unique_ptr<RocmTraceCollector> rocm_trace_collector_;
 };
-
-RocmTracerOptions GpuTracer::GetRocmTracerOptions() {
-  // TODO(rocm-profiler): We need support for context similar to CUDA
-  RocmTracerOptions options;
-  std::vector<uint32_t> empty_vec;
-
-  // clang formatting does not preserve one entry per line
-  // clang-format off
-  std::vector<uint32_t> hip_api_domain_ops{0,1,2,
-    /*
-      // KERNEL
-      HIP_API_ID_hipExtModuleLaunchKernel,
-      HIP_API_ID_hipModuleLaunchKernel,
-      HIP_API_ID_hipHccModuleLaunchKernel,
-      HIP_API_ID_hipLaunchKernel,
-      
-      hipExtLaunchKernel,
-      // MEMCPY
-      hipMemcpy,
-      hipMemcpyAsync,
-      
-      HIP_API_ID_hipMemcpyDtoD,
-      HIP_API_ID_hipMemcpyDtoDAsync,
-      HIP_API_ID_hipMemcpyDtoH,
-      HIP_API_ID_hipMemcpyDtoHAsync,
-      HIP_API_ID_hipMemcpyHtoD,
-      HIP_API_ID_hipMemcpyHtoDAsync,
-      HIP_API_ID_hipMemcpyPeer,
-      HIP_API_ID_hipMemcpyPeerAsync,
-      
-      // MEMSet
-      
-      HIP_API_ID_hipMemsetD32,
-      HIP_API_ID_hipMemsetD32Async,
-      HIP_API_ID_hipMemsetD16,
-      HIP_API_ID_hipMemsetD16Async,
-      HIP_API_ID_hipMemsetD8,
-      HIP_API_ID_hipMemsetD8Async,
-      HIP_API_ID_hipMemset,
-      HIP_API_ID_hipMemsetAsync,
-      
-      // MEMAlloc
-      hipMalloc,
-      hipMallocPitch,
-      // MEMFree
-      hipFree,
-      // GENERIC
-      hipStreamSynchronize,
-      */
-  };
-  // clang-format on
-
-  options.api_tracking_set =
-      std::set<uint32_t>(hip_api_domain_ops.begin(), hip_api_domain_ops.end());
-
-  // These are the list of APIs we track since roctracer activity
-  // does not provide all the information necessary to fully populate the
-  // TF events. We need to track the APIs for those activities in API domain but
-  // we only use them for filling the missing items in their corresponding
-  // activity (using correlation id).
-  // clang-format off
-  std::vector<uint32_t> hip_api_aux_ops{
-    0, 1,
-    // hipStreamWaitEvent,
-    // TODO(rocm-profiler): finding device ID from hipEventSynchronize need some
-    // extra work, we ignore it for now.
-    // hipEventSynchronize,
-    // HIP_API_ID_hipHostFree,
-    // HIP_API_ID_hipHostMalloc,
-    // HIP_API_ID_hipSetDevice  //  added to track default device
-  };
-
-  // clang-format on
-
-  hip_api_domain_ops.insert(hip_api_domain_ops.end(), hip_api_aux_ops.begin(),
-                            hip_api_aux_ops.end());
-
-  // options.api_callbacks.emplace(ACTIVITY_DOMAIN_HIP_API, hip_api_domain_ops);
-  // options.api_callbacks.emplace(ACTIVITY_DOMAIN_HIP_API, empty_vec);
-
-  // options.activity_tracing.emplace(ACTIVITY_DOMAIN_HIP_OPS, empty_vec);
-
-  return options;
-}
-
-RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
-    uint32_t num_gpus) {
-  RocmTraceCollectorOptions options;
-  options.max_callback_api_events = 2 * 1024 * 1024;
-  options.max_activity_api_events = 2 * 1024 * 1024;
-  options.max_annotation_strings = 1024 * 1024;
-  options.num_gpus = num_gpus;
-  return options;
-}
 
 absl::Status GpuTracer::DoStart() {
   if (!rocm_tracer_->IsAvailable()) {
     return tsl::errors::Unavailable("Another profile session running.");
   }
 
-  AnnotationStack::Enable(true);
-
-  RocmTraceCollectorOptions trace_collector_options =
-      GetRocmTraceCollectorOptions(rocm_tracer_->NumGpus());
+  // AnnotationStack::Enable(true);
 
   rocm_tracer_->setup();
   rocm_tracer_->start();
-
-  uint64_t start_gputime_ns = rocm_tracer_->GetTimestamp();
-  uint64_t start_walltime_ns = tsl::EnvTime::NowNanos();
-  rocm_trace_collector_ = CreateRocmCollector(
-      trace_collector_options, start_walltime_ns, start_gputime_ns);
-  LOG(ERROR) << "DoStart interrupted ...";
-  RocmTracerOptions tracer_options = GetRocmTracerOptions();
-  rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get());
-
   return absl::OkStatus();
 }
 
@@ -243,29 +132,6 @@ absl::Status GpuTracer::Stop() {
     profiling_state_ = status.ok() ? State::kStoppedOk : State::kStoppedError;
   }
   return absl::OkStatus();
-}
-
-absl::Status GpuTracer::CollectData(XSpace* space) {
-  LOG(ERROR) << "profiling_state_" << profiling_state_;
-  switch (profiling_state_) {
-    case State::kNotStarted:
-      VLOG(3) << "No trace data collected, session wasn't started";
-      return absl::OkStatus();
-    case State::kStartedOk:
-      return tsl::errors::FailedPrecondition(
-          "Cannot collect trace before stopping");
-    case State::kStartedError:
-      LOG(ERROR) << "Cannot collect, roctracer failed to start";
-      return absl::OkStatus();
-    case State::kStoppedError:
-      VLOG(3) << "No trace data collected";
-      return absl::OkStatus();
-    case State::kStoppedOk: {
-      if (rocm_trace_collector_) rocm_trace_collector_->Export(space);
-      return absl::OkStatus();
-    }
-  }
-  return tsl::errors::Internal("Invalid profiling state: ", profiling_state_);
 }
 
 // Not in anonymous namespace for testing purposes.

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -136,6 +136,7 @@ absl::Status GpuTracer::DoStart() {
   rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get());
   LOG(ERROR) << "cj rocm_tracer_collector = " << rocm_trace_collector_.get();
   LOG(ERROR) << "cj rocm_tracer_ collector = " << rocm_tracer_->get_collector();
+  // LOG(ERROR) << "cj check XSpace = " << space;
   LOG(ERROR) << "DO START ...";
 
   rocm_tracer_->setup();

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -216,7 +216,7 @@ absl::Status GpuTracer::DoStart() {
       trace_collector_options, start_walltime_ns, start_gputime_ns);
   LOG(ERROR) << "DoStart interrupted ...";
   RocmTracerOptions tracer_options = GetRocmTracerOptions();
-  // rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get());
+  rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get());
 
   return absl::OkStatus();
 }
@@ -247,7 +247,7 @@ absl::Status GpuTracer::Stop() {
 }
 
 absl::Status GpuTracer::CollectData(XSpace* space) {
-  // LOG(ERROR) << "profiling_state_" << profiling_state_;
+  LOG(ERROR) << "profiling_state_" << profiling_state_;
   switch (profiling_state_) {
     case State::kNotStarted:
       VLOG(3) << "No trace data collected, session wasn't started";

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -70,7 +70,7 @@ using tsl::profiler::XSpace;
 // GpuTracer for ROCm GPU.
 class GpuTracer : public profiler::ProfilerInterface {
  public:
-  GpuTracer() {
+  GpuTracer(RocmTracer* rocm_tracer) : rocm_tracer_(rocm_tracer) {
     LOG(FATAL) << "GpuTrace with rocprofv3...\n";
     Start();
     LOG(INFO) << "GpuTracer created.";
@@ -99,7 +99,7 @@ class GpuTracer : public profiler::ProfilerInterface {
   };
   State profiling_state_ = State::kNotStarted;
 
-  // RocmTracer* rocm_tracer_;
+  RocmTracer* rocm_tracer_;
   // std::unique_ptr<RocmTraceCollector> rocm_trace_collector_;
 };
 /*
@@ -273,17 +273,19 @@ absl::Status GpuTracer::CollectData(XSpace* space) {
 std::unique_ptr<profiler::ProfilerInterface> CreateGpuTracer(
     const ProfileOptions& options) {
   if (options.device_type() != ProfileOptions::GPU &&
-      options.device_type() != ProfileOptions::UNSPECIFIED)
+      options.device_type() != ProfileOptions::UNSPECIFIED){
+    LOG(ERROR) << "rocm_tracer initialised...";
     return nullptr;
+  }
 
-/*
   profiler::RocmTracer* rocm_tracer =
       profiler::RocmTracer::GetRocmTracerSingleton();
-  if (!rocm_tracer->IsAvailable()) return nullptr;
+  if (!rocm_tracer->IsAvailable()) {
+    LOG(ERROR) << "rocm_tracer initialised...";
+    return nullptr;
+  }
+  LOG(ERROR) << "rocm_tracer initialised...";
   return std::make_unique<profiler::GpuTracer>(rocm_tracer);
-  */
- return nullptr;
-  // return std::make_unique<profiler::GpuTracer>(nullptr);
 }
 
 auto register_rocm_gpu_tracer_factory = [] {

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -24,7 +24,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include "xla/backends/profiler/gpu/rocm_collector.h"
+// #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 #include "xla/tsl/util/env_var.h"
 #include "tsl/platform/abi.h"
@@ -65,10 +65,13 @@ using tsl::profiler::XLineBuilder;
 using tsl::profiler::XPlaneBuilder;
 using tsl::profiler::XSpace;
 
+
+
 // GpuTracer for ROCm GPU.
 class GpuTracer : public profiler::ProfilerInterface {
  public:
-  GpuTracer(RocmTracer* rocm_tracer) : rocm_tracer_(rocm_tracer) {
+  GpuTracer() {
+    Start();
     LOG(INFO) << "GpuTracer created.";
   }
   ~GpuTracer() override {}
@@ -76,15 +79,15 @@ class GpuTracer : public profiler::ProfilerInterface {
   // GpuTracer interface:
   absl::Status Start() override;
   absl::Status Stop() override;
-  absl::Status CollectData(XSpace* space) override;
+  // absl::Status CollectData(XSpace* space) override;
 
  private:
   absl::Status DoStart();
   absl::Status DoStop();
 
-  RocmTracerOptions GetRocmTracerOptions();
+  // RocmTracerOptions GetRocmTracerOptions();
 
-  RocmTraceCollectorOptions GetRocmTraceCollectorOptions(uint32_t num_gpus);
+  // RocmTraceCollectorOptions GetRocmTraceCollectorOptions(uint32_t num_gpus);
 
   enum State {
     kNotStarted,
@@ -95,10 +98,10 @@ class GpuTracer : public profiler::ProfilerInterface {
   };
   State profiling_state_ = State::kNotStarted;
 
-  RocmTracer* rocm_tracer_;
-  std::unique_ptr<RocmTraceCollector> rocm_trace_collector_;
+  // RocmTracer* rocm_tracer_;
+  // std::unique_ptr<RocmTraceCollector> rocm_trace_collector_;
 };
-
+/*
 RocmTracerOptions GpuTracer::GetRocmTracerOptions() {
   // TODO(rocm-profiler): We need support for context similar to CUDA
   RocmTracerOptions options;
@@ -170,9 +173,9 @@ RocmTracerOptions GpuTracer::GetRocmTracerOptions() {
                             hip_api_aux_ops.end());
 
   // options.api_callbacks.emplace(ACTIVITY_DOMAIN_HIP_API, hip_api_domain_ops);
-  options.api_callbacks.emplace(ACTIVITY_DOMAIN_HIP_API, empty_vec);
+  // options.api_callbacks.emplace(ACTIVITY_DOMAIN_HIP_API, empty_vec);
 
-  options.activity_tracing.emplace(ACTIVITY_DOMAIN_HIP_OPS, empty_vec);
+  // options.activity_tracing.emplace(ACTIVITY_DOMAIN_HIP_OPS, empty_vec);
 
   return options;
 }
@@ -186,8 +189,9 @@ RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
   options.num_gpus = num_gpus;
   return options;
 }
-
+*/
 absl::Status GpuTracer::DoStart() {
+  /*
   if (!rocm_tracer_->IsAvailable()) {
     return tsl::errors::Unavailable("Another profile session running.");
   }
@@ -203,6 +207,10 @@ absl::Status GpuTracer::DoStart() {
 
   RocmTracerOptions tracer_options = GetRocmTracerOptions();
   rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get());
+  */
+  xla::profiler::setup();
+  xla::profiler::start();
+  xla::profiler::identify(1);
 
   return absl::OkStatus();
 }
@@ -219,9 +227,13 @@ absl::Status GpuTracer::Start() {
 }
 
 absl::Status GpuTracer::DoStop() {
+  xla::profiler::stop();
+  xla::profiler::shutdown();
+  /*
   rocm_tracer_->Disable();
   AnnotationStack::Enable(false);
   return absl::OkStatus();
+  */
 }
 
 absl::Status GpuTracer::Stop() {
@@ -232,6 +244,7 @@ absl::Status GpuTracer::Stop() {
   return absl::OkStatus();
 }
 
+/*
 absl::Status GpuTracer::CollectData(XSpace* space) {
   switch (profiling_state_) {
     case State::kNotStarted:
@@ -253,6 +266,7 @@ absl::Status GpuTracer::CollectData(XSpace* space) {
   }
   return tsl::errors::Internal("Invalid profiling state: ", profiling_state_);
 }
+*/
 
 // Not in anonymous namespace for testing purposes.
 std::unique_ptr<profiler::ProfilerInterface> CreateGpuTracer(
@@ -261,11 +275,14 @@ std::unique_ptr<profiler::ProfilerInterface> CreateGpuTracer(
       options.device_type() != ProfileOptions::UNSPECIFIED)
     return nullptr;
 
+/*
   profiler::RocmTracer* rocm_tracer =
       profiler::RocmTracer::GetRocmTracerSingleton();
   if (!rocm_tracer->IsAvailable()) return nullptr;
-
   return std::make_unique<profiler::GpuTracer>(rocm_tracer);
+  */
+ return nullptr;
+  // return std::make_unique<profiler::GpuTracer>(nullptr);
 }
 
 auto register_rocm_gpu_tracer_factory = [] {

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -71,6 +71,7 @@ using tsl::profiler::XSpace;
 class GpuTracer : public profiler::ProfilerInterface {
  public:
   GpuTracer() {
+    std::cout << "GpuTrace with rocprofv3\n" << std::flush;
     Start();
     LOG(INFO) << "GpuTracer created.";
   }

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -71,7 +71,7 @@ using tsl::profiler::XSpace;
 class GpuTracer : public profiler::ProfilerInterface {
  public:
   GpuTracer() {
-    std::cout << "GpuTrace with rocprofv3\n" << std::flush;
+    LOG(FATAL) << "GpuTrace with rocprofv3...\n";
     Start();
     LOG(INFO) << "GpuTracer created.";
   }
@@ -80,7 +80,7 @@ class GpuTracer : public profiler::ProfilerInterface {
   // GpuTracer interface:
   absl::Status Start() override;
   absl::Status Stop() override;
-  // absl::Status CollectData(XSpace* space) override;
+  absl::Status CollectData(XSpace* space) override;
 
  private:
   absl::Status DoStart();
@@ -245,7 +245,7 @@ absl::Status GpuTracer::Stop() {
   return absl::OkStatus();
 }
 
-/*
+// /*
 absl::Status GpuTracer::CollectData(XSpace* space) {
   switch (profiling_state_) {
     case State::kNotStarted:
@@ -261,13 +261,13 @@ absl::Status GpuTracer::CollectData(XSpace* space) {
       VLOG(3) << "No trace data collected";
       return absl::OkStatus();
     case State::kStoppedOk: {
-      if (rocm_trace_collector_) rocm_trace_collector_->Export(space);
+      // if (rocm_trace_collector_) rocm_trace_collector_->Export(space);
       return absl::OkStatus();
     }
   }
   return tsl::errors::Internal("Invalid profiling state: ", profiling_state_);
 }
-*/
+// */
 
 // Not in anonymous namespace for testing purposes.
 std::unique_ptr<profiler::ProfilerInterface> CreateGpuTracer(

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -208,7 +208,6 @@ absl::Status GpuTracer::DoStart() {
 
   rocm_tracer_->setup();
   rocm_tracer_->start();
-  rocm_tracer_->identify(1);
 
   uint64_t start_gputime_ns = rocm_tracer_->GetTimestamp();
   uint64_t start_walltime_ns = tsl::EnvTime::NowNanos();

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -66,7 +66,6 @@ using tsl::profiler::XPlaneBuilder;
 using tsl::profiler::XSpace;
 
 
-
 // GpuTracer for ROCm GPU.
 class GpuTracer : public profiler::ProfilerInterface {
  public:
@@ -192,27 +191,9 @@ RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
 }
 */
 absl::Status GpuTracer::DoStart() {
-  /*
-  if (!rocm_tracer_->IsAvailable()) {
-    return tsl::errors::Unavailable("Another profile session running.");
-  }
-
-  AnnotationStack::Enable(true);
-
-  RocmTraceCollectorOptions trace_collector_options =
-      GetRocmTraceCollectorOptions(rocm_tracer_->NumGpus());
-  uint64_t start_gputime_ns = RocmTracer::GetTimestamp();
-  uint64_t start_walltime_ns = tsl::EnvTime::NowNanos();
-  rocm_trace_collector_ = CreateRocmCollector(
-      trace_collector_options, start_walltime_ns, start_gputime_ns);
-
-  RocmTracerOptions tracer_options = GetRocmTracerOptions();
-  rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get());
-  */
-  xla::profiler::setup();
-  xla::profiler::start();
-  xla::profiler::identify(1);
-
+  rocm_tracer_->setup();
+  rocm_tracer_->start();
+  rocm_tracer_->identify(1);
   return absl::OkStatus();
 }
 
@@ -228,13 +209,9 @@ absl::Status GpuTracer::Start() {
 }
 
 absl::Status GpuTracer::DoStop() {
-  xla::profiler::stop();
-  xla::profiler::shutdown();
-  /*
-  rocm_tracer_->Disable();
-  AnnotationStack::Enable(false);
-  return absl::OkStatus();
-  */
+  rocm_tracer_->stop();
+  rocm_tracer_->shutdown();
+  return absl::OkStatus();  
 }
 
 absl::Status GpuTracer::Stop() {
@@ -273,18 +250,14 @@ absl::Status GpuTracer::CollectData(XSpace* space) {
 std::unique_ptr<profiler::ProfilerInterface> CreateGpuTracer(
     const ProfileOptions& options) {
   if (options.device_type() != ProfileOptions::GPU &&
-      options.device_type() != ProfileOptions::UNSPECIFIED){
-    LOG(ERROR) << "rocm_tracer initialised...";
+      options.device_type() != ProfileOptions::UNSPECIFIED);
     return nullptr;
-  }
 
   profiler::RocmTracer* rocm_tracer =
       profiler::RocmTracer::GetRocmTracerSingleton();
   if (!rocm_tracer->IsAvailable()) {
-    LOG(ERROR) << "rocm_tracer initialised...";
     return nullptr;
   }
-  LOG(ERROR) << "rocm_tracer initialised...";
   return std::make_unique<profiler::GpuTracer>(rocm_tracer);
 }
 

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -71,9 +71,9 @@ using tsl::profiler::XSpace;
 class GpuTracer : public profiler::ProfilerInterface {
  public:
   GpuTracer(RocmTracer* rocm_tracer) : rocm_tracer_(rocm_tracer) {
-    LOG(FATAL) << "GpuTrace with rocprofv3...\n";
+    LOG(ERROR) << "GpuTrace with rocprofv3...\n";
     Start();
-    LOG(INFO) << "GpuTracer created.";
+    LOG(INFO) << "GpuTracer created...";
   }
   ~GpuTracer() override {}
 

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -430,7 +430,7 @@ class RocmTraceCollectorImpl : public profiler::RocmTraceCollector {
         start_gputime_ns_(start_gputime_ns),
         num_gpus_(options.num_gpus) {}
 
-  void AddEvent(RocmTracerEvent& event) override;
+  void AddEvent(RocmTracerEvent&& event) override;
   void Flush() override;
   void Export(XSpace* space) override;
 
@@ -454,10 +454,10 @@ class RocmTraceCollectorImpl : public profiler::RocmTraceCollector {
   absl::flat_hash_map<uint32_t, PerDeviceCollector> per_device_collector_;
 };
 
-void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent& event) {
+void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event) {
   LOG(ERROR) << "Starting RocmTraceCollectorImpl::AddEvent";
-  mutex_lock lock(event_maps_mutex_);
-  events_.push_back(std::move(event));
+  // mutex_lock lock(event_maps_mutex_);
+  // events_.push_back(std::move(event));
 }
 
 void RocmTraceCollectorImpl::Flush() {

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -455,9 +455,9 @@ class RocmTraceCollectorImpl : public profiler::RocmTraceCollector {
 };
 
 void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event) {
-  LOG(ERROR) << "Starting RocmTraceCollectorImpl::AddEvent";
-  // mutex_lock lock(event_maps_mutex_);
-  // events_.push_back(std::move(event));
+  // LOG(ERROR) << "Starting RocmTraceCollectorImpl::AddEvent";
+  mutex_lock lock(event_maps_mutex_);
+  events_.push_back(std::move(event));
 }
 
 void RocmTraceCollectorImpl::Flush() {

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -452,7 +452,6 @@ class RocmTraceCollectorImpl : public profiler::RocmTraceCollector {
   // std::vector<RocmTracerEvent> 
   RocmTracerEvent_t events_ TF_GUARDED_BY(event_maps_mutex_);
   absl::flat_hash_map<uint32_t, PerDeviceCollector> per_device_collector_;
-
 };
 
 void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent& event) {
@@ -466,13 +465,18 @@ void RocmTraceCollectorImpl::Flush() {
     auto device_id = event.device_id;
     per_device_collector_[device_id].AddEvent(std::move(event));
   }
+  LOG(ERROR) << "Complete RocmTraceCollectorImpl::Flush";
   events_.clear(); 
+  LOG(ERROR) << "Complete RocmTraceCollectorImpl events_.clear";
 }
 
 void RocmTraceCollectorImpl::Export(XSpace* space) {
   uint64_t end_gputime_ns = get_timestamp();
+  LOG(ERROR) << "Starting RocmTraceCollectorImpl::Export";
+  LOG(ERROR) << "test space = " << space;
   XPlaneBuilder host_plane(FindOrAddMutablePlaneWithName(
       space, tsl::profiler::kRoctracerApiPlaneName));
+  LOG(ERROR) << "Starting RocmTraceCollectorImpl, host_plane";
 
   for (int device_ordinal = 0; device_ordinal < num_gpus_; ++device_ordinal) {
     std::string name = GpuPlaneName(device_ordinal);

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -148,7 +148,7 @@ class RocmTraceCollector {
   virtual ~RocmTraceCollector() {}
 
   // virtual void AddEvent(RocmTracerEvent&& event, bool is_auxiliary) = 0;
-  virtual void AddEvent(RocmTracerEvent& event) = 0;
+  virtual void AddEvent(RocmTracerEvent&& event) = 0;
   /*
   virtual void OnEventsDropped(const std::string& reason,
                                uint32_t num_events) = 0;

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -125,6 +125,8 @@ struct RocmTracerEvent {
   int64_t stream_id = 0;
 };
 
+using RocmTracerEvent_t = std::vector<RocmTracerEvent>;
+
 struct RocmTraceCollectorOptions {
   // Maximum number of events to collect from callback API; if -1, no limit.
   // if 0, the callback API is enabled to build a correlation map, but no

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -87,6 +87,7 @@ enum class RocmTracerEventType {
   Unsupported = 0,
   HIP_RUNTIME_API,
   KERNEL_DISPATCH,
+  MEMORY_COPY,
 };
 
 const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type);
@@ -116,16 +117,12 @@ struct RocmTracerEvent {
   // RocmTracerEventDomain domain;
   RocmTracerEventType type;
   std::string name;
-  // This points to strings in AnnotationMap, which should outlive the point
-  // where serialization happens.
-  // absl::string_view annotation;
-  // absl::string_view roctx_range;
   uint64_t start_time_ns = 0;
   uint64_t end_time_ns = 0;
-  uint32_t device_id = kInvalidDeviceId;
-  uint32_t correlation_id = kInvalidCorrelationId;
-  uint32_t thread_id = kInvalidThreadId;
-  int64_t stream_id = kInvalidStreamId;
+  uint32_t device_id = 0;
+  uint32_t correlation_id = 0;
+  uint32_t thread_id = 0;
+  int64_t stream_id = 0;
 };
 
 struct RocmTraceCollectorOptions {

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -85,17 +85,8 @@ inline std::string ToXStat(const KernelDetails& kernel_info,
 
 enum class RocmTracerEventType {
   Unsupported = 0,
-  Kernel,
-  MemcpyH2D,
-  MemcpyD2H,
-  MemcpyD2D,
-  MemcpyP2P,
-  MemcpyOther,
-  MemoryAlloc,
-  MemoryFree,
-  Memset,
-  Synchronization,
-  Generic,
+  HIP_RUNTIME_API,
+  KERNEL_DISPATCH,
 };
 
 const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type);
@@ -122,35 +113,19 @@ struct SynchronizationDetails {
 };
 
 struct RocmTracerEvent {
-  static constexpr uint32_t kInvalidDeviceId =
-      std::numeric_limits<uint32_t>::max();
-  static constexpr uint32_t kInvalidThreadId =
-      std::numeric_limits<uint32_t>::max();
-  static constexpr uint32_t kInvalidCorrelationId =
-      std::numeric_limits<uint32_t>::max();
-  static constexpr uint64_t kInvalidStreamId =
-      std::numeric_limits<uint64_t>::max();
+  // RocmTracerEventDomain domain;
   RocmTracerEventType type;
-  RocmTracerEventSource source = RocmTracerEventSource::Invalid;
-  RocmTracerEventDomain domain;
   std::string name;
   // This points to strings in AnnotationMap, which should outlive the point
   // where serialization happens.
-  absl::string_view annotation;
-  absl::string_view roctx_range;
+  // absl::string_view annotation;
+  // absl::string_view roctx_range;
   uint64_t start_time_ns = 0;
   uint64_t end_time_ns = 0;
   uint32_t device_id = kInvalidDeviceId;
   uint32_t correlation_id = kInvalidCorrelationId;
   uint32_t thread_id = kInvalidThreadId;
   int64_t stream_id = kInvalidStreamId;
-  union {
-    MemcpyDetails memcpy_info;                    // If type == Memcpy*
-    MemsetDetails memset_info;                    // If type == Memset*
-    MemAllocDetails memalloc_info;                // If type == MemoryAlloc
-    KernelDetails kernel_info;                    // If type == Kernel
-    SynchronizationDetails synchronization_info;  // If type == Synchronization
-  };
 };
 
 struct RocmTraceCollectorOptions {
@@ -166,50 +141,29 @@ struct RocmTraceCollectorOptions {
   uint32_t num_gpus;
 };
 
-class AnnotationMap {
- public:
-  explicit AnnotationMap(uint64_t max_size) : max_size_(max_size) {}
-  void Add(uint32_t correlation_id, const std::string& annotation);
-  absl::string_view LookUp(uint32_t correlation_id);
-
- private:
-  struct AnnotationMapImpl {
-    // The population/consumption of annotations might happen from multiple
-    // callback/activity api related threads.
-    absl::Mutex mutex;
-    // Annotation tends to be repetitive, use a hash_set to store the strings,
-    // an use the reference to the string in the map.
-    absl::node_hash_set<std::string> annotations;
-    absl::flat_hash_map<uint32_t, absl::string_view> correlation_map;
-  };
-  const uint64_t max_size_;
-  AnnotationMapImpl map_;
-
- public:
-  // Disable copy and move.
-  AnnotationMap(const AnnotationMap&) = delete;
-  AnnotationMap& operator=(const AnnotationMap&) = delete;
-};
 
 class RocmTraceCollector {
  public:
   explicit RocmTraceCollector(const RocmTraceCollectorOptions& options)
-      : options_(options), annotation_map_(options.max_annotation_strings) {}
+      : options_(options) {}
   virtual ~RocmTraceCollector() {}
 
-  virtual void AddEvent(RocmTracerEvent&& event, bool is_auxiliary) = 0;
+  // virtual void AddEvent(RocmTracerEvent&& event, bool is_auxiliary) = 0;
+  virtual void AddEvent(RocmTracerEvent& event) = 0;
+  /*
   virtual void OnEventsDropped(const std::string& reason,
                                uint32_t num_events) = 0;
+                               */
   virtual void Flush() = 0;
   virtual void Export(XSpace* space) = 0;
 
-  AnnotationMap* annotation_map() { return &annotation_map_; }
+  // AnnotationMap* annotation_map() { return &annotation_map_; }
 
  protected:
   RocmTraceCollectorOptions options_;
 
- private:
-  AnnotationMap annotation_map_;
+ // private:
+ //  AnnotationMap annotation_map_;
 
  public:
   // Disable copy and move.

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -15,6 +15,11 @@ limitations under the License.
 
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 
+#include "xla/backends/profiler/gpu/common/call_stack.hpp"
+#include "xla/backends/profiler/gpu/common/defines.hpp"
+#include "xla/backends/profiler/gpu/common/filesystem.hpp"
+#include "xla/backends/profiler/gpu/common/name_info.hpp"
+
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_map.h"
 #include "rocm/rocm_config.h"
@@ -26,34 +31,358 @@ limitations under the License.
 #include "tsl/profiler/backends/cpu/annotation_stack.h"
 #include "tsl/profiler/utils/time_utils.h"
 
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
 extern "C" rocprofiler_tool_configure_result_t* rocprofiler_configure(
   uint32_t version, const char* runtime_version, uint32_t priority,
   rocprofiler_client_id_t* id
 );
 
 namespace xla {
-namespace profiler {
-
 namespace se = ::stream_executor;
+/*
 using tsl::mutex;
 using tsl::mutex_lock;
 using tsl::profiler::AnnotationStack;
+*/
+    
+namespace profiler {
+namespace {
+using xla::common::buffer_name_info;
+using xla::common::call_stack_t;
+using xla::common::source_location;
 
-constexpr uint32_t RocmTracerEvent::kInvalidDeviceId;
+using kernel_symbol_data_t = rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;
+using kernel_symbol_map_t  = std::unordered_map<rocprofiler_kernel_id_t, kernel_symbol_data_t>;
 
-#define RETURN_IF_ROCTRACER_ERROR(expr)                                     \
-  do {                                                                      \
-    roctracer_status_t status = expr;                                       \
-    if (status != ROCTRACER_STATUS_SUCCESS) {                               \
-      const char* errstr = se::wrap::roctracer_error_string();              \
-      LOG(ERROR) << "function " << #expr << "failed with error " << errstr; \
-      return tsl::errors::Internal(                                         \
-          absl::StrCat("roctracer call error", errstr));                    \
-    }                                                                       \
-  } while (false)
+rocprofiler_client_id_t*      client_id        = nullptr;
+rocprofiler_client_finalize_t client_fini_func = nullptr;
+rocprofiler_context_id_t      client_ctx       = {};
+rocprofiler_buffer_id_t       client_buffer    = {};
+buffer_name_info              client_name_info = {};
+kernel_symbol_map_t           client_kernels   = {};
 
 void
-thread_precreate(rocprofiler_runtime_library_t lib, void* tool_data)
+print_call_stack(const call_stack_t& _call_stack)
+{
+    common::print_call_stack("api_buffered_trace.log", _call_stack);
+}
+
+void
+tool_code_object_callback(rocprofiler_callback_tracing_record_t record,
+                          rocprofiler_user_data_t*              user_data,
+                          void*                                 callback_data)
+{
+    if(record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
+       record.operation == ROCPROFILER_CODE_OBJECT_LOAD)
+    {
+        if(record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD)
+        {
+            // flush the buffer to ensure that any lookups for the client kernel names for the code
+            // object are completed
+            auto flush_status = rocprofiler_flush_buffer(client_buffer);
+            if(flush_status != ROCPROFILER_STATUS_ERROR_BUFFER_BUSY)
+                ROCPROFILER_CALL(flush_status, "buffer flush");
+        }
+    }
+    else if(record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
+            record.operation == ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER)
+    {
+        auto* data = static_cast<kernel_symbol_data_t*>(record.payload);
+        if(record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD)
+        {
+            client_kernels.emplace(data->kernel_id, *data);
+        }
+        else if(record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD)
+        {
+            client_kernels.erase(data->kernel_id);
+        }
+    }
+
+    (void) user_data;
+    (void) callback_data;
+}
+
+void
+tool_tracing_callback(rocprofiler_context_id_t      context,
+                      rocprofiler_buffer_id_t       buffer_id,
+                      rocprofiler_record_header_t** headers,
+                      size_t                        num_headers,
+                      void*                         user_data,
+                      uint64_t                      drop_count)
+{
+    assert(user_data != nullptr);
+    assert(drop_count == 0 && "drop count should be zero for lossless policy");
+
+    /*
+    if(num_headers == 0)
+        throw std::runtime_error{
+            "rocprofiler invoked a buffer callback with no headers. this should never happen"};
+    else if(headers == nullptr)
+        throw std::runtime_error{"rocprofiler invoked a buffer callback with a null pointer to the "
+                                 "array of headers. this should never happen"};
+    */
+    for(size_t i = 0; i < num_headers; ++i)
+    {
+        auto* header = headers[i];
+
+        auto kind_name = std::string{};
+        if(header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING)
+        {
+            const char* _name = nullptr;
+            auto        _kind = static_cast<rocprofiler_buffer_tracing_kind_t>(header->kind);
+            ROCPROFILER_CALL(rocprofiler_query_buffer_tracing_kind_name(_kind, &_name, nullptr),
+                             "query buffer tracing kind name");
+            if(_name)
+            {
+                static size_t len = 15;
+
+                kind_name = std::string{_name};
+                len       = std::max(len, kind_name.length());
+                kind_name.resize(len, ' ');
+                kind_name += " :: ";
+            }
+        }
+
+        if(header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING &&
+           (header->kind == ROCPROFILER_BUFFER_TRACING_HSA_CORE_API ||
+            header->kind == ROCPROFILER_BUFFER_TRACING_HSA_AMD_EXT_API ||
+            header->kind == ROCPROFILER_BUFFER_TRACING_HSA_IMAGE_EXT_API ||
+            header->kind == ROCPROFILER_BUFFER_TRACING_HSA_FINALIZE_EXT_API))
+        {
+            auto* record =
+                static_cast<rocprofiler_buffer_tracing_hsa_api_record_t*>(header->payload);
+            auto info = std::stringstream{};
+            info << "tid=" << record->thread_id << ", context=" << context.handle
+                 << ", buffer_id=" << buffer_id.handle
+                 << ", cid=" << record->correlation_id.internal
+                 << ", extern_cid=" << record->correlation_id.external.value
+                 << ", kind=" << record->kind << ", operation=" << record->operation
+                 << ", start=" << record->start_timestamp << ", stop=" << record->end_timestamp
+                 << ", name=" << client_name_info.at(record->kind, record->operation);
+
+            if(record->start_timestamp > record->end_timestamp)
+            {
+                auto msg = std::stringstream{};
+                msg << "hsa api: start > end (" << record->start_timestamp << " > "
+                    << record->end_timestamp
+                    << "). diff = " << (record->start_timestamp - record->end_timestamp);
+                std::cerr << "threw an exception " << msg.str() << "\n" << std::flush;
+                // throw std::runtime_error{msg.str()};
+            }
+
+            static_cast<call_stack_t*>(user_data)->emplace_back(
+                source_location{__FUNCTION__, __FILE__, __LINE__, kind_name + info.str()});
+        }
+        else if(header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING &&
+                header->kind == ROCPROFILER_BUFFER_TRACING_HIP_RUNTIME_API)
+        {
+            auto* record =
+                static_cast<rocprofiler_buffer_tracing_hip_api_record_t*>(header->payload);
+            auto info = std::stringstream{};
+            info << "tid=" << record->thread_id << ", context=" << context.handle
+                 << ", buffer_id=" << buffer_id.handle
+                 << ", cid=" << record->correlation_id.internal
+                 << ", extern_cid=" << record->correlation_id.external.value
+                 << ", kind=" << record->kind << ", operation=" << record->operation
+                 << ", start=" << record->start_timestamp << ", stop=" << record->end_timestamp
+                 << ", name=" << client_name_info[record->kind][record->operation];
+
+            if(record->start_timestamp > record->end_timestamp)
+            {
+                auto msg = std::stringstream{};
+                msg << "hip api: start > end (" << record->start_timestamp << " > "
+                    << record->end_timestamp
+                    << "). diff = " << (record->start_timestamp - record->end_timestamp);
+                std::cerr << "threw an exception " << msg.str() << "\n" << std::flush;
+                // throw std::runtime_error{msg.str()};
+            }
+
+            static_cast<call_stack_t*>(user_data)->emplace_back(
+                source_location{__FUNCTION__, __FILE__, __LINE__, kind_name + info.str()});
+        }
+        else if(header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING &&
+                header->kind == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH)
+        {
+            auto* record =
+                static_cast<rocprofiler_buffer_tracing_kernel_dispatch_record_t*>(header->payload);
+
+            auto info = std::stringstream{};
+
+            info << "tid=" << record->thread_id << ", context=" << context.handle
+                 << ", buffer_id=" << buffer_id.handle
+                 << ", cid=" << record->correlation_id.internal
+                 << ", extern_cid=" << record->correlation_id.external.value
+                 << ", kind=" << record->kind << ", operation=" << record->operation
+                 << ", agent_id=" << record->dispatch_info.agent_id.handle
+                 << ", queue_id=" << record->dispatch_info.queue_id.handle
+                 << ", kernel_id=" << record->dispatch_info.kernel_id
+                 << ", kernel=" << client_kernels.at(record->dispatch_info.kernel_id).kernel_name
+                 << ", start=" << record->start_timestamp << ", stop=" << record->end_timestamp
+                 << ", private_segment_size=" << record->dispatch_info.private_segment_size
+                 << ", group_segment_size=" << record->dispatch_info.group_segment_size
+                 << ", workgroup_size=(" << record->dispatch_info.workgroup_size.x << ","
+                 << record->dispatch_info.workgroup_size.y << ","
+                 << record->dispatch_info.workgroup_size.z << "), grid_size=("
+                 << record->dispatch_info.grid_size.x << "," << record->dispatch_info.grid_size.y
+                 << "," << record->dispatch_info.grid_size.z << ")";
+
+
+            if(record->start_timestamp > record->end_timestamp)
+                printf("kernel dispatch: start > end");
+                // throw std::runtime_error("kernel dispatch: start > end");
+
+            static_cast<call_stack_t*>(user_data)->emplace_back(
+                source_location{__FUNCTION__, __FILE__, __LINE__, kind_name + info.str()});
+        }
+        else if(header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING &&
+                header->kind == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY)
+        {
+            auto* record =
+                static_cast<rocprofiler_buffer_tracing_memory_copy_record_t*>(header->payload);
+
+            auto info = std::stringstream{};
+
+            info << "tid=" << record->thread_id << ", context=" << context.handle
+                 << ", buffer_id=" << buffer_id.handle
+                 << ", cid=" << record->correlation_id.internal
+                 << ", extern_cid=" << record->correlation_id.external.value
+                 << ", kind=" << record->kind << ", operation=" << record->operation
+                 << ", src_agent_id=" << record->src_agent_id.handle
+                 << ", dst_agent_id=" << record->dst_agent_id.handle
+                 << ", direction=" << record->operation << ", start=" << record->start_timestamp
+                 << ", stop=" << record->end_timestamp
+                 << ", name=" << client_name_info.at(record->kind, record->operation);
+
+            if(record->start_timestamp > record->end_timestamp)
+                printf("memory copy: start > end \n");
+                // throw std::runtime_error("memory copy: start > end");
+
+            static_cast<call_stack_t*>(user_data)->emplace_back(
+                source_location{__FUNCTION__, __FILE__, __LINE__, kind_name + info.str()});
+        }
+        else if(header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING &&
+                header->kind == ROCPROFILER_BUFFER_TRACING_PAGE_MIGRATION)
+        {
+            auto* record =
+                static_cast<rocprofiler_buffer_tracing_page_migration_record_t*>(header->payload);
+
+            auto info = std::stringstream{};
+
+            info << "kind=" << record->kind << ", operation=" << record->operation
+                 << ", pid=" << record->pid << ", start=" << record->start_timestamp
+                 << ", stop=" << record->end_timestamp
+                 << ", name=" << client_name_info.at(record->kind, record->operation);
+
+            switch(record->operation)
+            {
+                case ROCPROFILER_PAGE_MIGRATION_PAGE_MIGRATE:
+                {
+                    info << ", page_fault=(" << record->page_fault.read_fault << ", "
+                         << record->page_fault.migrated << ", " << record->page_fault.node_id
+                         << ", " << std::hex << "0x" << record->page_fault.address << ")";
+                    break;
+                }
+                case ROCPROFILER_PAGE_MIGRATION_PAGE_FAULT:
+                {
+                    info << ", page_migrate=(" << std::hex << "0x"
+                         << record->page_migrate.start_addr << ", 0x"
+                         << record->page_migrate.end_addr << ", " << std::dec
+                         << record->page_migrate.from_node << ", " << record->page_migrate.to_node
+                         << ", " << record->page_migrate.prefetch_node << ", "
+                         << record->page_migrate.preferred_node << ", "
+                         << record->page_migrate.trigger << ")";
+                    break;
+                }
+                case ROCPROFILER_PAGE_MIGRATION_QUEUE_SUSPEND:
+                {
+                    info << ", queue_suspend=(" << record->queue_suspend.rescheduled << ", "
+                         << record->queue_suspend.node_id << ", " << record->queue_suspend.trigger
+                         << ")";
+                    break;
+                }
+                case ROCPROFILER_PAGE_MIGRATION_UNMAP_FROM_GPU:
+                {
+                    info << ", unmap_from_gpu=(" << record->unmap_from_gpu.node_id << std::hex
+                         << ", 0x" << record->unmap_from_gpu.start_addr << ", 0x"
+                         << record->unmap_from_gpu.end_addr << ", " << std::dec
+                         << record->unmap_from_gpu.trigger << ")";
+                    break;
+                }
+                case ROCPROFILER_PAGE_MIGRATION_NONE:
+                case ROCPROFILER_PAGE_MIGRATION_LAST:
+                {
+                    // throw std::runtime_error{"unexpected page migration value"};
+                    printf("page migration: start > end\n");
+                    break;
+                }
+            }
+
+            if(record->start_timestamp > record->end_timestamp)
+                printf("page migration: start > end\n");
+                // throw std::runtime_error("page migration: start > end");
+
+            static_cast<call_stack_t*>(user_data)->emplace_back(
+                source_location{__FUNCTION__, __FILE__, __LINE__, kind_name + info.str()});
+        }
+        else if(header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING &&
+                header->kind == ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY)
+        {
+            auto* record =
+                static_cast<rocprofiler_buffer_tracing_scratch_memory_record_t*>(header->payload);
+
+            auto info = std::stringstream{};
+
+            auto _elapsed =
+                std::chrono::duration_cast<std::chrono::duration<double, std::micro>>(
+                    std::chrono::nanoseconds{record->end_timestamp - record->start_timestamp})
+                    .count();
+
+            info << "tid=" << record->thread_id << ", context=" << context.handle
+                 << ", buffer_id=" << buffer_id.handle
+                 << ", cid=" << record->correlation_id.internal
+                 << ", extern_cid=" << record->correlation_id.external.value
+                 << ", kind=" << record->kind << ", operation=" << record->operation
+                 << ", agent_id=" << record->agent_id.handle
+                 << ", queue_id=" << record->queue_id.handle << ", thread_id=" << record->thread_id
+                 << ", elapsed=" << std::setprecision(3) << std::fixed << _elapsed
+                 << " usec, flags=" << record->flags
+                 << ", name=" << client_name_info.at(record->kind, record->operation);
+
+            static_cast<call_stack_t*>(user_data)->emplace_back(
+                source_location{__FUNCTION__, __FILE__, __LINE__, kind_name + info.str()});
+        }
+        else
+        {
+            auto _msg = std::stringstream{};
+            _msg << "unexpected rocprofiler_record_header_t category + kind: (" << header->category
+                 << " + " << header->kind << ")";
+            std::cout << _msg.str() << std::endl;
+            // throw std::runtime_error{_msg.str()};
+        }
+    }
+}
+
+void thread_precreate(rocprofiler_runtime_library_t lib, void* tool_data)
 {
     static_cast<call_stack_t*>(tool_data)->emplace_back(
         source_location{__FUNCTION__,
@@ -63,8 +392,7 @@ thread_precreate(rocprofiler_runtime_library_t lib, void* tool_data)
                             std::to_string(lib) + ")"});
 }
 
-void
-thread_postcreate(rocprofiler_runtime_library_t lib, void* tool_data)
+void thread_postcreate(rocprofiler_runtime_library_t lib, void* tool_data)
 {
     static_cast<call_stack_t*>(tool_data)->emplace_back(
         source_location{__FUNCTION__,
@@ -74,1544 +402,176 @@ thread_postcreate(rocprofiler_runtime_library_t lib, void* tool_data)
                             std::to_string(lib) + ")"});
 }
 
-namespace {
+int tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
+{
+    assert(tool_data != nullptr);
 
-// GetCachedTID() caches the thread ID in thread-local storage (which is a
-// userspace construct) to avoid unnecessary system calls. Without this caching,
-// it can take roughly 98ns, while it takes roughly 1ns with this caching.
-int32_t GetCachedTID() {
-  static thread_local int32_t current_thread_id =
-      tsl::Env::Default()->GetCurrentThreadId();
-  return current_thread_id;
-}
+    auto* call_stack_v = static_cast<call_stack_t*>(tool_data);
 
-const char* GetActivityDomainName(uint32_t domain) {
-  switch (domain) {
-    case ACTIVITY_DOMAIN_HSA_API:
-      return "HSA API";
-    case ACTIVITY_DOMAIN_HSA_OPS:
-      return "HSA OPS";
-    case ACTIVITY_DOMAIN_HIP_OPS:
-      return "HIP OPS/HCC/VDI";
-    case ACTIVITY_DOMAIN_HIP_API:
-      return "HIP API";
-    case ACTIVITY_DOMAIN_KFD_API:
-      return "KFD API";
-    case ACTIVITY_DOMAIN_EXT_API:
-      return "EXT API";
-    case ACTIVITY_DOMAIN_ROCTX:
-      return "ROCTX";
-    case ACTIVITY_DOMAIN_HSA_EVT:
-      return "HSA envents";
-    default:
-      DCHECK(false);
-      return "";
-  }
-  return "";
-}
+    call_stack_v->emplace_back(source_location{__FUNCTION__, __FILE__, __LINE__, ""});
 
-std::string GetActivityDomainOpName(uint32_t domain, uint32_t op) {
-  std::ostringstream oss;
-  oss << GetActivityDomainName(domain) << " - ";
-  switch (domain) {
-    case ACTIVITY_DOMAIN_HIP_API:
-      oss << hip_api_name(op);
-      break;
-    default:
-      oss << op;
-      break;
-  }
-  return oss.str();
-}
+    client_name_info = xla::common::get_buffer_tracing_names();
 
-const char* GetActivityPhaseName(uint32_t phase) {
-  switch (phase) {
-    case ACTIVITY_API_PHASE_ENTER:
-      return "ENTER";
-    case ACTIVITY_API_PHASE_EXIT:
-      return "EXIT";
-    default:
-      DCHECK(false);
-      return "";
-  }
-  return "";
-}
+    for(const auto& itr : client_name_info)
+    {
+        auto name_idx = std::stringstream{};
+        name_idx << " [" << std::setw(3) << itr.value << "]";
+        call_stack_v->emplace_back(
+            source_location{"rocprofiler_buffer_tracing_kind_names          " + name_idx.str(),
+                            __FILE__,
+                            __LINE__,
+                            std::string{itr.name}});
 
-inline void DumpApiCallbackData(uint32_t domain, uint32_t cbid,
-                                const void* cbdata) {
-  std::ostringstream oss;
-  oss << "API callback for " << GetActivityDomainName(domain);
-  if (domain == ACTIVITY_DOMAIN_HIP_API) {
-    const hip_api_data_t* data =
-        reinterpret_cast<const hip_api_data_t*>(cbdata);
-    oss << " - " << hip_api_name(cbid);
-    oss << ", correlation_id=" << data->correlation_id;
-    oss << ", phase=" << GetActivityPhaseName(data->phase);
-    switch (cbid) {
-      case HIP_API_ID_hipModuleLaunchKernel:
-      case HIP_API_ID_hipExtModuleLaunchKernel:
-      case HIP_API_ID_hipHccModuleLaunchKernel:
-      case HIP_API_ID_hipLaunchKernel:
-      case HIP_API_ID_hipExtLaunchKernel:
-        break;
-      case HIP_API_ID_hipMemcpyDtoH:
-        oss << ", sizeBytes=" << data->args.hipMemcpyDtoH.sizeBytes;
-        break;
-      case HIP_API_ID_hipMemcpyDtoHAsync:
-        oss << ", sizeBytes=" << data->args.hipMemcpyDtoHAsync.sizeBytes;
-        break;
-      case HIP_API_ID_hipMemcpyHtoD:
-        oss << ", sizeBytes=" << data->args.hipMemcpyHtoD.sizeBytes;
-        break;
-      case HIP_API_ID_hipMemcpyHtoDAsync:
-        oss << ", sizeBytes=" << data->args.hipMemcpyHtoDAsync.sizeBytes;
-        break;
-      case HIP_API_ID_hipMemcpyDtoD:
-        oss << ", sizeBytes=" << data->args.hipMemcpyDtoD.sizeBytes;
-        break;
-      case HIP_API_ID_hipMemcpyDtoDAsync:
-        oss << ", sizeBytes=" << data->args.hipMemcpyDtoDAsync.sizeBytes;
-        break;
-      case HIP_API_ID_hipMemcpyAsync:
-        oss << ", sizeBytes=" << data->args.hipMemcpyAsync.sizeBytes;
-        break;
-      case HIP_API_ID_hipMemsetD32:
-        oss << ", value=" << data->args.hipMemsetD32.value;
-        oss << ", count=" << data->args.hipMemsetD32.count;
-        break;
-      case HIP_API_ID_hipMemsetD32Async:
-        oss << ", value=" << data->args.hipMemsetD32Async.value;
-        oss << ", count=" << data->args.hipMemsetD32Async.count;
-        break;
-      case HIP_API_ID_hipMemsetD8:
-        oss << ", value=" << data->args.hipMemsetD8.value;
-        oss << ", count=" << data->args.hipMemsetD8.count;
-        break;
-      case HIP_API_ID_hipMemsetD8Async:
-        oss << ", value=" << data->args.hipMemsetD8Async.value;
-        oss << ", count=" << data->args.hipMemsetD8Async.count;
-        break;
-      case HIP_API_ID_hipMalloc:
-        oss << ", size=" << data->args.hipMalloc.size;
-        break;
-      case HIP_API_ID_hipFree:
-        oss << ", ptr=" << data->args.hipFree.ptr;
-        break;
-      case HIP_API_ID_hipStreamSynchronize:
-        break;
-      case HIP_API_ID_hipStreamWaitEvent:  // ignore all aux HIP API Events
-      case HIP_API_ID_hipHostFree:
-      case HIP_API_ID_hipHostMalloc:
-      case HIP_API_ID_hipSetDevice:
-        break;
-      default:
-        VLOG(3) << "Warning: HIP API is not handled: HIP_API_ID_"
-                << hip_api_name(cbid);
-        break;
+        for(auto [didx, ditr] : itr.items())
+        {
+            auto operation_idx = std::stringstream{};
+            operation_idx << " [" << std::setw(3) << didx << "]";
+            call_stack_v->emplace_back(source_location{
+                "rocprofiler_buffer_tracing_kind_operation_names" + operation_idx.str(),
+                __FILE__,
+                __LINE__,
+                std::string{"- "} + std::string{*ditr}});
+        }
     }
-  } else {
-    oss << ": " << cbid;
-  }
-  VLOG(3) << oss.str();
+
+    client_fini_func = fini_func;
+
+    ROCPROFILER_CALL(se::wrap::rocprofiler_create_context(&client_ctx), "context creation");
+
+    auto code_object_ops = std::vector<rocprofiler_tracing_operation_t>{
+        ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER};
+
+    ROCPROFILER_CALL(
+        se::wrap::rocprofiler_configure_callback_tracing_service(client_ctx,
+                                                       ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT,
+                                                       code_object_ops.data(),
+                                                       code_object_ops.size(),
+                                                       tool_code_object_callback,
+                                                       nullptr),
+        "code object tracing service configure");
+
+    constexpr auto buffer_size_bytes      = 4096;
+    constexpr auto buffer_watermark_bytes = buffer_size_bytes - (buffer_size_bytes / 8);
+
+    ROCPROFILER_CALL(se::wrap::rocprofiler_create_buffer(client_ctx,
+                                               buffer_size_bytes,
+                                               buffer_watermark_bytes,
+                                               ROCPROFILER_BUFFER_POLICY_LOSSLESS,
+                                               tool_tracing_callback,
+                                               tool_data,
+                                               &client_buffer),
+                     "buffer creation");
+
+    for(auto itr :
+        {ROCPROFILER_BUFFER_TRACING_HSA_CORE_API, ROCPROFILER_BUFFER_TRACING_HSA_AMD_EXT_API})
+    {
+        ROCPROFILER_CALL(se::wrap::rocprofiler_configure_buffer_tracing_service(
+                             client_ctx, itr, nullptr, 0, client_buffer),
+                         "buffer tracing service configure");
+    }
+
+    ROCPROFILER_CALL(
+        rocprofiler_configure_buffer_tracing_service(
+            client_ctx, ROCPROFILER_BUFFER_TRACING_HIP_RUNTIME_API, nullptr, 0, client_buffer),
+        "buffer tracing service configure");
+
+    ROCPROFILER_CALL(
+        rocprofiler_configure_buffer_tracing_service(
+            client_ctx, ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH, nullptr, 0, client_buffer),
+        "buffer tracing service for kernel dispatch configure");
+
+    ROCPROFILER_CALL(
+        rocprofiler_configure_buffer_tracing_service(
+            client_ctx, ROCPROFILER_BUFFER_TRACING_MEMORY_COPY, nullptr, 0, client_buffer),
+        "buffer tracing service for memory copy configure");
+
+    // May have incompatible kernel so only emit a warning here
+    ROCPROFILER_WARN(rocprofiler_configure_buffer_tracing_service(
+        client_ctx, ROCPROFILER_BUFFER_TRACING_PAGE_MIGRATION, nullptr, 0, client_buffer));
+
+    ROCPROFILER_CALL(
+        rocprofiler_configure_buffer_tracing_service(
+            client_ctx, ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY, nullptr, 0, client_buffer),
+        "buffer tracing service for page migration configure");
+
+    auto client_thread = rocprofiler_callback_thread_t{};
+    ROCPROFILER_CALL(rocprofiler_create_callback_thread(&client_thread),
+                     "creating callback thread");
+
+    ROCPROFILER_CALL(rocprofiler_assign_callback_thread(client_buffer, client_thread),
+                     "assignment of thread for buffer");
+
+    int valid_ctx = 0;
+    ROCPROFILER_CALL(rocprofiler_context_is_valid(client_ctx, &valid_ctx),
+                     "context validity check");
+    if(valid_ctx == 0)
+    {
+        // notify rocprofiler that initialization failed
+        // and all the contexts, buffers, etc. created
+        // should be ignored
+        return -1;
+    }
+
+    ROCPROFILER_CALL(rocprofiler_start_context(client_ctx), "rocprofiler context start");
+
+    // no errors
+    return 0;
 }
 
-void DumpActivityRecord(const roctracer_record_t* record,
-                        std::string extra_info) {
-  std::ostringstream oss;
-  oss << "Activity callback for " << GetActivityDomainName(record->domain);
-  oss << ", op name= "
-      << se::wrap::roctracer_op_string(record->domain, record->op,
-                                       record->kind);
-  oss << ", correlation_id=" << record->correlation_id;
-  oss << ", begin_ns=" << record->begin_ns;
-  oss << ", end_ns=" << record->end_ns;
-  oss << ", duration=" << record->end_ns - record->begin_ns;
-  oss << ", device_id=" << record->device_id;
-  oss << ", queue_id=" << record->queue_id;
-  oss << ", process_id=" << record->process_id;
-  oss << ", thread_id=" << record->thread_id;
-  oss << ", external_id=" << record->external_id;
-  oss << ", bytes=" << record->bytes;
-  oss << ", domain=" << record->domain;
-  oss << ", op=" << record->op;
-  oss << ", kind=" << record->kind;
-  oss << ", extra_info=" << extra_info;
-  VLOG(3) << oss.str();
-}
+void tool_fini(void* tool_data)
+{
+    assert(tool_data != nullptr);
 
+    auto* _call_stack = static_cast<call_stack_t*>(tool_data);
+    _call_stack->emplace_back(source_location{__FUNCTION__, __FILE__, __LINE__, ""});
+
+    print_call_stack(*_call_stack);
+
+    delete _call_stack;
+}
 }  // namespace
 
-const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type) {
-  switch (type) {
-    case RocmTracerEventType::Kernel:
-      return "Kernel";
-    case RocmTracerEventType::MemcpyH2D:
-      return "MemcpyH2D";
-    case RocmTracerEventType::MemcpyD2H:
-      return "MemcpyD2H";
-    case RocmTracerEventType::MemcpyD2D:
-      return "MemcpyD2D";
-    case RocmTracerEventType::MemcpyP2P:
-      return "MemcpyP2P";
-    case RocmTracerEventType::MemcpyOther:
-      return "MemcpyOther";
-    case RocmTracerEventType::MemoryAlloc:
-      return "MemoryAlloc";
-    case RocmTracerEventType::MemoryFree:
-      return "MemoryFree";
-    case RocmTracerEventType::Memset:
-      return "Memset";
-    case RocmTracerEventType::Synchronization:
-      return "Synchronization";
-    case RocmTracerEventType::Generic:
-      return "Generic";
-    default:
-      DCHECK(false);
-      return "";
-  }
-  return "";
-}
-
-const char* GetRocmTracerEventSourceName(const RocmTracerEventSource& source) {
-  switch (source) {
-    case RocmTracerEventSource::ApiCallback:
-      return "ApiCallback";
-      break;
-    case RocmTracerEventSource::Activity:
-      return "Activity";
-      break;
-    case RocmTracerEventSource::Invalid:
-      return "Invalid";
-      break;
-    default:
-      DCHECK(false);
-      return "";
-  }
-  return "";
-}
-
-// FIXME(rocm-profiler): These domain names are not consistent with the
-// GetActivityDomainName function
-const char* GetRocmTracerEventDomainName(const RocmTracerEventDomain& domain) {
-  switch (domain) {
-    case RocmTracerEventDomain::HIP_API:
-      return "HIP_API";
-      break;
-    case RocmTracerEventDomain::HIP_OPS:
-      return "HIP_OPS";
-      break;
-    default:
-      VLOG(3) << "RocmTracerEventDomain::InvalidDomain";
-      DCHECK(false);
-      return "";
-  }
-  return "";
-}
-
-absl::Status RocmApiCallbackImpl::operator()(uint32_t domain, uint32_t cbid,
-                                             const void* cbdata) {
-  /* Some APIs such as hipMalloc, implicitly work on th devices set by the
-    user using APIs such as hipSetDevice. API callbacks and activity records
-    for functions like hipMalloc does not return the device id (CUDA does). To
-    solve this we need to track the APIs that select the device (such as
-    hipSetDevice) for each thread.
-    */
-
-  thread_local uint32_t default_device = hipGetStreamDeviceId(nullptr);
-
-  // DumpApiCallbackData(domain, cbid, cbdata);
-
-  if (domain != ACTIVITY_DOMAIN_HIP_API) return tsl::OkStatus();
-
-  const hip_api_data_t* data = reinterpret_cast<const hip_api_data_t*>(cbdata);
-
-  if (data->phase == ACTIVITY_API_PHASE_ENTER) {
-    if (options_.api_tracking_set.find(cbid) !=
-        options_.api_tracking_set.end()) {
-      mutex_lock lock(api_call_start_mutex_);
-      api_call_start_time_.emplace(data->correlation_id,
-                                   RocmTracer::GetTimestamp());
+void
+setup()
+{
+    if(int status = 0;
+       rocprofiler_is_initialized(&status) == ROCPROFILER_STATUS_SUCCESS && status == 0)
+    {
+        ROCPROFILER_CALL(rocprofiler_force_configure(&rocprofiler_configure),
+                         "force configuration");
     }
+}
 
-    if (cbid == HIP_API_ID_hipSetDevice) {
-      default_device = hipGetStreamDeviceId(nullptr);
+void
+shutdown()
+{
+    if(client_id)
+    {
+        ROCPROFILER_CALL(rocprofiler_flush_buffer(client_buffer), "buffer flush");
+        client_fini_func(*client_id);
     }
-  } else if (data->phase == ACTIVITY_API_PHASE_EXIT) {
-    uint64_t enter_time = 0, exit_time = 0;
-
-    if (options_.api_tracking_set.find(cbid) !=
-        options_.api_tracking_set.end()) {
-      mutex_lock lock(api_call_start_mutex_);
-      if (api_call_start_time_.find(data->correlation_id) !=
-          api_call_start_time_.end()) {
-        enter_time = api_call_start_time_.at(data->correlation_id);
-        api_call_start_time_.erase(data->correlation_id);
-      } else {
-        LOG(WARNING) << "An API exit callback received without API enter "
-                        "with same correlation id. Event droped!";
-        return tsl::OkStatus();  // This API does not belong to us.
-      }
-      exit_time = RocmTracer::GetTimestamp();
-    }
-    // Set up the map from correlation id to annotation string.
-    const std::string& annotation = AnnotationStack::Get();
-    if (!annotation.empty()) {
-      collector_->annotation_map()->Add(data->correlation_id, annotation);
-    }
-
-    if (options_.api_tracking_set.find(cbid) ==
-        options_.api_tracking_set.end()) {
-      VLOG(3) << "API callback is from the auxilarity list. Corr. id="
-              << data->correlation_id;
-    }
-    DumpApiCallbackData(domain, cbid, cbdata);
-
-    switch (cbid) {
-      // star in comments means it does not exist in the driver wrapper
-      case HIP_API_ID_hipModuleLaunchKernel:
-      case HIP_API_ID_hipExtModuleLaunchKernel:  // *
-      case HIP_API_ID_hipHccModuleLaunchKernel:  // *
-      case HIP_API_ID_hipLaunchKernel:           // *
-      case HIP_API_ID_hipExtLaunchKernel:
-
-        this->AddKernelEventUponApiExit(cbid, data, enter_time, exit_time);
-
-        // Add the correlation_ids for these events to the pending set
-        // so that we can explicitly wait for their corresponding
-        // HIP runtime activity records, before exporting the trace data
-        tracer_->AddToPendingActivityRecords(data->correlation_id);
-        break;
-      case HIP_API_ID_hipMemcpy:
-      case HIP_API_ID_hipMemcpyDtoH:
-      case HIP_API_ID_hipMemcpyDtoHAsync:
-      case HIP_API_ID_hipMemcpyHtoD:
-      case HIP_API_ID_hipMemcpyHtoDAsync:
-      case HIP_API_ID_hipMemcpyDtoD:
-      case HIP_API_ID_hipMemcpyDtoDAsync:
-      case HIP_API_ID_hipMemcpyAsync:
-        this->AddNormalMemcpyEventUponApiExit(cbid, data, enter_time,
-                                              exit_time);
-        tracer_->AddToPendingActivityRecords(data->correlation_id);
-        break;
-      case HIP_API_ID_hipMemset:
-      case HIP_API_ID_hipMemsetAsync:
-      case HIP_API_ID_hipMemsetD32:
-      case HIP_API_ID_hipMemsetD32Async:
-      case HIP_API_ID_hipMemsetD16:
-      case HIP_API_ID_hipMemsetD16Async:
-      case HIP_API_ID_hipMemsetD8:
-      case HIP_API_ID_hipMemsetD8Async:
-        this->AddMemsetEventUponApiExit(cbid, data, enter_time, exit_time);
-        break;
-      case HIP_API_ID_hipMalloc:
-      case HIP_API_ID_hipMallocPitch:
-      case HIP_API_ID_hipHostMalloc:
-      case HIP_API_ID_hipFree:
-      case HIP_API_ID_hipHostFree:
-        this->AddMallocFreeEventUponApiExit(cbid, data, default_device,
-                                            enter_time, exit_time);
-        break;
-      case HIP_API_ID_hipStreamSynchronize:
-      case HIP_API_ID_hipStreamWaitEvent:
-        // case HIP_API_ID_hipEventSynchronize:
-        this->AddSynchronizeEventUponApiExit(cbid, data, enter_time, exit_time);
-        break;
-      case HIP_API_ID_hipSetDevice:
-        // we track this ID only to find the device ID
-        //  for the current thread.
-        break;
-      default:
-        //
-        LOG(WARNING) << "API call "
-                     << se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API,
-                                                      cbid, 0)
-                     << ", corr. id=" << data->correlation_id
-                     << " dropped. No capturing function was found!";
-        // AddGenericEventUponApiExit(cbid, data);
-        break;
-    }
-  }
-  return tsl::OkStatus();
 }
 
-void RocmApiCallbackImpl::AddKernelEventUponApiExit(uint32_t cbid,
-                                                    const hip_api_data_t* data,
-                                                    const uint64_t enter_time,
-                                                    const uint64_t exit_time) {
-  /*
-  extra fields:
-    kernel_info, domain
-
-  missing fields:
-    context_id
-  */
-  RocmTracerEvent event;
-
-  event.domain = RocmTracerEventDomain::HIP_API;
-  event.type = RocmTracerEventType::Kernel;
-  event.source = RocmTracerEventSource::ApiCallback;
-  event.thread_id = GetCachedTID();
-  event.correlation_id = data->correlation_id;
-  event.start_time_ns = enter_time;
-  event.end_time_ns = exit_time;
-
-  switch (cbid) {
-    case HIP_API_ID_hipModuleLaunchKernel: {
-      const hipFunction_t kernelFunc = data->args.hipModuleLaunchKernel.f;
-      if (kernelFunc != nullptr) event.name = hipKernelNameRef(kernelFunc);
-
-      event.kernel_info.dynamic_shared_memory_usage =
-          data->args.hipModuleLaunchKernel.sharedMemBytes;
-      event.kernel_info.block_x = data->args.hipModuleLaunchKernel.blockDimX;
-      event.kernel_info.block_y = data->args.hipModuleLaunchKernel.blockDimY;
-      event.kernel_info.block_z = data->args.hipModuleLaunchKernel.blockDimZ;
-      event.kernel_info.grid_x = data->args.hipModuleLaunchKernel.gridDimX;
-      event.kernel_info.grid_y = data->args.hipModuleLaunchKernel.gridDimY;
-      event.kernel_info.grid_z = data->args.hipModuleLaunchKernel.gridDimZ;
-      event.kernel_info.func_ptr = kernelFunc;
-      const hipStream_t& stream = data->args.hipModuleLaunchKernel.stream;
-      // TODO(rocm-profiler): wrap this API if possible.
-      event.device_id = hipGetStreamDeviceId(stream);
-    } break;
-    case HIP_API_ID_hipExtModuleLaunchKernel: {
-      const hipFunction_t kernelFunc = data->args.hipExtModuleLaunchKernel.f;
-      if (kernelFunc != nullptr) event.name = hipKernelNameRef(kernelFunc);
-
-      event.kernel_info.dynamic_shared_memory_usage =
-          data->args.hipExtModuleLaunchKernel.sharedMemBytes;
-      unsigned int blockDimX =
-          data->args.hipExtModuleLaunchKernel.localWorkSizeX;
-      unsigned int blockDimY =
-          data->args.hipExtModuleLaunchKernel.localWorkSizeY;
-      unsigned int blockDimZ =
-          data->args.hipExtModuleLaunchKernel.localWorkSizeZ;
-
-      event.kernel_info.block_x = blockDimX;
-      event.kernel_info.block_y = blockDimY;
-      event.kernel_info.block_z = blockDimZ;
-      event.kernel_info.grid_x =
-          data->args.hipExtModuleLaunchKernel.globalWorkSizeX / blockDimX;
-      event.kernel_info.grid_y =
-          data->args.hipExtModuleLaunchKernel.globalWorkSizeY / blockDimY;
-      event.kernel_info.grid_z =
-          data->args.hipExtModuleLaunchKernel.globalWorkSizeZ / blockDimZ;
-      event.kernel_info.func_ptr = kernelFunc;
-      const hipStream_t& stream = data->args.hipExtModuleLaunchKernel.hStream;
-      event.device_id = hipGetStreamDeviceId(stream);
-    } break;
-    case HIP_API_ID_hipHccModuleLaunchKernel: {
-      const hipFunction_t kernelFunc = data->args.hipHccModuleLaunchKernel.f;
-      if (kernelFunc != nullptr) event.name = hipKernelNameRef(kernelFunc);
-
-      event.kernel_info.dynamic_shared_memory_usage =
-          data->args.hipHccModuleLaunchKernel.sharedMemBytes;
-      event.kernel_info.block_x = data->args.hipHccModuleLaunchKernel.blockDimX;
-      event.kernel_info.block_y = data->args.hipHccModuleLaunchKernel.blockDimY;
-      event.kernel_info.block_z = data->args.hipHccModuleLaunchKernel.blockDimZ;
-      event.kernel_info.grid_x =
-          data->args.hipHccModuleLaunchKernel.globalWorkSizeX /
-          event.kernel_info.block_x;
-      event.kernel_info.grid_y =
-          data->args.hipHccModuleLaunchKernel.globalWorkSizeY /
-          event.kernel_info.block_y;
-      event.kernel_info.grid_z =
-          data->args.hipHccModuleLaunchKernel.globalWorkSizeZ /
-          event.kernel_info.block_z;
-      event.kernel_info.func_ptr = kernelFunc;
-      const hipStream_t& stream = data->args.hipHccModuleLaunchKernel.hStream;
-      event.device_id = hipGetStreamDeviceId(stream);
-      event.kernel_info.dynamic_shared_memory_usage =
-          data->args.hipHccModuleLaunchKernel.sharedMemBytes;
-    } break;
-    case HIP_API_ID_hipLaunchKernel: {
-      const void* func_addr = data->args.hipLaunchKernel.function_address;
-      hipStream_t stream = data->args.hipLaunchKernel.stream;
-      if (func_addr != nullptr)
-        event.name = hipKernelNameRefByPtr(func_addr, stream);
-
-      event.kernel_info.dynamic_shared_memory_usage =
-          data->args.hipLaunchKernel.sharedMemBytes;
-      event.kernel_info.block_x = data->args.hipLaunchKernel.dimBlocks.x;
-      event.kernel_info.block_y = data->args.hipLaunchKernel.dimBlocks.y;
-      event.kernel_info.block_z = data->args.hipLaunchKernel.dimBlocks.z;
-      event.kernel_info.grid_x = data->args.hipLaunchKernel.numBlocks.x;
-      event.kernel_info.grid_y = data->args.hipLaunchKernel.numBlocks.y;
-      event.kernel_info.grid_z = data->args.hipLaunchKernel.numBlocks.z;
-      event.kernel_info.func_ptr = (void*)func_addr;
-      event.device_id = hipGetStreamDeviceId(stream);
-    } break;
-    case HIP_API_ID_hipExtLaunchKernel: {
-      const void* func_addr = data->args.hipExtLaunchKernel.function_address;
-      hipStream_t stream = data->args.hipExtLaunchKernel.stream;
-      if (func_addr != nullptr)
-        event.name = hipKernelNameRefByPtr(func_addr, stream);
-
-      event.kernel_info.dynamic_shared_memory_usage =
-          data->args.hipExtLaunchKernel.sharedMemBytes;
-      event.kernel_info.block_x = data->args.hipExtLaunchKernel.dimBlocks.x;
-      event.kernel_info.block_y = data->args.hipExtLaunchKernel.dimBlocks.y;
-      event.kernel_info.block_z = data->args.hipExtLaunchKernel.dimBlocks.z;
-      event.kernel_info.grid_x = data->args.hipExtLaunchKernel.numBlocks.x;
-      event.kernel_info.grid_y = data->args.hipExtLaunchKernel.numBlocks.y;
-      event.kernel_info.grid_z = data->args.hipExtLaunchKernel.numBlocks.z;
-      event.kernel_info.func_ptr = const_cast<void*>(func_addr);
-      event.device_id = hipGetStreamDeviceId(stream);
-    } break;
-  }
-  bool is_auxiliary =
-      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
-  collector_->AddEvent(std::move(event), is_auxiliary);
+void
+start()
+{
+    ROCPROFILER_CALL(rocprofiler_start_context(client_ctx), "context start");
 }
 
-void RocmApiCallbackImpl::AddNormalMemcpyEventUponApiExit(
-    uint32_t cbid, const hip_api_data_t* data, uint64_t enter_time,
-    uint64_t exit_time) {
-  /*
-    missing:
-      device_id(partially, have only for async), context_id,
-    memcpy_info.kind(CUPTI puts CUPTI_ACTIVITY_MEMCPY_KIND_UNKNOWN),
-      memcpy_info.destination(partially, only for async)( CUPTI puts device_id),
-
-    extra:
-      domain, name,
-  */
-  // for CUDA, it does NOT capture stream id for these types
-
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_API;
-  event.name = se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid, 0);
-  event.source = RocmTracerEventSource::ApiCallback;
-  event.thread_id = GetCachedTID();
-  event.correlation_id = data->correlation_id;
-  event.start_time_ns = enter_time;
-  event.end_time_ns = exit_time;
-
-  /* The general hipMemcpy or hipMemcpyAsync can support any kind of memory
-  copy operation, such as H2D, D2D, P2P, and D2H. Here we use MemcpyOther for
-  all api calls with HipMemcpy(+Async) to carry-on this generality.
-  We also assume that if we want to copy data BETWEEN devices, we do not use
-  hipMemcpy(+Async) or hipMemcpyDtoD(+Async) as we explicitly always set the
-  destenation as the source device id). Ultimately, to figure out the actual
-  device we can use hipPointerGetAttributes but we do not do that now .In the
-  other words, we assume we use hipMemcpyPeer to achieve the copy between
-  devices.
-  */
-
-  switch (cbid) {
-    case HIP_API_ID_hipMemcpyDtoH: {
-      event.type = RocmTracerEventType::MemcpyD2H;
-      event.memcpy_info.num_bytes = data->args.hipMemcpyDtoH.sizeBytes;
-      event.memcpy_info.async = false;
-    } break;
-    case HIP_API_ID_hipMemcpyDtoHAsync: {
-      event.type = RocmTracerEventType::MemcpyD2H;
-      const hipStream_t& stream = data->args.hipMemcpyDtoHAsync.stream;
-      event.device_id = hipGetStreamDeviceId(stream);
-      event.memcpy_info.num_bytes = data->args.hipMemcpyDtoHAsync.sizeBytes;
-      event.memcpy_info.async = true;
-      event.memcpy_info.destination = event.device_id;
-    } break;
-    case HIP_API_ID_hipMemcpyHtoD: {
-      event.type = RocmTracerEventType::MemcpyH2D;
-      event.memcpy_info.num_bytes = data->args.hipMemcpyHtoD.sizeBytes;
-      event.memcpy_info.async = false;
-      // we set the destenattion device id for it using the device id we get
-      // from activities when they exchange information before flushing
-    } break;
-    case HIP_API_ID_hipMemcpyHtoDAsync: {
-      event.type = RocmTracerEventType::MemcpyH2D;
-      const hipStream_t& stream = data->args.hipMemcpyHtoDAsync.stream;
-      event.device_id = hipGetStreamDeviceId(stream);
-      event.memcpy_info.num_bytes = data->args.hipMemcpyHtoDAsync.sizeBytes;
-      event.memcpy_info.async = true;
-      event.memcpy_info.destination = event.device_id;
-    } break;
-    case HIP_API_ID_hipMemcpyDtoD: {
-      event.type = RocmTracerEventType::MemcpyD2D;
-      event.memcpy_info.num_bytes = data->args.hipMemcpyDtoD.sizeBytes;
-      event.memcpy_info.async = false;
-    } break;
-    case HIP_API_ID_hipMemcpyDtoDAsync: {
-      event.type = RocmTracerEventType::MemcpyD2D;
-      const hipStream_t& stream = data->args.hipMemcpyDtoDAsync.stream;
-      event.device_id = hipGetStreamDeviceId(stream);
-      event.memcpy_info.num_bytes = data->args.hipMemcpyDtoDAsync.sizeBytes;
-      event.memcpy_info.async = true;
-      event.memcpy_info.destination = event.device_id;
-    } break;
-    case HIP_API_ID_hipMemcpy: {
-      event.type = RocmTracerEventType::MemcpyOther;
-      event.memcpy_info.num_bytes = data->args.hipMemcpy.sizeBytes;
-      event.memcpy_info.async = false;
-    } break;
-    case HIP_API_ID_hipMemcpyAsync: {
-      event.type = RocmTracerEventType::MemcpyOther;
-      const hipStream_t& stream = data->args.hipMemcpyAsync.stream;
-      event.device_id = hipGetStreamDeviceId(stream);
-      event.memcpy_info.num_bytes = data->args.hipMemcpyAsync.sizeBytes;
-      event.memcpy_info.async = true;
-      event.memcpy_info.destination = event.device_id;
-    } break;
-    default:
-      LOG(WARNING) << "Unsupported Memcpy API for profiling observed for cbid="
-                   << cbid << ". Event dropped!";
-      return;
-      break;
-  }
-
-  bool is_auxiliary =
-      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
-  collector_->AddEvent(std::move(event), is_auxiliary);
-}
-void RocmApiCallbackImpl::AddMemcpyPeerEventUponApiExit(
-    uint32_t cbid, const hip_api_data_t* data, uint64_t enter_time,
-    uint64_t exit_time) {
-  /*
-    missing: context_id, memcpy_info.kind
-
-    extra: domain, name,
-  */
-
-  RocmTracerEvent event;
-  event.type = RocmTracerEventType::MemcpyP2P;
-  event.domain = RocmTracerEventDomain::HIP_API;
-  event.name = se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid, 0);
-  event.source = RocmTracerEventSource::ApiCallback;
-  event.thread_id = GetCachedTID();
-  event.correlation_id = data->correlation_id;
-  event.start_time_ns = enter_time;
-  event.end_time_ns = exit_time;
-
-  switch (cbid) {
-    case HIP_API_ID_hipMemcpyPeer:
-      event.device_id = data->args.hipMemcpyPeer.srcDeviceId;
-      event.memcpy_info.destination = data->args.hipMemcpyPeer.dstDeviceId;
-      event.memcpy_info.num_bytes = data->args.hipMemcpyPeer.sizeBytes;
-      event.memcpy_info.async = false;
-      break;
-    case HIP_API_ID_hipMemcpyPeerAsync:
-      event.device_id = data->args.hipMemcpyPeerAsync.srcDevice;
-      event.memcpy_info.destination = data->args.hipMemcpyPeerAsync.dstDeviceId;
-      event.memcpy_info.num_bytes = data->args.hipMemcpyPeerAsync.sizeBytes;
-      event.memcpy_info.async = true;
-      break;
-    default:
-      LOG(WARNING)
-          << "Unsupported MemcpyPeer API for profiling observed for cbid="
-          << cbid << ". Event dropped!";
-      return;
-      break;
-  }
-
-  bool is_auxiliary =
-      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
-  collector_->AddEvent(std::move(event), is_auxiliary);
-}
-void RocmApiCallbackImpl::AddMemsetEventUponApiExit(uint32_t cbid,
-                                                    const hip_api_data_t* data,
-                                                    uint64_t enter_time,
-                                                    uint64_t exit_time) {
-  /*
-    misses:
-      device_id(only avail. for async), context_id
-
-    extras:
-      domain, name
-  */
-
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_API;
-  event.name = se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid, 0);
-  event.source = RocmTracerEventSource::ApiCallback;
-  event.thread_id = GetCachedTID();
-  event.correlation_id = data->correlation_id;
-  event.start_time_ns = enter_time;
-  event.end_time_ns = exit_time;
-
-  switch (cbid) {
-    case HIP_API_ID_hipMemsetD8:
-      event.type = RocmTracerEventType::Memset;
-      event.memset_info.num_bytes = data->args.hipMemsetD8.count;
-      event.memset_info.async = false;
-      break;
-    case HIP_API_ID_hipMemsetD8Async: {
-      event.type = RocmTracerEventType::Memset;
-      event.memset_info.num_bytes = data->args.hipMemsetD8Async.count;
-      event.memset_info.async = true;
-      const hipStream_t& stream = data->args.hipMemsetD8Async.stream;
-      event.device_id = hipGetStreamDeviceId(stream);
-    } break;
-    case HIP_API_ID_hipMemsetD16:
-      event.type = RocmTracerEventType::Memset;
-      event.memset_info.num_bytes = 2 * data->args.hipMemsetD16.count;
-      event.memset_info.async = false;
-      break;
-    case HIP_API_ID_hipMemsetD16Async: {
-      event.type = RocmTracerEventType::Memset;
-      event.memset_info.num_bytes = 2 * data->args.hipMemsetD16Async.count;
-      event.memset_info.async = true;
-      const hipStream_t& stream = data->args.hipMemsetD16Async.stream;
-      event.device_id = hipGetStreamDeviceId(stream);
-    } break;
-    case HIP_API_ID_hipMemsetD32:
-      event.type = RocmTracerEventType::Memset;
-      event.memset_info.num_bytes = 4 * data->args.hipMemsetD32.count;
-      event.memset_info.async = false;
-      break;
-    case HIP_API_ID_hipMemsetD32Async: {
-      event.type = RocmTracerEventType::Memset;
-      event.memset_info.num_bytes = 4 * data->args.hipMemsetD32Async.count;
-      event.memset_info.async = true;
-      const hipStream_t& stream = data->args.hipMemsetD32Async.stream;
-      event.device_id = hipGetStreamDeviceId(stream);
-    } break;
-    case HIP_API_ID_hipMemset:
-      event.type = RocmTracerEventType::Memset;
-      event.memset_info.num_bytes = data->args.hipMemset.sizeBytes;
-      event.memset_info.async = false;
-      break;
-    case HIP_API_ID_hipMemsetAsync: {
-      event.type = RocmTracerEventType::Memset;
-      event.memset_info.num_bytes = data->args.hipMemsetAsync.sizeBytes;
-      event.memset_info.async = true;
-      const hipStream_t& stream = data->args.hipMemsetAsync.stream;
-      event.device_id = hipGetStreamDeviceId(stream);
-    } break;
-    default:
-      LOG(WARNING) << "Unsupported Memset API for profiling observed for cbid="
-                   << cbid << ". Event dropped!";
-      return;
-      break;
-  }
-
-  bool is_auxiliary =
-      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
-  collector_->AddEvent(std::move(event), is_auxiliary);
+void
+identify(uint64_t val)
+{
+    auto _tid = rocprofiler_thread_id_t{};
+    rocprofiler_get_thread_id(&_tid);
+    rocprofiler_user_data_t user_data = {};
+    user_data.value                   = val;
+    rocprofiler_push_external_correlation_id(client_ctx, _tid, user_data);
 }
 
-void RocmApiCallbackImpl::AddMallocFreeEventUponApiExit(
-    uint32_t cbid, const hip_api_data_t* data, uint32_t device_id,
-    uint64_t enter_time, uint64_t exit_time) {
-  /*
-    misses: context_id
-
-    extras: domain
-  */
-
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_API;
-  event.type = (cbid == HIP_API_ID_hipFree || cbid == HIP_API_ID_hipHostFree)
-                   ? RocmTracerEventType::MemoryFree
-                   : RocmTracerEventType::MemoryAlloc;
-  event.source = RocmTracerEventSource::ApiCallback;
-  event.name = se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid, 0);
-  event.device_id = device_id;
-  event.thread_id = GetCachedTID();
-  // We do not set stream_id (probably to zero as Malloc etc. commands seems
-  // to run on  default stream). Later we use the unassigned stream_id as a
-  // feature to assign events to host or device.
-  event.correlation_id = data->correlation_id;
-  event.start_time_ns = enter_time;
-  event.end_time_ns = exit_time;
-
-  switch (cbid) {
-    case HIP_API_ID_hipMalloc:
-      event.memalloc_info.num_bytes = data->args.hipMalloc.size;
-      break;
-    case HIP_API_ID_hipMallocPitch:
-      event.memalloc_info.num_bytes = data->args.hipMallocPitch.pitch__val *
-                                      data->args.hipMallocPitch.height;
-      break;
-    case HIP_API_ID_hipHostMalloc:
-      event.memalloc_info.num_bytes = data->args.hipHostMalloc.size;
-      break;
-    case HIP_API_ID_hipFree:
-    case HIP_API_ID_hipHostFree:
-      event.memalloc_info.num_bytes = 0;
-      break;
-    default:
-      LOG(WARNING)
-          << "Unsupported Malloc/Free API for profiling observed for cbid="
-          << cbid << ". Event dropped!";
-      return;
-      break;
-  }
-
-  bool is_auxiliary =
-      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
-  collector_->AddEvent(std::move(event), is_auxiliary);
-}
-
-void RocmApiCallbackImpl::AddSynchronizeEventUponApiExit(
-    uint32_t cbid, const hip_api_data_t* data, uint64_t enter_time,
-    uint64_t exit_time) {
-  // TODO(rocm-profiler): neither CUDA and nor we capture annotaint for this
-  // event
-  /*
-    misses: context_id
-
-    extras: domain,
-  */
-
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_API;
-  event.type = RocmTracerEventType::Synchronization;
-  event.source = RocmTracerEventSource::ApiCallback;
-  event.name = se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid, 0);
-  event.thread_id = GetCachedTID();
-  event.correlation_id = data->correlation_id;
-  event.start_time_ns = enter_time;
-  event.end_time_ns = exit_time;
-
-  switch (cbid) {
-    case HIP_API_ID_hipStreamSynchronize: {
-      event.synchronization_info.sync_type =
-          RocmTracerSyncTypes::StreamSynchronize;
-      const hipStream_t& stream = data->args.hipStreamSynchronize.stream;
-      event.device_id = hipGetStreamDeviceId(stream);
-    } break;
-    case HIP_API_ID_hipStreamWaitEvent: {
-      event.synchronization_info.sync_type = RocmTracerSyncTypes::StreamWait;
-      const hipStream_t& stream = data->args.hipStreamWaitEvent.stream;
-      event.device_id = hipGetStreamDeviceId(stream);
-    } break;
-    default:
-      LOG(WARNING)
-          << "Unsupported Synchronization API for profiling observed for cbid="
-          << cbid << ". Event dropped!";
-      return;
-      break;
-  }
-  bool is_auxiliary =
-      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
-  collector_->AddEvent(std::move(event), is_auxiliary);
-}
-
-absl::Status RocmActivityCallbackImpl::operator()(const char* begin,
-                                                  const char* end) {
-  // we do not dump activities in this set in logger
-
-  static std::set<activity_op_t> dump_excluded_activities = {
-      HIP_API_ID_hipGetDevice,
-      HIP_API_ID_hipSetDevice,
-      HIP_API_ID___hipPushCallConfiguration,
-      HIP_API_ID___hipPopCallConfiguration,
-      HIP_API_ID_hipEventQuery,
-      HIP_API_ID_hipCtxSetCurrent,
-      HIP_API_ID_hipEventRecord,
-      HIP_API_ID_hipEventQuery,
-      HIP_API_ID_hipGetDeviceProperties,
-      HIP_API_ID_hipPeekAtLastError,
-      HIP_API_ID_hipModuleGetFunction,
-      HIP_API_ID_hipEventCreateWithFlags};
-
-  const roctracer_record_t* record =
-      reinterpret_cast<const roctracer_record_t*>(begin);
-  const roctracer_record_t* end_record =
-      reinterpret_cast<const roctracer_record_t*>(end);
-
-  while (record < end_record) {
-    // DumpActivityRecord(record);
-
-    switch (record->domain) {
-      // HIP API activities.
-      case ACTIVITY_DOMAIN_HIP_API:
-        switch (record->op) {
-          case HIP_API_ID_hipModuleLaunchKernel:
-          case HIP_API_ID_hipExtModuleLaunchKernel:
-          case HIP_API_ID_hipHccModuleLaunchKernel:
-          case HIP_API_ID_hipLaunchKernel:
-          case HIP_API_ID_hipExtLaunchKernel:
-            DumpActivityRecord(record, std::to_string(__LINE__));
-            AddHipKernelActivityEvent(record);
-            break;
-          case HIP_API_ID_hipMemcpyDtoH:
-          case HIP_API_ID_hipMemcpyHtoD:
-          case HIP_API_ID_hipMemcpyDtoD:
-          case HIP_API_ID_hipMemcpyDtoHAsync:
-          case HIP_API_ID_hipMemcpyHtoDAsync:
-          case HIP_API_ID_hipMemcpyDtoDAsync:
-          case HIP_API_ID_hipMemcpyAsync:
-          case HIP_API_ID_hipMemcpy:
-            DumpActivityRecord(record, std::to_string(__LINE__));
-            AddNormalHipMemcpyActivityEvent(record);
-            break;
-          case HIP_API_ID_hipMemset:
-          case HIP_API_ID_hipMemsetAsync:
-          case HIP_API_ID_hipMemsetD32:
-          case HIP_API_ID_hipMemsetD32Async:
-          case HIP_API_ID_hipMemsetD16:
-          case HIP_API_ID_hipMemsetD16Async:
-          case HIP_API_ID_hipMemsetD8:
-          case HIP_API_ID_hipMemsetD8Async:
-            DumpActivityRecord(record, std::to_string(__LINE__));
-            AddHipMemsetActivityEvent(record);
-            break;
-
-          case HIP_API_ID_hipMalloc:
-          case HIP_API_ID_hipMallocPitch:
-          case HIP_API_ID_hipHostMalloc:
-          case HIP_API_ID_hipFree:
-          case HIP_API_ID_hipHostFree:
-            DumpActivityRecord(record, std::to_string(__LINE__));
-            AddHipMallocActivityEvent(record);
-            break;
-          case HIP_API_ID_hipStreamSynchronize:
-          case HIP_API_ID_hipStreamWaitEvent:
-            // case HIP_API_ID_hipStreamWaitEvent:
-            DumpActivityRecord(record, std::to_string(__LINE__));
-            AddHipStreamSynchronizeActivityEvent(record);
-            break;
-
-          default:
-            if (dump_excluded_activities.find(record->op) ==
-                dump_excluded_activities.end()) {
-              std::string drop_message(
-                  "\nNot in the API tracked activities. Dropped!");
-              DumpActivityRecord(record, drop_message);
-            }
-            break;
-        }  // switch (record->op).
-        break;
-
-      // HCC ops activities.
-      case ACTIVITY_DOMAIN_HIP_OPS:
-
-        switch (record->op) {
-          case HIP_OP_ID_DISPATCH:
-            DumpActivityRecord(record, std::to_string(__LINE__));
-            AddHccKernelActivityEvent(record);
-            tracer_->RemoveFromPendingActivityRecords(record->correlation_id);
-            break;
-          case HIP_OP_ID_COPY:
-            switch (record->kind) {
-              // TODO(rocm-profiler): use enum instead.
-              case 4595:   /*CopyDeviceToHost*/
-              case 4596:   /*CopyDeviceToDevice*/
-              case 4597: { /*CopyHostToDevice*/
-                /*MEMCPY*/
-                // roctracer returns CopyHostToDevice for hipMemcpyDtoD API
-                //  Please look at the issue #53 in roctracer GitHub repo.
-                DumpActivityRecord(record, "");
-                AddNormalHipOpsMemcpyActivityEvent(record);
-                tracer_->RemoveFromPendingActivityRecords(
-                    record->correlation_id);
-              } break;
-              case 4615: /*FillBuffer*/
-                /*MEMSET*/
-                DumpActivityRecord(record, "");
-                AddHipOpsMemsetActivityEvent(record);
-                break;
-              case 4606: /*MARKER*/
-                // making the log shorter.
-                // markers are with 0ns duration.
-                break;
-              default:
-                std::string drop_message(
-                    "\nNot in the HIP-OPS-COPY tracked activities. Dropeed!");
-                DumpActivityRecord(record, drop_message);
-                break;
-            }  // switch (record->kind)
-            break;
-          default:
-            std::string drop_message(
-                "\nNot in the HIP-OPS tracked activities. Dropped!");
-            DumpActivityRecord(record, drop_message);
-            break;
-        }  // switch (record->op).
-        break;
-      default:
-        std::string drop_message(
-            "\nNot in the tracked domain activities. Dropped!");
-        DumpActivityRecord(record, drop_message);
-        break;
-    }
-
-    RETURN_IF_ROCTRACER_ERROR(static_cast<roctracer_status_t>(
-#if TF_ROCM_VERSION >= 50300
-        se::wrap::roctracer_next_record(record, &record)
-#else
-        roctracer_next_record(record, &record)
-#endif
-            ));
-  }
-
-  return tsl::OkStatus();
-}
-
-void RocmActivityCallbackImpl::AddHipKernelActivityEvent(
-    const roctracer_record_t* record) {
-  /*
-  missing:
-   name, device_id(got from hcc), context_id, stream_id(got from hcc),
- nvtx_range, kernel_info
-
-  extra:
-   domain
- activity record contains process/thread ID
- */
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_API;
-  event.type = RocmTracerEventType::Kernel;
-  event.source = RocmTracerEventSource::Activity;
-  // event.name =  /* we use the API name instead*/
-  //    se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
-  event.correlation_id = record->correlation_id;
-  // TODO(rocm-profiler): CUDA uses device id and correlation ID for finding
-  // annotations.
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
-
-  event.start_time_ns = record->begin_ns;
-  event.end_time_ns = record->end_ns;
-
-  collector_->AddEvent(std::move(event), false);
-}
-
-void RocmActivityCallbackImpl::AddNormalHipMemcpyActivityEvent(
-    const roctracer_record_t* record) {
-  /*
-  ---------------NormalMemcpy-------------------
-    misses:context_id, memcpy_info.kind, memcpy_info.srckind,
-  memcpy_info.dstkind, memcpy_info.num_bytes, memcpy_info.destenation,
-  device_id, stream_id,
-
-    extras: domain
-  ---------------PeerMemcpy---------------------
-    misses: device_id, context_id, stream_id, memcpy_info.kind,
-      memcpy_info.num_bytes, memcpy_info.destination,
-    extras:
-      domain,
-  */
-
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_API;
-  event.source = RocmTracerEventSource::Activity;
-  event.start_time_ns = record->begin_ns;
-  event.end_time_ns = record->end_ns;
-  event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
-  // TODO(roc-profiler): record->bytes is not a valid value
-  // event.memcpy_info.num_bytes = record->bytes;
-  event.name =
-      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
-  switch (record->op) {
-    case HIP_API_ID_hipMemcpyDtoH:
-    case HIP_API_ID_hipMemcpyDtoHAsync:
-      event.type = RocmTracerEventType::MemcpyD2H;
-      event.memcpy_info.async =
-          (record->op == HIP_API_ID_hipMemcpyDtoHAsync) ? true : false;
-      break;
-    case HIP_API_ID_hipMemcpyHtoD:
-    case HIP_API_ID_hipMemcpyHtoDAsync:
-      event.type = RocmTracerEventType::MemcpyH2D;
-      event.memcpy_info.async =
-          (record->op == HIP_API_ID_hipMemcpyHtoDAsync) ? true : false;
-      break;
-    case HIP_API_ID_hipMemcpyDtoD:
-    case HIP_API_ID_hipMemcpyDtoDAsync:
-      event.type = RocmTracerEventType::MemcpyD2D;
-      event.memcpy_info.async =
-          (record->op == HIP_API_ID_hipMemcpyDtoDAsync) ? true : false;
-      break;
-    case HIP_API_ID_hipMemcpy:
-    case HIP_API_ID_hipMemcpyAsync:
-      event.type = RocmTracerEventType::MemcpyOther;
-      event.memcpy_info.async =
-          (record->op == HIP_API_ID_hipMemcpyAsync) ? true : false;
-      break;
-    case HIP_API_ID_hipMemcpyPeer:
-    case HIP_API_ID_hipMemcpyPeerAsync:
-      event.type = RocmTracerEventType::MemcpyP2P;
-      event.memcpy_info.async =
-          (record->op == HIP_API_ID_hipMemcpyPeerAsync) ? true : false;
-      break;
-    default:
-      LOG(WARNING) << "Unsupported Memcpy/MemcpyPeer activity for profiling "
-                      "observed for cbid="
-                   << record->op << ". Event dropped!";
-      return;
-      break;
-  }
-
-  collector_->AddEvent(std::move(event), false);
-}
-
-void RocmActivityCallbackImpl::AddHipMemsetActivityEvent(
-    const roctracer_record_t* record) {
-  /*
-    misses:
-      device_id, context_id, stram_id, memset_info.num_bytes
-      memset_info.kind
-
-    extras:
-      domain, annotation
-  */
-
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_API;
-  event.source = RocmTracerEventSource::Activity;
-  event.name =
-      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
-  event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
-
-  event.type = RocmTracerEventType::Memset;
-
-  switch (record->op) {
-    case HIP_API_ID_hipMemset:
-      event.memset_info.async = false;
-      break;
-    case HIP_API_ID_hipMemsetAsync:
-      event.memset_info.async = true;
-      break;
-    case HIP_API_ID_hipMemsetD8:
-      event.memset_info.async = false;
-      break;
-    case HIP_API_ID_hipMemsetD8Async:
-      event.memset_info.async = true;
-      break;
-    case HIP_API_ID_hipMemsetD16:
-      event.memset_info.async = false;
-      break;
-    case HIP_API_ID_hipMemsetD16Async:
-      event.memset_info.async = true;
-      break;
-    case HIP_API_ID_hipMemsetD32:
-      event.memset_info.async = false;
-      break;
-    case HIP_API_ID_hipMemsetD32Async:
-      event.memset_info.async = true;
-      break;
-  }
-
-  event.start_time_ns = record->begin_ns;
-  event.end_time_ns = record->end_ns;
-
-  collector_->AddEvent(std::move(event), false);
-}
-
-void RocmActivityCallbackImpl::AddHipMallocActivityEvent(
-    const roctracer_record_t* record) {
-  /*
-    misses: device_id, context_id, memory_residency_info (num_byts, kind,
-    address)
-
-    extras:
-      annotation, domain,
-  */
-
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_API;
-  event.type = RocmTracerEventType::MemoryAlloc;
-  event.source = RocmTracerEventSource::Activity;
-  event.name =
-      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
-  event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
-  // similar to CUDA we set this to the default stream
-  event.stream_id = 0;
-  event.start_time_ns = record->begin_ns;
-  // making sure it does not have 0ns duration. Otherwise, it may not show up in
-  // the trace view
-  event.end_time_ns = std::max(record->end_ns, record->begin_ns + 1);
-
-  collector_->AddEvent(std::move(event), false);
-}
-
-void RocmActivityCallbackImpl::AddHipStreamSynchronizeActivityEvent(
-    const roctracer_record_t* record) {
-  /*
-  misses: context_id, device_id (cuda also does not provide but we can get from
-  API-CB)
-
-  extras: domain, synchronization_info.sync_type, annotation
-  */
-
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_API;
-  event.type = RocmTracerEventType::Synchronization;
-  event.source = RocmTracerEventSource::Activity;
-  event.name =
-      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
-  event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
-  event.start_time_ns = record->begin_ns;
-
-  // making sure it does not have 0ns duration. Otherwise, it may not show up in
-  // the trace view
-  event.end_time_ns = std::max(record->end_ns, record->begin_ns + 1);
-
-  switch (record->op) {
-    case HIP_API_ID_hipStreamSynchronize:
-      event.synchronization_info.sync_type =
-          RocmTracerSyncTypes::StreamSynchronize;
-      break;
-    case HIP_API_ID_hipStreamWaitEvent:
-      event.synchronization_info.sync_type = RocmTracerSyncTypes::StreamWait;
-      break;
-    default:
-      event.synchronization_info.sync_type = RocmTracerSyncTypes::InvalidSync;
-      break;
-  }
-  collector_->AddEvent(std::move(event), false);
-}
-
-// TODO(rocm-profiler): rename this function. this is HIP-OP
-void RocmActivityCallbackImpl::AddHccKernelActivityEvent(
-    const roctracer_record_t* record) {
-  /*
-   missing:
-     name, context_id, nvtx_range, kernel_info
-
-   extra:
-     domain (thread id from the HIP activity)
-
-   activity record contains device/stream ID
- */
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_OPS;
-  event.type = RocmTracerEventType::Kernel;
-  event.source = RocmTracerEventSource::Activity;
-  event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
-  event.start_time_ns = record->begin_ns;
-  event.end_time_ns = record->end_ns;
-  event.device_id = record->device_id;
-  event.stream_id = record->queue_id;
-
-  collector_->AddEvent(std::move(event), false);
-}
-
-void RocmActivityCallbackImpl::AddNormalHipOpsMemcpyActivityEvent(
-    const roctracer_record_t* record) {
-  /*
-    misses:
-      type, name(the name set here is not clear enough but we keep it for
-    debug), context_id, memcpy_info.kind, memcpy_info.num_bytes,
-    memcpy_info.async, memcpy_info.src_mem_kind, memcpy_info.dst_mem_kind
-
-    extras:
-      domain,
-
-  */
-
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_OPS;
-  event.source = RocmTracerEventSource::Activity;
-  event.name =  // name is stored for debug
-      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
-  event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
-
-  event.start_time_ns = record->begin_ns;
-  event.end_time_ns = record->end_ns;
-  event.device_id = record->device_id;
-  event.memcpy_info.destination = event.device_id;
-  event.stream_id = record->queue_id;
-
-  // we set the type as MemcpyOther as HIP-OPS activity record does not carry
-  // this information
-  event.type = RocmTracerEventType::MemcpyOther;
-
-  collector_->AddEvent(std::move(event), false);
-}
-
-void RocmActivityCallbackImpl::AddHipOpsMemsetActivityEvent(
-    const roctracer_record_t* record) {
-  /*
-    misses:
-      name (name recorder here is not clear enough for Memset. We only capture
-    it for debug), context_id, memset_info.kind, memset_info.num_bytes,
-    memset_info.async
-
-    extras:
-      dommain, annotation,
-
-  */
-
-  RocmTracerEvent event;
-  event.domain = RocmTracerEventDomain::HIP_OPS;
-  event.source = RocmTracerEventSource::Activity;
-  event.name =  // name is stored for debug
-      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
-  event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
-
-  event.start_time_ns = record->begin_ns;
-  event.end_time_ns = record->end_ns;
-  event.device_id = record->device_id;
-  event.stream_id = record->queue_id;
-
-  event.type = RocmTracerEventType::Memset;
-
-  collector_->AddEvent(std::move(event), false);
-}
-
-/* static */ RocmTracer* RocmTracer::GetRocmTracerSingleton() {
-  static auto* singleton = new RocmTracer();
-  return singleton;
-}
-
-// FIXME(rocm-profiler): we should also check if we have AMD GPUs
-bool RocmTracer::IsAvailable() const {
-  return !activity_tracing_enabled_ && !api_tracing_enabled_;  // &&NumGpus()
-}
-
-int RocmTracer::NumGpus() {
-  static int num_gpus = []() -> int {
-    if (hipInit(0) != hipSuccess) {
-      return 0;
-    }
-    int gpu_count;
-    if (hipGetDeviceCount(&gpu_count) != hipSuccess) {
-      return 0;
-    }
-    LOG(INFO) << "Profiler found " << gpu_count << " GPUs";
-    return gpu_count;
-  }();
-  return num_gpus;
-}
-
-void RocmTracer::Enable(const RocmTracerOptions& options,
-                        RocmTraceCollector* collector) {
-  options_ = options;
-  collector_ = collector;
-  static std::once_flag configure_once;
-  std::call_once(configure_once, rocprofiler_force_configure, &rocprofiler_configure,
-                 "force configuration");
-  api_cb_impl_ = new RocmApiCallbackImpl(options, this, collector);
-  activity_cb_impl_ = new RocmActivityCallbackImpl(options, this, collector);
-
-  // From ROCm 3.5 onwards, the following call is required.
-  // don't quite know what it does (no documentation!), only that without it
-  // the call to enable api/activity tracing will run into a segfault
-  se::wrap::roctracer_set_properties(ACTIVITY_DOMAIN_HIP_API, nullptr);
-
-  EnableApiTracing().IgnoreError();
-  EnableActivityTracing().IgnoreError();
-  LOG(INFO) << "GpuTracer started";
-}
-
-void RocmTracer::Disable() {
-  // TODO(rocm-profiler): TF has a SyncAndFlush() function
-  // to be called before disabling. It makes sure all the contexts
-  // has finished all the tasks before shutting down the profiler
-  DisableApiTracing().IgnoreError();
-  DisableActivityTracing().IgnoreError();
-  delete api_cb_impl_;
-  delete activity_cb_impl_;
-  collector_->Flush();
-  collector_ = nullptr;
-  options_.reset();
-  LOG(INFO) << "GpuTracer stopped";
-}
-
-void ApiCallback(uint32_t domain, uint32_t cbid, const void* cbdata,
-                 void* user_data) {
-  RocmTracer* tracer = reinterpret_cast<RocmTracer*>(user_data);
-  tracer->ApiCallbackHandler(domain, cbid, cbdata).IgnoreError();
-}
-
-absl::Status RocmTracer::ApiCallbackHandler(uint32_t domain, uint32_t cbid,
-                                            const void* cbdata) {
-  if (api_tracing_enabled_)
-    TF_RETURN_IF_ERROR((*api_cb_impl_)(domain, cbid, cbdata));
-  return tsl::OkStatus();
-}
-
-absl::Status RocmTracer::EnableApiTracing() {
-  if (api_tracing_enabled_) return tsl::OkStatus();
-  api_tracing_enabled_ = true;
-
-  for (auto& iter : options_->api_callbacks) {
-    activity_domain_t domain = iter.first;
-    std::vector<uint32_t>& ops = iter.second;
-    if (ops.size() == 0) {
-      VLOG(3) << "Enabling API tracing for domain "
-              << GetActivityDomainName(domain);
-      RETURN_IF_ROCTRACER_ERROR(se::wrap::roctracer_enable_domain_callback(
-          domain, ApiCallback, this));
-    } else {
-      VLOG(3) << "Enabling API tracing for " << ops.size() << " ops in domain "
-              << GetActivityDomainName(domain);
-      for (auto& op : ops) {
-        VLOG(3) << "Enabling API tracing for "
-                << GetActivityDomainOpName(domain, op);
-        RETURN_IF_ROCTRACER_ERROR(se::wrap::roctracer_enable_op_callback(
-            domain, op, ApiCallback, this));
-      }
-    }
-  }
-  return tsl::OkStatus();
-}
-
-absl::Status RocmTracer::DisableApiTracing() {
-  if (!api_tracing_enabled_) return tsl::OkStatus();
-  api_tracing_enabled_ = false;
-
-  for (auto& iter : options_->api_callbacks) {
-    activity_domain_t domain = iter.first;
-    std::vector<uint32_t>& ops = iter.second;
-    if (ops.size() == 0) {
-      VLOG(3) << "Disabling API tracing for domain "
-              << GetActivityDomainName(domain);
-      RETURN_IF_ROCTRACER_ERROR(
-          se::wrap::roctracer_disable_domain_callback(domain));
-    } else {
-      VLOG(3) << "Disabling API tracing for " << ops.size() << " ops in domain "
-              << GetActivityDomainName(domain);
-      for (auto& op : ops) {
-        VLOG(3) << "Disabling API tracing for "
-                << GetActivityDomainOpName(domain, op);
-        RETURN_IF_ROCTRACER_ERROR(
-            se::wrap::roctracer_disable_op_callback(domain, op));
-      }
-    }
-  }
-  return tsl::OkStatus();
-}
-
-void ActivityCallback(const char* begin, const char* end, void* user_data) {
-  RocmTracer* tracer = reinterpret_cast<RocmTracer*>(user_data);
-  tracer->ActivityCallbackHandler(begin, end).IgnoreError();
-}
-
-absl::Status RocmTracer::ActivityCallbackHandler(const char* begin,
-                                                 const char* end) {
-  if (activity_tracing_enabled_) {
-    TF_RETURN_IF_ERROR((*activity_cb_impl_)(begin, end));
-  } else {
-    LOG(WARNING) << "ActivityCallbackHandler called when "
-                    "activity_tracing_enabled_ is false";
-
-    VLOG(3) << "Dropped Activity Records Start";
-    const roctracer_record_t* record =
-        reinterpret_cast<const roctracer_record_t*>(begin);
-    const roctracer_record_t* end_record =
-        reinterpret_cast<const roctracer_record_t*>(end);
-    while (record < end_record) {
-      DumpActivityRecord(record,
-                         "activity_tracing_enabled_ is false. Dropped!");
-#if TF_ROCM_VERSION >= 50300
-      RETURN_IF_ROCTRACER_ERROR(static_cast<roctracer_status_t>(
-          se::wrap::roctracer_next_record(record, &record)));
-#else
-      RETURN_IF_ROCTRACER_ERROR(static_cast<roctracer_status_t>(
-          roctracer_next_record(record, &record)));
-#endif
-    }
-    VLOG(3) << "Dropped Activity Records End";
-  }
-  return tsl::OkStatus();
-}
-
-absl::Status RocmTracer::EnableActivityTracing() {
-  if (activity_tracing_enabled_) return tsl::OkStatus();
-  activity_tracing_enabled_ = true;
-
-  if (!options_->activity_tracing.empty()) {
-    // Create the memory pool to store activity records in
-    if (se::wrap::roctracer_default_pool_expl(nullptr) == NULL) {
-      roctracer_properties_t properties{};
-      properties.buffer_size = 0x1000;
-      properties.buffer_callback_fun = ActivityCallback;
-      properties.buffer_callback_arg = this;
-      VLOG(3) << "Creating roctracer activity buffer: buff-size="
-              << properties.buffer_size;
-      RETURN_IF_ROCTRACER_ERROR(
-          se::wrap::roctracer_open_pool_expl(&properties, nullptr));
-    }
-  }
-
-  for (auto& iter : options_->activity_tracing) {
-    activity_domain_t domain = iter.first;
-    std::vector<uint32_t>& ops = iter.second;
-    if (ops.size() == 0) {
-      VLOG(3) << "Enabling Activity tracing for domain "
-              << GetActivityDomainName(domain);
-      RETURN_IF_ROCTRACER_ERROR(
-          se::wrap::roctracer_enable_domain_activity_expl(domain, nullptr));
-    } else {
-      VLOG(3) << "Enabling Activity tracing for " << ops.size()
-              << " ops in domain " << GetActivityDomainName(domain);
-      for (auto& op : ops) {
-        VLOG(3) << "Enabling Activity tracing for "
-                << GetActivityDomainOpName(domain, op);
-        // roctracer library has not exported "roctracer_enable_op_activity"
-        RETURN_IF_ROCTRACER_ERROR(
-            se::wrap::roctracer_enable_op_activity_expl(domain, op, nullptr));
-      }
-    }
-  }
-
-  return tsl::OkStatus();
-}
-
-absl::Status RocmTracer::DisableActivityTracing() {
-  if (!activity_tracing_enabled_) return tsl::OkStatus();
-
-  for (auto& iter : options_->activity_tracing) {
-    activity_domain_t domain = iter.first;
-    std::vector<uint32_t>& ops = iter.second;
-    if (ops.size() == 0) {
-      VLOG(3) << "Disabling Activity tracing for domain "
-              << GetActivityDomainName(domain);
-      RETURN_IF_ROCTRACER_ERROR(
-          se::wrap::roctracer_disable_domain_activity(domain));
-    } else {
-      VLOG(3) << "Disabling Activity tracing for " << ops.size()
-              << " ops in domain " << GetActivityDomainName(domain);
-      for (auto& op : ops) {
-        VLOG(3) << "Disabling Activity tracing for "
-                << GetActivityDomainOpName(domain, op);
-        RETURN_IF_ROCTRACER_ERROR(
-            se::wrap::roctracer_disable_op_activity(domain, op));
-      }
-    }
-  }
-
-  // TODO(rocm-profiler): this stopping mechanism needs improvement.
-  // Flush the activity buffer BEFORE setting the activity_tracing_enable_
-  // flag to FALSE. This is because the activity record callback routine is
-  // gated by the same flag
-  VLOG(3) << "Flushing roctracer activity buffer";
-  RETURN_IF_ROCTRACER_ERROR(se::wrap::roctracer_flush_activity_expl(nullptr));
-  // roctracer_flush_buf();
-
-  // Explicitly wait for (almost) all pending activity records
-  // The choice of all of the following is based what seemed to work
-  // best when enabling tracing on a large testcase (BERT)
-  // * 100 ms as the initial sleep duration AND
-  // * 1 as the initial threshold value
-  // * 6 as the maximum number of iterations
-  int duration_ms = 100;
-  size_t threshold = 1;
-  for (int i = 0; i < 6; i++, duration_ms *= 2, threshold *= 2) {
-    if (GetPendingActivityRecordsCount() < threshold) break;
-    VLOG(3) << "Wait for pending activity records :" << " Pending count = "
-            << GetPendingActivityRecordsCount()
-            << ", Threshold = " << threshold;
-    VLOG(3) << "Wait for pending activity records : sleep for " << duration_ms
-            << " ms";
-    tsl::profiler::SleepForMillis(duration_ms);
-  }
-  ClearPendingActivityRecordsCount();
-
-  activity_tracing_enabled_ = false;
-
-  return tsl::OkStatus();
-}
-
-/*static*/ uint64_t RocmTracer::GetTimestamp() {
-  uint64_t ts;
-  if (se::wrap::roctracer_get_timestamp(&ts) != ROCTRACER_STATUS_SUCCESS) {
-    const char* errstr = se::wrap::roctracer_error_string();
-    LOG(ERROR) << "function roctracer_get_timestamp failed with error "
-               << errstr;
-    // Return 0 on error.
-    return 0;
-  }
-  return ts;
+void
+stop()
+{
+    ROCPROFILER_CALL(rocprofiler_stop_context(client_ctx), "context stop");
 }
 
 }  // namespace profiler
@@ -1627,7 +587,7 @@ rocprofiler_configure(uint32_t                 version,
     id->name = "XLA";
 
     // store client info
-    client::client_id = id;
+    xla::profiler::client_id = id;
 
     // compute major/minor/patch version info
     uint32_t major = version / 10000;
@@ -1641,10 +601,10 @@ rocprofiler_configure(uint32_t                 version,
 
     std::clog << info.str() << std::endl;
 
-    auto* client_tool_data = new std::vector<client::source_location>{};
+    auto* client_tool_data = new std::vector<xla::profiler::source_location>{};
 
     client_tool_data->emplace_back(
-        client::source_location{__FUNCTION__, __FILE__, __LINE__, info.str()});
+        xla::common::source_location{__FUNCTION__, __FILE__, __LINE__, info.str()});
 
     ROCPROFILER_CALL(rocprofiler_at_internal_thread_create(
                          xla::profiler::thread_precreate,

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -502,7 +502,7 @@ int tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
     constexpr auto buffer_size_bytes      = 4096;
     constexpr auto buffer_watermark_bytes = buffer_size_bytes - (buffer_size_bytes / 8);
 
-    /*
+    
     ROCPROFILER_CALL(se::wrap::rocprofiler_create_buffer(client_ctx,
                                                buffer_size_bytes,
                                                buffer_watermark_bytes,
@@ -511,7 +511,7 @@ int tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
                                                tool_data,
                                                &client_buffer),
                      "buffer creation");
-    */
+    
     for(auto itr :
         {ROCPROFILER_BUFFER_TRACING_HSA_CORE_API, ROCPROFILER_BUFFER_TRACING_HSA_AMD_EXT_API})
     {
@@ -624,6 +624,15 @@ stop()
     ROCPROFILER_CALL(se::wrap::rocprofiler_stop_context(client_ctx), "context stop");
 }
 
+/* static */ RocmTracer* RocmTracer::GetRocmTracerSingleton() {
+  static auto* singleton = new RocmTracer();
+  return singleton;
+}
+
+bool RocmTracer::IsAvailable() const {
+  return true;  // &&NumGpus()
+}
+
 }  // namespace profiler
 }  // namespace xla
 
@@ -638,7 +647,7 @@ rocprofiler_configure(uint32_t                 version,
 
     // store client info
     xla::profiler::client_id = id;
-    std::cout << "Configure rocprofv3...\n" <<std::flush;
+    LOG(ERROR) << "Configure rocprofv3...\n";
 
     // compute major/minor/patch version info
     uint32_t major = version / 10000;

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -635,10 +635,10 @@ rocprofiler_configure(uint32_t                 version,
 {
     // set the client name
     id->name = "XLA-with-rocprofv3";
-    std::cout << "Configure XLA with rocprofv3!\n";
 
     // store client info
     xla::profiler::client_id = id;
+    std::cout << "Configure rocprofv3...\n" <<std::flush;
 
     // compute major/minor/patch version info
     uint32_t major = version / 10000;
@@ -647,7 +647,7 @@ rocprofiler_configure(uint32_t                 version,
 
     // generate info string
     auto info = std::stringstream{};
-    info << id->name << " (priority=" << priority << ") is using rocprofiler-sdk v" << major << "."
+    info << id->name << "Configure XLA with rocprofv3... (priority=" << priority << ") is using rocprofiler-sdk v" << major << "."
          << minor << "." << patch << " (" << runtime_version << ")";
 
     std::clog << info.str() << std::endl;

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -71,10 +71,10 @@ public:
 
 protected:
   // protected constructor for injecting mock cupti interface for testing.
-  explicit RocmTracer() : num_gpus_(NumGpus()) {}
+  explicit RocmTracer();
 
 private:
-    bool is_available_; // availability status
+    // bool is_available_; // availability status
     int num_gpus_; 
     std::optional<RocmTracerOptions> options_;
     RocmTraceCollector* collector_ = nullptr;

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -41,6 +41,8 @@ limitations under the License.
 namespace xla {
 namespace profiler {
 
+// std::vector<RocmTracerEvent> all_rocm_events_1;
+
 struct RocmTracerOptions {
   std::set<uint32_t> api_tracking_set;  // actual api set we want to profile
 
@@ -65,6 +67,8 @@ public:
     static int NumGpus();
     void Enable(RocmTraceCollector* collector);
     RocmTraceCollector* get_collector() { return collector_; }
+    void AppendEvent(RocmTracerEvent event) { rocm_events_.push_back(event); }
+    RocmTracerEvent_t GetEvents() {return rocm_events_;}
 
     void setup() CLIENT_API;
     void start() CLIENT_API;
@@ -80,6 +84,7 @@ private:
     int num_gpus_; 
     // std::optional<RocmTracerOptions> options_;
     RocmTraceCollector* collector_ = nullptr;
+    RocmTracerEvent_t rocm_events_;
     static tsl::mutex mtx;
 
 public:

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -27,6 +27,8 @@ limitations under the License.
 #include "tsl/platform/status.h"
 #include "tsl/platform/types.h"
 
+#include <mutex>
+
 #include "xla/stream_executor/rocm/roctracer_wrapper.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 
@@ -61,7 +63,7 @@ public:
 
     static uint64_t GetTimestamp();
     static int NumGpus();
-    void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector);
+    void Enable(RocmTraceCollector* collector);
     RocmTraceCollector* get_collector() { return collector_; }
 
     void setup() CLIENT_API;
@@ -76,8 +78,9 @@ protected:
 private:
     // bool is_available_; // availability status
     int num_gpus_; 
-    std::optional<RocmTracerOptions> options_;
+    // std::optional<RocmTracerOptions> options_;
     RocmTraceCollector* collector_ = nullptr;
+    static tsl::mutex mtx;
 
 public:
   // Disable copy and move.

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -58,35 +58,31 @@ public:
 
     // Only one profile session can be live in the same time.
     bool IsAvailable() const;
-    // void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector);
 
-    // static uint64_t GetTimestamp();
-    // static int NumGpus();
+    static uint64_t GetTimestamp();
+    static int NumGpus();
+    void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector);
+    RocmTraceCollector* get_collector() { return collector_; }
 
     void setup() CLIENT_API;
     void start() CLIENT_API;
     void stop() CLIENT_API;
     void shutdown() CLIENT_API;
 
+protected:
+  // protected constructor for injecting mock cupti interface for testing.
+  explicit RocmTracer() : num_gpus_(NumGpus()) {}
+
 private:
-    // Private constructor for singleton
-    RocmTracer() : is_available_(true) {
-        LOG(INFO) << "RocmTracer initialized...";
-    }
-
-    // Private destructor
-    ~RocmTracer() {
-        LOG(INFO) << "RocmTracer destroyed...";
-    }
-
     bool is_available_; // availability status
-    // int num_gpus_; 
-    // std::optional<RocmTracerOptions> options_;
-    // RocmTraceCollector* collector_ = nullptr;
+    int num_gpus_; 
+    std::optional<RocmTracerOptions> options_;
+    RocmTraceCollector* collector_ = nullptr;
 
-    // Disable copy constructor and assignment operator
-    RocmTracer(const RocmTracer&) = delete;
-    RocmTracer& operator=(const RocmTracer&) = delete;
+public:
+  // Disable copy and move.
+  RocmTracer(const RocmTracer&) = delete;
+  RocmTracer& operator=(const RocmTracer&) = delete;
 };  // end of RocmTracer
 
 }  // end of namespace profiler

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -58,10 +58,10 @@ public:
 
     // Only one profile session can be live in the same time.
     bool IsAvailable() const;
-    void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector);
+    // void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector);
 
-    static uint64_t GetTimestamp();
-    static int NumGpus();
+    // static uint64_t GetTimestamp();
+    // static int NumGpus();
 
     void setup() CLIENT_API;
     void start() CLIENT_API;
@@ -70,7 +70,7 @@ public:
 
 private:
     // Private constructor for singleton
-    RocmTracer() : is_available_(true), num_gpus_(NumGpus()) {
+    RocmTracer() : is_available_(true) {
         LOG(INFO) << "RocmTracer initialized...";
     }
 
@@ -80,9 +80,9 @@ private:
     }
 
     bool is_available_; // availability status
-    int num_gpus_; 
-    std::optional<RocmTracerOptions> options_;
-    RocmTraceCollector* collector_ = nullptr;
+    // int num_gpus_; 
+    // std::optional<RocmTracerOptions> options_;
+    // RocmTraceCollector* collector_ = nullptr;
 
     // Disable copy constructor and assignment operator
     RocmTracer(const RocmTracer&) = delete;

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -63,12 +63,10 @@ public:
     static uint64_t GetTimestamp();
     static int NumGpus();
 
-
     void setup() CLIENT_API;
     void start() CLIENT_API;
     void stop() CLIENT_API;
     void shutdown() CLIENT_API;
-    void identify(uint64_t corr_id) CLIENT_API;
 
 private:
     // Private constructor for singleton

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -53,6 +53,98 @@ stop() CLIENT_API;
 
 void
 identify(uint64_t corr_id) CLIENT_API;
+
+class RocmTracer {
+public:
+    // Constructor
+    RocmTracer() {
+        std::cout << "RocmTracer initialized." << std::endl;
+    }
+
+    // Destructor
+    ~RocmTracer() {
+        std::cout << "RocmTracer destroyed." << std::endl;
+    }
+};
+
+class RocmTracer {
+public:
+    // Get the singleton instance of RocmTracer
+    static RocmTracer& GetRocmTracerSingleton() {
+        static RocmTracer instance;
+        return instance;
+    }
+
+    // Check if the tracer is available
+    bool IsAvailable() const {
+        // Simulate a check for tracer availability
+        return is_available_;
+    }
+
+    // Start tracing a specific operation
+    void StartTracing(const std::string& operation_name) {
+        if (IsAvailable()) {
+            std::cout << "Started tracing operation: " << operation_name << std::endl;
+        } else {
+            std::cout << "RocmTracer is not available." << std::endl;
+        }
+    }
+
+    // Stop tracing the current operation
+    void StopTracing(const std::string& operation_name) {
+        if (IsAvailable()) {
+            std::cout << "Stopped tracing operation: " << operation_name << std::endl;
+        } else {
+            std::cout << "RocmTracer is not available." << std::endl;
+        }
+    }
+
+    // Collect and print trace data
+    void CollectTraceData() {
+        if (IsAvailable()) {
+            std::cout << "Collecting trace data..." << std::endl;
+            // Simulate trace data collection
+            std::cout << "Trace data: [Dummy data]" << std::endl;
+        } else {
+            std::cout << "RocmTracer is not available." << std::endl;
+        }
+    }
+
+    // Dummy method to simulate tracer events
+    void LogEvent(const std::string& event_name) {
+        if (IsAvailable()) {
+            std::cout << "Logging event: " << event_name << std::endl;
+        } else {
+            std::cout << "RocmTracer is not available." << std::endl;
+        }
+    }
+
+    // Dummy method to clear trace data
+    void ClearTraceData() {
+        if (IsAvailable()) {
+            std::cout << "Clearing trace data." << std::endl;
+        } else {
+            std::cout << "RocmTracer is not available." << std::endl;
+        }
+    }
+
+private:
+    // Private constructor for singleton
+    RocmTracer() : is_available_(true) {
+        std::cout << "RocmTracer initialized." << std::endl;
+    }
+
+    // Private destructor
+    ~RocmTracer() {
+        std::cout << "RocmTracer destroyed." << std::endl;
+    }
+
+    // Disable copy constructor and assignment operator
+    RocmTracer(const RocmTracer&) = delete;
+    RocmTracer& operator=(const RocmTracer&) = delete;
+
+    bool is_available_; // Simulated availability status
+};
 }  // namespace profiler
 }  // namespace xla
 

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -21,193 +21,39 @@ limitations under the License.
 #include "absl/container/flat_hash_set.h"
 #include "absl/container/node_hash_set.h"
 #include "absl/types/optional.h"
-#include "xla/backends/profiler/gpu/rocm_collector.h"
-#include "xla/stream_executor/rocm/roctracer_wrapper.h"
+
 #include "tsl/platform/errors.h"
 #include "tsl/platform/macros.h"
 #include "tsl/platform/status.h"
 #include "tsl/platform/types.h"
 
+#include "xla/stream_executor/rocm/roctracer_wrapper.h"
+
+#ifdef buffered_api_tracing_client_EXPORTS
+#    define CLIENT_API __attribute__((visibility("default")))
+#else
+#    define CLIENT_API
+#endif
+
+#include <cstdint>
+
 namespace xla {
 namespace profiler {
+void
+setup() CLIENT_API;
 
-enum class RocmTracerSyncTypes {
-  InvalidSync = 0,
-  StreamSynchronize,  // caller thread wait stream to become empty
-  EventSynchronize,   // caller thread will block until event happens
-  StreamWait          // compute stream will wait for event to happen
-};
+void
+shutdown() CLIENT_API;
 
-struct RocmTracerOptions {
-  std::set<uint32_t> api_tracking_set;  // actual api set we want to profile
+void
+start() CLIENT_API;
 
-  // map of domain --> ops for which we need to enable the API callbacks
-  // If the ops vector is empty, then enable API callbacks for entire domain
-  absl::flat_hash_map<activity_domain_t, std::vector<uint32_t> > api_callbacks;
+void
+stop() CLIENT_API;
 
-  // map of domain --> ops for which we need to enable the Activity records
-  // If the ops vector is empty, then enable Activity records for entire domain
-  absl::flat_hash_map<activity_domain_t, std::vector<uint32_t> >
-      activity_tracing;
-};
-
-class RocmTracer;
-
-class RocmApiCallbackImpl {
- public:
-  RocmApiCallbackImpl(const RocmTracerOptions& options, RocmTracer* tracer,
-                      RocmTraceCollector* collector)
-      : options_(options), tracer_(tracer), collector_(collector) {}
-
-  absl::Status operator()(uint32_t domain, uint32_t cbid, const void* cbdata);
-
- private:
-  void AddKernelEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
-                                 uint64_t enter_time, uint64_t exit_time);
-  void AddNormalMemcpyEventUponApiExit(uint32_t cbid,
-                                       const hip_api_data_t* data,
-                                       uint64_t enter_time, uint64_t exit_time);
-  void AddMemcpyPeerEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
-                                     uint64_t enter_time, uint64_t exit_time);
-  void AddMemsetEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
-                                 uint64_t enter_time, uint64_t exit_time);
-  void AddMallocFreeEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
-                                     uint32_t device_id, uint64_t enter_time,
-                                     uint64_t exit_time);
-  void AddStreamSynchronizeEventUponApiExit(uint32_t cbid,
-                                            const hip_api_data_t* data,
-                                            uint64_t enter_time,
-                                            uint64_t exit_time);
-  void AddSynchronizeEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
-                                      uint64_t enter_time, uint64_t exit_time);
-
-  RocmTracerOptions options_;
-  RocmTracer* tracer_ = nullptr;
-  RocmTraceCollector* collector_ = nullptr;
-  tsl::mutex api_call_start_mutex_;
-  // TODO(rocm-profiler): replace this with absl hashmap
-  // keep a map from the corr. id to enter time for API callbacks.
-  std::map<uint32_t, uint64_t> api_call_start_time_
-      TF_GUARDED_BY(api_call_start_mutex_);
-};
-
-class RocmActivityCallbackImpl {
- public:
-  RocmActivityCallbackImpl(const RocmTracerOptions& options, RocmTracer* tracer,
-                           RocmTraceCollector* collector)
-      : options_(options), tracer_(tracer), collector_(collector) {}
-
-  absl::Status operator()(const char* begin, const char* end);
-
- private:
-  void AddHipKernelActivityEvent(const roctracer_record_t* record);
-  void AddNormalHipMemcpyActivityEvent(const roctracer_record_t* record);
-  void AddHipMemsetActivityEvent(const roctracer_record_t* record);
-  void AddHipMallocActivityEvent(const roctracer_record_t* record);
-  void AddHipStreamSynchronizeActivityEvent(const roctracer_record_t* record);
-  void AddHccKernelActivityEvent(const roctracer_record_t* record);
-  void AddNormalHipOpsMemcpyActivityEvent(const roctracer_record_t* record);
-  void AddHipOpsMemsetActivityEvent(const roctracer_record_t* record);
-  RocmTracerOptions options_;
-  RocmTracer* tracer_ = nullptr;
-  RocmTraceCollector* collector_ = nullptr;
-};
-
-// The class uses roctracer callback/activity API and forward the collected
-// trace events to RocmTraceCollector. There should be only one RocmTracer
-// per process.
-class RocmTracer {
- public:
-  // Returns a pointer to singleton RocmTracer.
-  static RocmTracer* GetRocmTracerSingleton();
-
-  // Only one profile session can be live in the same time.
-  bool IsAvailable() const;
-
-  void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector);
-  void Disable();
-
-  absl::Status ApiCallbackHandler(uint32_t domain, uint32_t cbid,
-                                  const void* cbdata);
-  absl::Status ActivityCallbackHandler(const char* begin, const char* end);
-
-  static uint64_t GetTimestamp();
-  static int NumGpus();
-
-  void AddToPendingActivityRecords(uint32_t correlation_id) {
-    pending_activity_records_.Add(correlation_id);
-  }
-
-  void RemoveFromPendingActivityRecords(uint32_t correlation_id) {
-    pending_activity_records_.Remove(correlation_id);
-  }
-
-  void ClearPendingActivityRecordsCount() { pending_activity_records_.Clear(); }
-
-  size_t GetPendingActivityRecordsCount() {
-    return pending_activity_records_.Count();
-  }
-
- protected:
-  // protected constructor for injecting mock cupti interface for testing.
-  explicit RocmTracer() : num_gpus_(NumGpus()) {}
-
- private:
-  absl::Status EnableApiTracing();
-  absl::Status DisableApiTracing();
-
-  absl::Status EnableActivityTracing();
-  absl::Status DisableActivityTracing();
-
-  int num_gpus_;
-  std::optional<RocmTracerOptions> options_;
-  RocmTraceCollector* collector_ = nullptr;
-
-  bool api_tracing_enabled_ = false;
-  bool activity_tracing_enabled_ = false;
-
-  RocmApiCallbackImpl* api_cb_impl_;
-  RocmActivityCallbackImpl* activity_cb_impl_;
-
-  class PendingActivityRecords {
-   public:
-    // add a correlation id to the pending set
-    void Add(uint32_t correlation_id) {
-      absl::MutexLock lock(&mutex);
-      pending_set.insert(correlation_id);
-    }
-    // remove a correlation id from the pending set
-    void Remove(uint32_t correlation_id) {
-      absl::MutexLock lock(&mutex);
-      pending_set.erase(correlation_id);
-    }
-    // clear the pending set
-    void Clear() {
-      absl::MutexLock lock(&mutex);
-      pending_set.clear();
-    }
-    // count the number of correlation ids in the pending set
-    size_t Count() {
-      absl::MutexLock lock(&mutex);
-      return pending_set.size();
-    }
-
-   private:
-    // set of co-relation ids for which the hcc activity record is pending
-    absl::flat_hash_set<uint32_t> pending_set;
-    // the callback which processes the activity records (and consequently
-    // removes items from the pending set) is called in a separate thread
-    // from the one that adds item to the list.
-    absl::Mutex mutex;
-  };
-  PendingActivityRecords pending_activity_records_;
-
- public:
-  // Disable copy and move.
-  RocmTracer(const RocmTracer&) = delete;
-  RocmTracer& operator=(const RocmTracer&) = delete;
-};
-
+void
+identify(uint64_t corr_id) CLIENT_API;
 }  // namespace profiler
 }  // namespace xla
+
 #endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -39,21 +39,6 @@ limitations under the License.
 
 namespace xla {
 namespace profiler {
-void
-setup() CLIENT_API;
-
-void
-shutdown() CLIENT_API;
-
-void
-start() CLIENT_API;
-
-void
-stop() CLIENT_API;
-
-void
-identify(uint64_t corr_id) CLIENT_API;
-
 
 class RocmTracer {
 public:
@@ -63,71 +48,30 @@ public:
     // Only one profile session can be live in the same time.
     bool IsAvailable() const;
 
-    // Start tracing a specific operation
-    void StartTracing(const std::string& operation_name) {
-        if (IsAvailable()) {
-            std::cout << "Started tracing operation: " << operation_name << std::endl;
-        } else {
-            std::cout << "RocmTracer is not available." << std::endl;
-        }
-    }
-
-    // Stop tracing the current operation
-    void StopTracing(const std::string& operation_name) {
-        if (IsAvailable()) {
-            std::cout << "Stopped tracing operation: " << operation_name << std::endl;
-        } else {
-            std::cout << "RocmTracer is not available." << std::endl;
-        }
-    }
-
-    // Collect and print trace data
-    void CollectTraceData() {
-        if (IsAvailable()) {
-            std::cout << "Collecting trace data..." << std::endl;
-            // Simulate trace data collection
-            std::cout << "Trace data: [Dummy data]" << std::endl;
-        } else {
-            std::cout << "RocmTracer is not available." << std::endl;
-        }
-    }
-
-    // Dummy method to simulate tracer events
-    void LogEvent(const std::string& event_name) {
-        if (IsAvailable()) {
-            std::cout << "Logging event: " << event_name << std::endl;
-        } else {
-            std::cout << "RocmTracer is not available." << std::endl;
-        }
-    }
-
-    // Dummy method to clear trace data
-    void ClearTraceData() {
-        if (IsAvailable()) {
-            std::cout << "Clearing trace data." << std::endl;
-        } else {
-            std::cout << "RocmTracer is not available." << std::endl;
-        }
-    }
+    void setup() CLIENT_API;
+    void shutdown() CLIENT_API;
+    void start() CLIENT_API;
+    void stop() CLIENT_API;
+    void identify(uint64_t corr_id) CLIENT_API;
 
 private:
     // Private constructor for singleton
     RocmTracer() : is_available_(true) {
-        LOG(ERROR) << "RocmTracer initialized...";
+        LOG(INFO) << "RocmTracer initialized...";
     }
 
     // Private destructor
     ~RocmTracer() {
-        std::cout << "RocmTracer destroyed..." << std::endl;
+        LOG(INFO) << "RocmTracer destroyed...";
     }
 
     // Disable copy constructor and assignment operator
     RocmTracer(const RocmTracer&) = delete;
     RocmTracer& operator=(const RocmTracer&) = delete;
     bool is_available_; // Simulated availability status
-};
+};  // end of RocmTracer
 
-}  // namespace profiler
-}  // namespace xla
+}  // end of namespace profiler
+}  // end of namespace xla
 
 #endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -58,9 +58,11 @@ public:
 
     // Only one profile session can be live in the same time.
     bool IsAvailable() const;
+    void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector);
 
     static uint64_t GetTimestamp();
     static int NumGpus();
+
 
     void setup() CLIENT_API;
     void start() CLIENT_API;
@@ -81,6 +83,8 @@ private:
 
     bool is_available_; // availability status
     int num_gpus_; 
+    std::optional<RocmTracerOptions> options_;
+    RocmTraceCollector* collector_ = nullptr;
 
     // Disable copy constructor and assignment operator
     RocmTracer(const RocmTracer&) = delete;

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -35,8 +35,6 @@ limitations under the License.
 #    define CLIENT_API
 #endif
 
-#include <cstdint>
-
 namespace xla {
 namespace profiler {
 
@@ -49,9 +47,9 @@ public:
     bool IsAvailable() const;
 
     void setup() CLIENT_API;
-    void shutdown() CLIENT_API;
     void start() CLIENT_API;
     void stop() CLIENT_API;
+    void shutdown() CLIENT_API;
     void identify(uint64_t corr_id) CLIENT_API;
 
 private:

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -54,32 +54,14 @@ stop() CLIENT_API;
 void
 identify(uint64_t corr_id) CLIENT_API;
 
-class RocmTracer {
-public:
-    // Constructor
-    RocmTracer() {
-        std::cout << "RocmTracer initialized." << std::endl;
-    }
-
-    // Destructor
-    ~RocmTracer() {
-        std::cout << "RocmTracer destroyed." << std::endl;
-    }
-};
 
 class RocmTracer {
 public:
-    // Get the singleton instance of RocmTracer
-    static RocmTracer& GetRocmTracerSingleton() {
-        static RocmTracer instance;
-        return instance;
-    }
+    // Returns a pointer to singleton RocmTracer.
+    static RocmTracer* GetRocmTracerSingleton();
 
-    // Check if the tracer is available
-    bool IsAvailable() const {
-        // Simulate a check for tracer availability
-        return is_available_;
-    }
+    // Only one profile session can be live in the same time.
+    bool IsAvailable() const;
 
     // Start tracing a specific operation
     void StartTracing(const std::string& operation_name) {
@@ -131,20 +113,20 @@ public:
 private:
     // Private constructor for singleton
     RocmTracer() : is_available_(true) {
-        std::cout << "RocmTracer initialized." << std::endl;
+        LOG(ERROR) << "RocmTracer initialized...";
     }
 
     // Private destructor
     ~RocmTracer() {
-        std::cout << "RocmTracer destroyed." << std::endl;
+        std::cout << "RocmTracer destroyed..." << std::endl;
     }
 
     // Disable copy constructor and assignment operator
     RocmTracer(const RocmTracer&) = delete;
     RocmTracer& operator=(const RocmTracer&) = delete;
-
     bool is_available_; // Simulated availability status
 };
+
 }  // namespace profiler
 }  // namespace xla
 

--- a/xla/python/BUILD
+++ b/xla/python/BUILD
@@ -1278,6 +1278,9 @@ tsl_pybind_extension(
         "-fexceptions",
         "-fno-strict-aliasing",
     ],
+    additional_exported_symbols = [
+        "rocprofiler_configure",
+    ],
     defines = if_google(
         [],
         select({

--- a/xla/stream_executor/rocm/roctracer_wrapper.h
+++ b/xla/stream_executor/rocm/roctracer_wrapper.h
@@ -20,14 +20,17 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_ROCM_ROCTRACER_WRAPPER_H_
 #define XLA_STREAM_EXECUTOR_ROCM_ROCTRACER_WRAPPER_H_
 
-#include "rocm/include/roctracer/roctracer.h"
-#include "rocm/include/roctracer/roctracer_hip.h"
-#include "rocm/rocm_config.h"
-#if TF_ROCM_VERSION >= 50300
-#include "rocm/include/roctracer/roctracer_roctx.h"
-#else
-#include "rocm/include/roctracer/roctracer_hcc.h"
-#endif
+#include <rocm/include/rocprofiler-sdk/buffer.h>
+#include <rocm/include/rocprofiler-sdk/buffer_tracing.h>
+#include <rocm/include/rocprofiler-sdk/callback_tracing.h>
+#include <rocm/include/rocprofiler-sdk/external_correlation.h>
+#include <romc/include/rocprofiler-sdk/fwd.h>
+#include <rocm/include/rocprofiler-sdk/internal_threading.h>
+#include <rocm/include/rocprofiler-sdk/registration.h>
+#include <rocm/include/rocprofiler-sdk/rocprofiler.h>
+#include <rocm/include/rocprofiler-sdk/cxx/name_info.hpp>
+#include <rocm/include/rocprofiler-sdk/hip.h>
+
 #include "xla/stream_executor/platform/dso_loader.h"
 #include "xla/stream_executor/platform/port.h"
 #include "tsl/platform/env.h"
@@ -66,42 +69,22 @@ namespace wrap {
 
 #endif  // PLATFORM_GOOGLE
 
-#if TF_ROCM_VERSION >= 50300
-#define FOREACH_ROCTRACER_API(DO_FUNC)           \
-  DO_FUNC(roctracer_default_pool_expl)           \
-  DO_FUNC(roctracer_disable_domain_activity)     \
-  DO_FUNC(roctracer_disable_domain_callback)     \
-  DO_FUNC(roctracer_disable_op_activity)         \
-  DO_FUNC(roctracer_disable_op_callback)         \
-  DO_FUNC(roctracer_enable_domain_activity_expl) \
-  DO_FUNC(roctracer_enable_domain_callback)      \
-  DO_FUNC(roctracer_enable_op_activity_expl)     \
-  DO_FUNC(roctracer_enable_op_callback)          \
-  DO_FUNC(roctracer_error_string)                \
-  DO_FUNC(roctracer_flush_activity_expl)         \
-  DO_FUNC(roctracer_get_timestamp)               \
-  DO_FUNC(roctracer_op_string)                   \
-  DO_FUNC(roctracer_open_pool_expl)              \
-  DO_FUNC(roctracer_set_properties)              \
-  DO_FUNC(roctracer_next_record)
+// only support which latest version ?
+#if TF_ROCM_VERSION >= 50700
+#define FOREACH_ROCTRACER_API(DO_FUNC)                     \
+  DO_FUNC(rocprofiler_force_configure)                     \
+  DO_FUNC(rocprofiler_at_internal_thread_create)           \
+  DO_FUNC(rocprofiler_create_buffer)                       \
+  DO_FUNC(rocprofiler_flush_buffer)                        \
+  DO_FUNC(rocprofiler_get_status_string)                   \
+  DO_FUNC(rocprofiler_create_context)                      \
+  DO_FUNC(rocprofiler_context_is_valid)                    \
+  DO_FUNC(rocprofiler_start_context)                       \
+  DO_FUNC(rocprofiler_configure_callback_tracing_service)  \
+  DO_FUNC(rocprofiler_configure_callback_thread)           \
+  DO_FUNC(rocprofiler_asign_callback_thread)              
 #else
-#define FOREACH_ROCTRACER_API(DO_FUNC)           \
-  DO_FUNC(roctracer_default_pool_expl)           \
-  DO_FUNC(roctracer_disable_domain_activity)     \
-  DO_FUNC(roctracer_disable_domain_callback)     \
-  DO_FUNC(roctracer_disable_op_activity)         \
-  DO_FUNC(roctracer_disable_op_callback)         \
-  DO_FUNC(roctracer_enable_domain_activity_expl) \
-  DO_FUNC(roctracer_enable_domain_callback)      \
-  DO_FUNC(roctracer_enable_op_activity_expl)     \
-  DO_FUNC(roctracer_enable_op_callback)          \
-  DO_FUNC(roctracer_error_string)                \
-  DO_FUNC(roctracer_flush_activity_expl)         \
-  DO_FUNC(roctracer_get_timestamp)               \
-  DO_FUNC(roctracer_op_string)                   \
-  DO_FUNC(roctracer_open_pool_expl)              \
-  DO_FUNC(roctracer_set_properties)
-#endif
+
 FOREACH_ROCTRACER_API(ROCTRACER_API_WRAPPER)
 
 #undef FOREACH_ROCTRACER_API

--- a/xla/stream_executor/rocm/roctracer_wrapper.h
+++ b/xla/stream_executor/rocm/roctracer_wrapper.h
@@ -20,16 +20,20 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_ROCM_ROCTRACER_WRAPPER_H_
 #define XLA_STREAM_EXECUTOR_ROCM_ROCTRACER_WRAPPER_H_
 
+#ifndef TF_ROCM_VERSION
+#define TF_ROCM_VERSION 500000  // Default value if not defined
+#endif
+
 #include <rocm/include/rocprofiler-sdk/buffer.h>
 #include <rocm/include/rocprofiler-sdk/buffer_tracing.h>
 #include <rocm/include/rocprofiler-sdk/callback_tracing.h>
 #include <rocm/include/rocprofiler-sdk/external_correlation.h>
-#include <romc/include/rocprofiler-sdk/fwd.h>
+#include <rocm/include/rocprofiler-sdk/fwd.h>
 #include <rocm/include/rocprofiler-sdk/internal_threading.h>
 #include <rocm/include/rocprofiler-sdk/registration.h>
 #include <rocm/include/rocprofiler-sdk/rocprofiler.h>
 #include <rocm/include/rocprofiler-sdk/cxx/name_info.hpp>
-#include <rocm/include/rocprofiler-sdk/hip.h>
+// #include <rocm/include/rocprofiler-sdk/hip.h>
 
 #include "xla/stream_executor/platform/dso_loader.h"
 #include "xla/stream_executor/platform/port.h"
@@ -70,11 +74,14 @@ namespace wrap {
 #endif  // PLATFORM_GOOGLE
 
 // only support which latest version ?
-#if TF_ROCM_VERSION >= 50700
+/*
+#if TF_ROCM_VERSION >= 507000
 #define FOREACH_ROCTRACER_API(DO_FUNC)                     \
   DO_FUNC(rocprofiler_force_configure)                     \
   DO_FUNC(rocprofiler_at_internal_thread_create)           \
   DO_FUNC(rocprofiler_create_buffer)                       \
+  DO_FUNC(rocprofiler_get_buffer_tracing_names)            \
+  DO_FUNC(rocprofiler_get_callback_tracing_names)          \
   DO_FUNC(rocprofiler_flush_buffer)                        \
   DO_FUNC(rocprofiler_get_status_string)                   \
   DO_FUNC(rocprofiler_create_context)                      \
@@ -82,10 +89,21 @@ namespace wrap {
   DO_FUNC(rocprofiler_start_context)                       \
   DO_FUNC(rocprofiler_configure_callback_tracing_service)  \
   DO_FUNC(rocprofiler_configure_callback_thread)           \
-  DO_FUNC(rocprofiler_asign_callback_thread)              
-#else
-
+  DO_FUNC(rocprofiler_asign_callback_thread)               \
+  DO_FUNC(rocprofiler_get_timestamp)                       
+#endif
 FOREACH_ROCTRACER_API(ROCTRACER_API_WRAPPER)
+*/
+ROCTRACER_API_WRAPPER(rocprofiler_force_configure)
+ROCTRACER_API_WRAPPER(rocprofiler_create_context)
+ROCTRACER_API_WRAPPER(rocprofiler_configure_callback_tracing_service)
+ROCTRACER_API_WRAPPER(rocprofiler_create_buffer)
+ROCTRACER_API_WRAPPER(rocprofiler_flush_buffer)
+ROCTRACER_API_WRAPPER(rocprofiler_configure_buffer_tracing_service)
+ROCTRACER_API_WRAPPER(rocprofiler_get_thread_id)
+// ROCTRACER_API_WRAPPER(rocprofiler_get_timestamp)
+
+
 
 #undef FOREACH_ROCTRACER_API
 #undef ROCTRACER_API_WRAPPER

--- a/xla/stream_executor/rocm/roctracer_wrapper.h
+++ b/xla/stream_executor/rocm/roctracer_wrapper.h
@@ -135,6 +135,7 @@ ROCTRACER_API_WRAPPER(rocprofiler_query_buffer_tracing_kind_operation_name)
 ROCTRACER_API_WRAPPER(rocprofiler_iterate_buffer_tracing_kind_operations)
 ROCTRACER_API_WRAPPER(rocprofiler_iterate_buffer_tracing_kinds)
 ROCTRACER_API_WRAPPER(rocprofiler_get_status_string)
+ROCTRACER_API_WRAPPER(rocprofiler_configure)
 
 
 #undef FOREACH_ROCTRACER_API

--- a/xla/stream_executor/rocm/roctracer_wrapper.h
+++ b/xla/stream_executor/rocm/roctracer_wrapper.h
@@ -136,6 +136,7 @@ ROCTRACER_API_WRAPPER(rocprofiler_iterate_buffer_tracing_kind_operations)
 ROCTRACER_API_WRAPPER(rocprofiler_iterate_buffer_tracing_kinds)
 ROCTRACER_API_WRAPPER(rocprofiler_get_status_string)
 ROCTRACER_API_WRAPPER(rocprofiler_configure)
+ROCTRACER_API_WRAPPER(rocprofiler_get_timestamp)
 
 
 #undef FOREACH_ROCTRACER_API

--- a/xla/stream_executor/rocm/roctracer_wrapper.h
+++ b/xla/stream_executor/rocm/roctracer_wrapper.h
@@ -21,7 +21,7 @@ limitations under the License.
 #define XLA_STREAM_EXECUTOR_ROCM_ROCTRACER_WRAPPER_H_
 
 #ifndef TF_ROCM_VERSION
-#define TF_ROCM_VERSION 500000  // Default value if not defined
+#define TF_ROCM_VERSION 600000  // Default value if not defined
 #endif
 
 #include <rocm/include/rocprofiler-sdk/buffer.h>
@@ -31,18 +31,8 @@ limitations under the License.
 #include <rocm/include/rocprofiler-sdk/fwd.h>
 #include <rocm/include/rocprofiler-sdk/internal_threading.h>
 #include <rocm/include/rocprofiler-sdk/registration.h>
-#include <rocm/include/rocprofiler-sdk/rocprofiler.h>
 #include <rocm/include/rocprofiler-sdk/cxx/name_info.hpp>
-// #include <rocm/include/rocprofiler-sdk/hip.h>
-
 #include <rocm/include/rocprofiler-sdk/rocprofiler.h>
-#include <rocm/include/rocprofiler-sdk/buffer.h>
-#include <rocm/include/rocprofiler-sdk/buffer_tracing.h>
-#include <rocm/include/rocprofiler-sdk/callback_tracing.h>
-#include <rocm/include/rocprofiler-sdk/external_correlation.h>
-#include <rocm/include/rocprofiler-sdk/fwd.h>
-#include <rocm/include/rocprofiler-sdk/internal_threading.h>
-#include <rocm/include/rocprofiler-sdk/registration.h>
 
 
 #include "xla/stream_executor/platform/dso_loader.h"
@@ -124,6 +114,7 @@ namespace wrap {
 #endif
 FOREACH_ROCTRACER_API(ROCTRACER_API_WRAPPER)
 */
+
 ROCTRACER_API_WRAPPER(rocprofiler_force_configure)
 ROCTRACER_API_WRAPPER(rocprofiler_start_context)
 ROCTRACER_API_WRAPPER(rocprofiler_stop_context)
@@ -141,6 +132,9 @@ ROCTRACER_API_WRAPPER(rocprofiler_at_internal_thread_create)
 ROCTRACER_API_WRAPPER(rocprofiler_push_external_correlation_id)
 ROCTRACER_API_WRAPPER(rocprofiler_query_buffer_tracing_kind_name)
 ROCTRACER_API_WRAPPER(rocprofiler_query_buffer_tracing_kind_operation_name)
+ROCTRACER_API_WRAPPER(rocprofiler_iterate_buffer_tracing_kind_operations)
+ROCTRACER_API_WRAPPER(rocprofiler_iterate_buffer_tracing_kinds)
+ROCTRACER_API_WRAPPER(rocprofiler_get_status_string)
 
 
 #undef FOREACH_ROCTRACER_API


### PR DESCRIPTION
WIP:
1. the design of rocprofiler-sdk (v3) is totally different from roctracer (v1 and v2), trying to integrate rocprofiler-sdk into XLA as a backend to profiling JAX and TensorFlow models running with ROCm runtime. 

atm, trying to transferring traced events to XEvent for visualisation. 