### PR TITLE
Fix gpu_hlo_runner_test 

### DIFF
--- a/xla/service/gpu/tests/gpu_hlo_runner_test.cc
+++ b/xla/service/gpu/tests/gpu_hlo_runner_test.cc
@@ -41,7 +41,9 @@ class HloRunnerTest : public GpuCodegenTest {};
 TEST_F(HloRunnerTest, RunSingle) {
 
   std::ifstream ifs("input.hlo");
-  ASSERT_TRUE(ifs.good());
+  if(ifs.fail()) {
+    GTEST_SKIP() << "No input HLO file provided!";
+  }
 
   std::stringstream buffer;
   buffer << ifs.rdbuf();


### PR DESCRIPTION
Error reported here: https://ontrack-internal.amd.com/browse/SWDEV-498584

The test was meant to be manual only, and not run in CI. With this it will be skipped when input is not found.