### PR TITLE
[ROCm] SWDEV-504746 - Fix build error

### DIFF
--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -701,6 +701,8 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
       return GraphNodeType::kMemAlloc;
     case hipGraphNodeTypeMemFree:
       return GraphNodeType::kMemFree;
+    default:
+      return absl::InternalError("Invalid HIP graph node type");
   }
 
   return absl::InternalError("Invalid HIP graph node type");


### PR DESCRIPTION
HIP adds new enum hipGraphNodeTypeBatchMemOp in hipGraphNodeType. The switch case doesn't handle hipGraphNodeTypeBatchMemOp causing build failure in TensorFlow.