### PR TITLE
fixing triton tests

### DIFF
--- a/xla/service/gpu/fusions/triton/triton_fusion_emitter_parametrized_test.cc
+++ b/xla/service/gpu/fusions/triton/triton_fusion_emitter_parametrized_test.cc
@@ -65,19 +65,6 @@ class MixedTypeTest : public GpuCodegenTest,
     }
   }
 
-  se::GpuComputeCapability GetGpuComputeCapability() {
-    return backend()
-        .default_stream_executor()
-        ->GetDeviceDescription()
-        .gpu_compute_capability();
-  }
-
-  void SetUp() override {
-    if (std::holds_alternative<se::RocmComputeCapability>(GetGpuComputeCapability())) {
-      GTEST_SKIP() << "Related fusions are not performed on ROCm without Triton.";
-    }
-  }
-
   DebugOptions GetDebugOptionsForTest() override {
     DebugOptions debug_options = GpuCodegenTest::GetDebugOptionsForTest();
     // We are testing Triton, remove cuBLAS fallback for these tests.

--- a/xla/service/gpu/fusions/triton/triton_support_test.cc
+++ b/xla/service/gpu/fusions/triton/triton_support_test.cc
@@ -437,7 +437,7 @@ ENTRY triton_computation {
                           ParseTemplateAndGetInstruction(kHloTestTemplate, F32,
                                                          HloOpcode::kReduce));
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{3, 4},
-                 se::CudaComputeCapability::Ampere());
+                 AllDevicesToTest()[0]);
 }
 
 TEST_P(
@@ -525,7 +525,7 @@ ENTRY triton_computation {
 }
 
 TEST_F(ReduceTest, ReduceWithNonConstReduceValueIsSupportedWithTriton) {
-  const se::GpuComputeCapability cc = se::CudaComputeCapability::Ampere();
+  const se::GpuComputeCapability cc = AllDevicesToTest()[0];
   const std::string kHloTestTemplate = R"(
 add {
   Arg_0 = $0[] parameter(0)


### PR DESCRIPTION
Fixing triton tests (CudaComputeCapability was passed as a param):
```
[ RUN      ] ReduceTest.IsTritonSupportedReductionWithMultidimensionalTile
2024-12-17 10:59:06.550673: I xla/service/platform_util.cc:81] platform ROCM present but no XLA compiler available: could not find registered compiler for platform ROCM -- was support for that platform linked in?
unknown file: Failure
C++ exception with description "std::get: wrong index for variant" thrown in the test body.
[  FAILED  ] ReduceTest.IsTritonSupportedReductionWithMultidimensionalTile (9 ms)
[ RUN      ] ReduceTest.ReduceWithNonConstReduceValueIsSupportedWithTriton
2024-12-17 10:59:06.560041: I xla/service/platform_util.cc:81] platform ROCM present but no XLA compiler available: could not find registered compiler for platform ROCM -- was support for that platform linked in?
unknown file: Failure
C++ exception with description "std::get: wrong index for variant" thrown in the test body.
[  FAILED  ] ReduceTest.ReduceWithNonConstReduceValueIsSupportedWithTriton (3 ms)
[----------] 2 tests from ReduceTest (12 ms total)
```

Duplicate function definitions in triton_fusion_emitter_parametrized_test.cc