### PR TITLE
PR #17432: [ROCm] Skip Parametric/TestF16/MajorToMinor tests as it re…

### DIFF
--- a/xla/tests/dot_operation_test.cc
+++ b/xla/tests/dot_operation_test.cc
@@ -314,6 +314,7 @@ class ParametricDotTest : public DotOperationTest,
       std::string_view name(
           ::testing::UnitTest::GetInstance()->current_test_info()->name());
       if (name.find("TestF16/270x270x520_MajorToMinor") != std::string::npos) {
+        GTEST_SKIP() << "Not supported on ROCm until Triton is re-enabled.";
         execution_options_.mutable_debug_options()->set_xla_gpu_autotune_level(
             0);
         DotTestParam param = GetParam();


### PR DESCRIPTION
…quires trit…

Imported from GitHub PR https://github.com/openxla/xla/pull/17432

…on gemm

This fails due to cce3b37b6 which disables triton gemm on ROCm. Copybara import of the project:

--
9a47e052bf5707fc12d6d80464755ad0f306e1da by Harsha HS <Harsha.HavanurShamsundara@amd.com>:

[ROCm] Skip Parametric/TestF16/MajorToMinor tests as it requires triton gemm

Merging this change closes #17432

COPYBARA_INTEGRATE_REVIEW=https://github.com/openxla/xla/pull/17432 from ROCm:ci_skip_dot_tests_on_ROCm_20240924 9a47e052bf5707fc12d6d80464755ad0f306e1da PiperOrigin-RevId: 688477932