### PR TITLE
Enable layout asssignment opt

### DIFF
--- a/xla/backends/interpreter/compiler.cc
+++ b/xla/backends/interpreter/compiler.cc
@@ -103,8 +103,11 @@ absl::Status InterpreterCompiler::RunHloOptimization(HloModule* hlo_module) {
       /*rewrite_training_op=*/true,
       /*rewrite_inference_op=*/true,
       /*rewrite_grad_op=*/true);
-  pipeline.AddPass<LayoutAssignment>(
+  const DebugOptions& opts = hlo_module->config().debug_options();
+  if(opts.xla_enable_layout_assignment()) {
+    pipeline.AddPass<LayoutAssignment>(
       hlo_module->mutable_entry_computation_layout());
+  }
 
   return pipeline.Run(hlo_module).status();
 }

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -326,6 +326,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_scatter_determinism_expander(true);
   opts.set_xla_gpu_unsupported_enable_ragged_all_to_all_decomposer(false);
   opts.set_xla_gpu_experimental_pack_dot_operands_along_k_dimension(false);
+  opts.set_xla_enable_layout_assignment(true);
   return opts;
 }
 
@@ -2248,6 +2249,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
               set_xla_gpu_experimental_pack_dot_operands_along_k_dimension),
       debug_options->xla_gpu_experimental_pack_dot_operands_along_k_dimension(),
       "For sub-byte dot operands, layout them along contracting dimensions."));
+  flag_list->push_back(tsl::Flag(
+      "xla_enable_layout_assignment",
+      bool_setter_for(
+          &DebugOptions::set_xla_enable_layout_assignment),
+      debug_options->xla_enable_layout_assignment(),
+      "Enable GpuLayoutAssignment pass"));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/pjrt/interpreter/interpreter_client.cc
+++ b/xla/pjrt/interpreter/interpreter_client.cc
@@ -481,8 +481,11 @@ absl::StatusOr<std::unique_ptr<HloModule>> InterpreterClient::RunHloPasses(
       /*rewrite_training_op=*/true,
       /*rewrite_inference_op=*/true,
       /*rewrite_grad_op=*/true);
-  pipeline.AddPass<LayoutAssignment>(
+  const DebugOptions& opts = hlo_module->config().debug_options();
+  if(opts.xla_enable_layout_assignment()) {
+    pipeline.AddPass<LayoutAssignment>(
       hlo_module->mutable_entry_computation_layout());
+  }
 
   TF_RETURN_IF_ERROR(pipeline.Run(hlo_module.get()).status());
   return hlo_module;

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1020,9 +1020,13 @@ absl::Status RunLayoutAssignmentPasses(
   // be flattened.
   pipeline.AddPass<FlattenCallGraph>();
   ChannelLayoutConstraints layout_constraints;
-  pipeline.AddPass<GpuLayoutAssignment>(
+
+  const DebugOptions& opts = hlo_module->config().debug_options();
+  if(opts.xla_enable_layout_assignment()) {
+    pipeline.AddPass<GpuLayoutAssignment>(
       hlo_module->mutable_entry_computation_layout(), gpu_version, dnn_version,
       device_description, &layout_constraints);
+  }
   // Run SubByteNormalization because GpuLayoutAssignment may modify a
   // Layout's element_size_in_bits field.
   pipeline.AddPass<SubByteNormalization>(

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1119,7 +1119,10 @@ message DebugOptions {
   // For sub-byte dot operands, layout them along contracting dimensions.
   bool xla_gpu_experimental_pack_dot_operands_along_k_dimension = 362;
 
-  // Next id: 363
+  // Enabled GpuLayoutAssignment HLO pass
+  bool xla_enable_layout_assignment = 363;
+
+  // Next id: 364
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION

Added xla flag **xla_enable_layout_assignment** to disable LayoutAssignment optimization pass (useful when running preoptimized HLOs containing bitcast ops)