### PR TITLE
Fix getJaxPluginPaths defalt env paths

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/amdgpu_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/amdgpu_backend.cc
@@ -179,8 +179,8 @@ struct JaxPluginPaths {
 JaxPluginPaths getJaxPluginPaths() {
   JaxPluginPaths paths;
 
-  paths.bitcode_path = std::getenv("JAX_ROCM_PLUGIN_INTERNAL_BITCODE_PATH");
-  paths.lld_path = std::getenv("JAX_ROCM_PLUGIN_INTERNAL_LLD_PATH");
+  paths.bitcode_path = std::getenv("JAX_ROCM_PLUGIN_INTERNAL_BITCODE_PATH") ?: "";
+  paths.lld_path = std::getenv("JAX_ROCM_PLUGIN_INTERNAL_LLD_PATH") ?: "";
 
   return paths;
 }


### PR DESCRIPTION
Fixes defaults paths when we render `bitcode_path` and `ldd_path`.