### PR TITLE
Add ability to use lld and bitcode paths from jax

### DIFF
--- a/third_party/tsl/tsl/platform/default/dso_loader.cc
+++ b/third_party/tsl/tsl/platform/default/dso_loader.cc
@@ -162,37 +162,37 @@ absl::StatusOr<void*> GetRocblasDsoHandle() {
 }
 
 absl::StatusOr<void*> GetMiopenDsoHandle() {
-  return GetDsoHandle("MIOpen", "");
+  return GetDsoHandle("MIOpen", "1");
 }
 
 absl::StatusOr<void*> GetHipfftDsoHandle() {
-  return GetDsoHandle("hipfft", "");
+  return GetDsoHandle("hipfft", "0");
 }
 
 absl::StatusOr<void*> GetRocrandDsoHandle() {
-  return GetDsoHandle("rocrand", "");
+  return GetDsoHandle("rocrand", "1");
 }
 
 absl::StatusOr<void*> GetRocsolverDsoHandle() {
-  return GetDsoHandle("rocsolver", "");
+  return GetDsoHandle("rocsolver", "0");
 }
 
 #if TF_ROCM_VERSION >= 40500
 absl::StatusOr<void*> GetHipsolverDsoHandle() {
-  return GetDsoHandle("hipsolver", "");
+  return GetDsoHandle("hipsolver", "0");
 }
 #endif
 
 absl::StatusOr<void*> GetRoctracerDsoHandle() {
-  return GetDsoHandle("roctracer64", "");
+  return GetDsoHandle("roctracer64", "4");
 }
 
 absl::StatusOr<void*> GetHipsparseDsoHandle() {
-  return GetDsoHandle("hipsparse", "");
+  return GetDsoHandle("hipsparse", "1");
 }
 
 absl::StatusOr<void*> GetHipblasltDsoHandle() {
-  return GetDsoHandle("hipblaslt", "");
+  return GetDsoHandle("hipblaslt", "0");
 }
 
 absl::StatusOr<void*> GetHipDsoHandle() {

--- a/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -805,6 +805,20 @@ void HsacoCache::Add(const std::string& ir, uint64_t hash,
   g_hsacoCache.cache.back().hsaco = hsaco;
 }
 
+struct JaxPluginPaths {
+  std::string bitcode_path;
+  std::string lld_path;
+};
+
+JaxPluginPaths getJaxPluginPaths() {
+  JaxPluginPaths paths;
+
+  paths.bitcode_path = std::getenv("JAX_ROCM_PLUGIN_INTERNAL_BITCODE_PATH") ?: "";
+  paths.lld_path = std::getenv("JAX_ROCM_PLUGIN_INTERNAL_LLD_PATH") ?: "";
+
+  return paths;
+}
+
 // Emits the given module to HSA Code Object. target_machine is an initialized
 // TargetMachine for the AMDGPU target.
 absl::StatusOr<std::vector<uint8_t>> EmitModuleToHsaco(
@@ -871,12 +885,21 @@ absl::StatusOr<std::vector<uint8_t>> EmitModuleToHsaco(
   }
   // Locate lld.
   std::string lld_path;
-  if (std::getenv("LLVM_PATH")) {
-    lld_path = tsl::io::JoinPath(std::getenv("LLVM_PATH"), "bin");
-  } else {
-    lld_path = tsl::io::JoinPath(tsl::RocmRoot(), "llvm/bin");
+  llvm::SmallVector<std::string, 3> lld_paths;
+
+  if (const char* llvm_path = std::getenv("LLVM_PATH")) {
+    lld_paths.push_back(tsl::io::JoinPath(std::getenv("LLVM_PATH"), "bin"));
   }
-  auto lld_program = llvm::sys::findProgramByName("ld.lld", {lld_path});
+  lld_paths.push_back(tsl::io::JoinPath(tsl::RocmRoot(), "llvm/bin"));
+
+  // push LLD path from JAX plugin if set
+  auto jax_paths = getJaxPluginPaths();
+  if (!jax_paths.lld_path.empty()) {
+    lld_paths.push_back(jax_paths.lld_path);
+  }
+
+  auto lld_program = llvm::sys::findProgramByName(
+      "ld.lld", llvm::to_vector_of<llvm::StringRef>(lld_paths));
   if (!lld_program) {
     return xla::Internal("unable to find ld.lld in PATH: %s",
                          lld_program.getError().message());
@@ -1022,11 +1045,12 @@ std::string GetROCDLDir(const DebugOptions& debug_options) {
     potential_rocdl_dirs.push_back(datadir);
   }
   potential_rocdl_dirs.push_back(tsl::RocdlRoot());
+  potential_rocdl_dirs.push_back(getJaxPluginPaths().bitcode_path);
 
   // Tries all potential ROCDL directories in the order they are inserted.
-  // Returns the first directory that exists in the file system.
+  // Returns the first directory that contains opencompute math libs bitcode file (ocml.bc)
   for (const std::string& potential_rocdl_dir : potential_rocdl_dirs) {
-    if (tsl::Env::Default()->IsDirectory(potential_rocdl_dir).ok()) {
+    if (tsl::Env::Default()->FileExists(tsl::io::JoinPath(potential_rocdl_dir, "ocml.bc")).ok()) {
       VLOG(2) << "Found ROCm-Device-Libs dir " << potential_rocdl_dir;
       return potential_rocdl_dir;
     }


### PR DESCRIPTION
Moved auto-discovery of bitcode and lld paths into the jax rocm plugin during load time which then
get passed to the amdgpu_backend via environment variables.

This avoids changing any interfaces or messing with cuda datadir hacks.

(cherry picked from commit fc4dc40ac433f8df905a393b171d2584ccd5be20)