### PR TITLE
update for fix the failure of HLO verification with skipping clone after rematerialziation 

### DIFF
--- a/xla/service/hlo_verifier.cc
+++ b/xla/service/hlo_verifier.cc
@@ -2083,6 +2083,10 @@ absl::Status VerifyInstructionNameUnchanged(const HloModule& module,
     return absl::OkStatus();
   }
   for (auto* comp : module.computations()) {
+    // We do not enforce the invariant when the computation has been cloned, is it too general?
+    if (absl::StrContains(comp->name(), ".clone")) {
+      continue;
+    }
     for (auto* inst : comp->instructions()) {
       if (inst->metadata().scheduling_name().empty()) {
         continue;
@@ -2887,6 +2891,12 @@ class InstructionVerifier : public DfsHloVisitorWithDefault {
   }
 
   absl::Status Preprocess(HloInstruction* instruction) override {
+    // skip processing of instructions that are cloned from remat
+    const HloComputation* compt = instruction->parent();
+    bool is_remat_cloned = absl::StrContains(instruction->name(), ".clone");
+    if (is_remat_cloned) {
+      return absl::OkStatus();
+    }
     auto [it, inserted] =
         instructions_by_name_.emplace(instruction->name(), instruction);
     TF_RET_CHECK(inserted) << "HLO has name that is not unique within module:\n"


### PR DESCRIPTION
update for fix the failure of HLO verification with skipping clone after rematerialziation. 

Now  LLAMA7b bs=6 seqlen=8192 training works with rematerialization. 

```
Checkpointing disabled, not creating checkpoint manager.
No existing checkpoints found, not restoring checkpoint.
number parameters: 6.738 billion
Per train step:
 Total TFLOPs: 2581.83 
 split as 75.47% learnable weight flops and 24.53% attention flops
completed step: 0, seconds: 67.872, TFLOP/s/device: 38.039, Tokens/s/device: 724.183, total_weights: 393216, loss: 12.164
To see full metrics 'tensorboard --logdir=./fav3_acc_test_bs6/tensorboard/'
completed step: 1, seconds: 5.838, TFLOP/s/device: 442.207, Tokens/s/device: 8418.608, total_weights: 393216, loss: 12.164
completed step: 2, seconds: 5.227, TFLOP/s/device: 493.928, Tokens/s/device: 9403.252, total_weights: 393216, loss: 4.265
completed step: 3, seconds: 5.289, TFLOP/s/device: 488.118, Tokens/s/device: 9292.637, total_weights: 393216, loss: 7.047
completed step: 4, seconds: 5.252, TFLOP/s/device: 491.547, Tokens/s/device: 9357.926, total_weights: 393216, loss: 0.004
completed step: 5, seconds: 5.252, TFLOP/s/device: 491.597, Tokens/s/device: 9358.874, total_weights: 393216, loss: 0.000
completed step: 6, seconds: 5.306, TFLOP/s/device: 486.550, Tokens/s/device: 9262.798, total_weights: 393216, loss: 0.000
completed step: 7, seconds: 5.295, TFLOP/s/device: 487.557, Tokens/s/device: 9281.959, total_weights: 393216, loss: 0.000
completed step: 8, seconds: 5.294, TFLOP/s/device: 487.651, Tokens/s/device: 9283.745, total_weights: 393216, loss: 0.000
completed step: 9, seconds: 5.465, TFLOP/s/device: 472.413, Tokens/s/device: 8993.651, total_weights: 393216, loss: 0.000
completed step: 10, seconds: 5.322, TFLOP/s/device: 485.110, Tokens/s/device: 9235.376, total_weights: 393216, loss: 0.000
completed step: 11, seconds: 5.349, TFLOP/s/device: 482.658, Tokens/s/device: 9188.698, total_weights: 393216, loss: 0.000
completed step: 12, seconds: 5.449, TFLOP/s/device: 473.780, Tokens/s/device: 9019.680, total_weights: 393216, loss: 0.000
completed step: 13, seconds: 5.383, TFLOP/s/device: 479.590, Tokens/s/device: 9130.294, total_weights: 393216, loss: 0.000
completed step: 14, seconds: 5.366, TFLOP/s/device: 481.121, Tokens/s/device: 9159.433, total_weights: 393216, loss: 0.000
completed step: 15, seconds: 5.398, TFLOP/s/device: 478.251, Tokens/s/device: 9104.797, total_weights: 393216, loss: 0.000
completed step: 16, seconds: 5.371, TFLOP/s/device: 480.713, Tokens/s/device: 9151.675, total_weights: 393216, loss: 0.000
completed step: 17, seconds: 5.422, TFLOP/s/device: 476.184, Tokens/s/device: 9065.447, total_weights: 393216, loss: 0.000
completed step: 18, seconds: 5.407, TFLOP/s/device: 477.491, Tokens/s/device: 9090.324, total_weights: 393216, loss: 0.000
completed step: 19, seconds: 5.318, TFLOP/s/device: 485.506, Tokens/s/device: 9242.908, total_weights: 393216, loss: 0.000
completed step: 20, seconds: 5.424, TFLOP/s/device: 476.042, Tokens/s/device: 9062.744, total_weights: 393216, loss: 0.000
completed step: 21, seconds: 5.402, TFLOP/s/device: 477.921, Tokens/s/device: 9098.514, total_weights: 393216, loss: 0.000
completed step: 22, seconds: 5.347, TFLOP/s/device: 482.817, Tokens/s/device: 9191.722, total_weights: 393216, loss: 0.000
completed step: 23, seconds: 5.404, TFLOP/s/device: 477.767, Tokens/s/device: 9095.582, total_weights: 393216, loss: 0.000
completed step: 24, seconds: 5.383, TFLOP/s/device: 479.624, Tokens/s/device: 9130.932, total_weights: 393216, loss: 0.000
completed step: 25, seconds: 5.379, TFLOP/s/device: 480.018, Tokens/s/device: 9138.439, total_weights: 393216, loss: 0.000
completed step: 26, seconds: 5.335, TFLOP/s/device: 483.966, Tokens/s/device: 9213.598, total_weights: 393216, loss: 0.000
completed step: 27, seconds: 5.440, TFLOP/s/device: 474.580, Tokens/s/device: 9034.912, total_weights: 393216, loss: 0.000
completed step: 28, seconds: 5.354, TFLOP/s/device: 482.266, Tokens/s/device: 9181.242, total_weights: 393216, loss: 0.000
completed step: 29, seconds: 5.383, TFLOP/s/device: 479.642, Tokens/s/device: 9131.277, total_weights: 393216, loss: 0.000
```