### PR TITLE
[ROCm] Use kernel cache per stream executor for redzone checker

### DIFF
--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -355,14 +355,20 @@ gpu_only_cc_library(
 )
 
 gpu_kernel_library(
-    name = "redzone_allocator_kernel",
+    name = "redzone_allocator_kernel_rocm",
     srcs = [
-        "redzone_allocator_kernel.cu.cc",
+        "redzone_allocator_kernel.h",
+        "redzone_allocator_kernel_rocm.cu.cc",
     ],
-    tags = ["gpu"],
-    deps = if_cuda_is_configured([
-        "@local_config_cuda//cuda:cuda_headers",
-    ]) + if_rocm_is_configured([
+    tags = ["manual"],
+    deps = [
+        ":gpu_asm_opts",
+        "//xla/stream_executor:device_memory",
+        "//xla/stream_executor:kernel",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor:typed_kernel_factory",
+        "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/status:statusor",
         "@local_config_rocm//rocm:rocm_headers",
         "@local_config_rocm//rocm:rocm_config",
     ]),

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -370,7 +370,7 @@ gpu_kernel_library(
         "@com_google_absl//absl/container:node_hash_map",
         "@com_google_absl//absl/status:statusor",
         "@local_config_rocm//rocm:rocm_headers",
-        "@local_config_rocm//rocm:rocm_config",
+        "@local_config_rocm//rocm:rocm_config"
     ],
 )
 

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -371,7 +371,7 @@ gpu_kernel_library(
         "@com_google_absl//absl/status:statusor",
         "@local_config_rocm//rocm:rocm_headers",
         "@local_config_rocm//rocm:rocm_config",
-    ]),
+    ],
 )
 
 gpu_only_cc_library(

--- a/xla/stream_executor/gpu/redzone_allocator_kernel.cu.cc
+++ b/xla/stream_executor/gpu/redzone_allocator_kernel.cu.cc
@@ -15,7 +15,15 @@ limitations under the License.
 
 #include <cstdint>
 
-namespace stream_executor::redzone_checker_kernel {
+#include "absl/container/node_hash_map.h"
+#include "absl/status/statusor.h"
+#include "xla/stream_executor/device_memory.h"
+#include "xla/stream_executor/gpu/redzone_allocator_kernel.h"
+#include "xla/stream_executor/kernel.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/typed_kernel_factory.h"
+#include "tsl/platform/statusor.h"
+
 
 namespace {
 __global__ void kernel_func(uint8_t* input_buffer,
@@ -28,6 +36,39 @@ __global__ void kernel_func(uint8_t* input_buffer,
 }
 }  // namespace
 
-void* kernel() { return reinterpret_cast<void*>(kernel_func); }
 
-}  // namespace stream_executor::redzone_checker_kernel
+namespace stream_executor {
+template <typename... Args>
+static absl::StatusOr<TypedKernel<Args...>*> LoadKernelOrGetPtr(
+    StreamExecutor* executor, absl::string_view kernel_name, void *kernel_ptr) {
+  using KernelPtrCacheKey =
+      std::tuple<StreamExecutor*, absl::string_view, void *>;
+
+  static absl::Mutex kernel_ptr_cache_mutex(absl::kConstInit);
+  static auto& kernel_ptr_cache ABSL_GUARDED_BY(kernel_ptr_cache_mutex) =
+      *new absl::node_hash_map<KernelPtrCacheKey, TypedKernel<Args...>>();
+  KernelPtrCacheKey kernel_ptr_cache_key{executor, kernel_name, kernel_ptr};
+  absl::MutexLock lock(&kernel_ptr_cache_mutex);
+
+  auto it = kernel_ptr_cache.find(kernel_ptr_cache_key);
+  if (it == kernel_ptr_cache.end()) {
+    TF_ASSIGN_OR_RETURN(TypedKernel<Args...> loaded,
+                        (TypedKernelFactory<Args...>::Create(
+                            executor, kernel_name, kernel_ptr)));
+    it =
+        kernel_ptr_cache.emplace(kernel_ptr_cache_key, std::move(loaded)).first;
+  }
+
+  CHECK(it != kernel_ptr_cache.end());
+  return &it->second;
+}
+
+absl::StatusOr<ComparisonKernel*> GetComparisonKernel(
+    StreamExecutor* executor, GpuAsmOpts /*gpu_asm_opts*/) {
+
+  return LoadKernelOrGetPtr<DeviceMemory<uint8_t>, uint8_t, uint64_t,
+                            DeviceMemory<uint64_t>>(
+      executor, "redzone_checker", reinterpret_cast<void*>(redzone_checker_kernel));
+}
+
+}  // namespace stream_executor


### PR DESCRIPTION
cherry-picked from https://github.com/openxla/xla/pull/23494