### PR TITLE
[ROCm] Check for shared memory resource during triton fusion emitter

### DIFF
--- a/xla/backends/gpu/codegen/triton/fusion_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/fusion_emitter.cc
@@ -1316,8 +1316,7 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
   const int shared_mem_bytes =
       triton_module->getAttrOfType<mlir::IntegerAttr>("ttg.shared").getInt();
   VLOG(2) << "Shared memory usage: " << shared_mem_bytes << " B";
-  if (std::holds_alternative<se::CudaComputeCapability>(cc) &&
-      shared_mem_bytes > device_info.shared_memory_per_block_optin()) {
+  if (shared_mem_bytes > device_info.shared_memory_per_block_optin()) {
     return absl::ResourceExhaustedError(absl::StrFormat(
         "Shared memory size limit exceeded: requested %d, available: %d",
         shared_mem_bytes, device_info.shared_memory_per_block_optin()));

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -1032,6 +1032,7 @@ RocmExecutor::CreateDeviceDescription(int device_ordinal) {
 
   desc.set_shared_memory_per_core(GetMaxSharedMemoryPerCore(device).value());
   desc.set_shared_memory_per_block(GetMaxSharedMemoryPerBlock(device).value());
+  desc.set_shared_memory_per_block_optin(GetMaxSharedMemoryPerBlock(device).value());
   int core_count = GetMultiprocessorCount(device).value();
   desc.set_core_count(core_count);
   desc.set_fpus_per_core(fpus_per_core(gcn_arch_name));

--- a/xla/tools/hlo_opt/gpu_specs/mi200.txtpb
+++ b/xla/tools/hlo_opt/gpu_specs/mi200.txtpb
@@ -16,6 +16,7 @@ gpu_device_info {
   threads_per_block_limit: 1024
   threads_per_warp: 64
   shared_memory_per_block: 65536
+  shared_memory_per_block_optin: 65536
   shared_memory_per_core: 65536
   threads_per_core_limit: 2048
   core_count: 110


### PR DESCRIPTION
Port fix from upstream: https://github.com/openxla/xla/pull/24578