### PR TITLE
Set warp_size to 64.

### DIFF
--- a/xla/backends/gpu/codegen/triton/xla_triton_passes.td
+++ b/xla/backends/gpu/codegen/triton/xla_triton_passes.td
@@ -23,7 +23,7 @@ def SparseAddEncodingPass : Pass<"sparse-add-encoding", "mlir::ModuleOp"> {
   let options = [
     Option<"num_warps_", "num-warps", "int32_t", /*default=*/"4",
            "Number of warps">,
-    Option<"threads_per_warp_", "threads-per-warp", "int32_t", /*default=*/"32",
+    Option<"threads_per_warp_", "threads-per-warp", "int32_t", /*default=*/"64",
            "Number of threads per warp">,
     Option<"num_ctas_", "num-ctas", "int32_t", /*default=*/"1",
            "Number of CTAs in a CGA">,

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -282,7 +282,7 @@ absl::StatusOr<int64_t> GetMaxRegistersPerBlock(hipDevice_t device) {
 
 absl::StatusOr<int64_t> GetThreadsPerWarp(hipDevice_t device) {
   // TODO(ROCm): This is almost certainly wrong but tests seem to rely on it.
-  return 32;
+  return 64;
 }
 
 absl::Status GetGridLimits(int* x, int* y, int* z, hipDevice_t device) {


### PR DESCRIPTION
Set warp_size to 64.
Just for testing purposes - to get list of failing tests with warp_size = 64.