### PR TITLE
Set correct  threads_per_warp to 64 for AMD GPU

### DIFF
--- a/xla/backends/gpu/codegen/emitters/reduction.h
+++ b/xla/backends/gpu/codegen/emitters/reduction.h
@@ -122,7 +122,12 @@ class ReductionFusion : public EmitterBase {
   }
 
   int64_t WarpSize() const {
+#ifdef TENSORFLOW_USE_ROCM
+    return 32;   // TODO  just a temporary solution  due to the reduction algorithm depends on warpsize 32,
+		 // will change back to right warpsize when algorithm is fixed.
+#else
     return ::xla::gpu::WarpSize(analysis_.device_info());
+#endif    
   }
 
   // The reduction heroes for each reduction group.

--- a/xla/backends/gpu/codegen/emitters/scatter.cc
+++ b/xla/backends/gpu/codegen/emitters/scatter.cc
@@ -99,7 +99,11 @@ using mlir::func::FuncOp;
 using mlir::func::ReturnOp;
 using primitive_util::IsUnsignedIntegralType;
 
-constexpr int64_t kNumWarpsPerBlock = 4;
+#ifdef TENSORFLOW_USE_ROCM
+  constexpr int64_t kNumWarpsPerBlock = 2;
+#else
+  constexpr int64_t kNumWarpsPerBlock = 4;
+#endif
 constexpr int64_t kMaxVectorizedBits = 128;
 constexpr int64_t kScatterOperandIndex = 0;
 constexpr int64_t kScatterIndicesIndex = 1;

--- a/xla/backends/gpu/codegen/emitters/transforms/passes.h
+++ b/xla/backends/gpu/codegen/emitters/transforms/passes.h
@@ -48,7 +48,11 @@ std::unique_ptr<mlir::Pass> CreateLowerToLLVMPass(
     const std::string& gpu_device_info = "");
 std::unique_ptr<mlir::Pass> CreateLowerToLLVMPass(
     const se::DeviceDescription& device_description);
-std::unique_ptr<mlir::Pass> CreateLowerXlaGpuToScfPass(int64_t warp_size = 32);
+#ifdef TENSORFLOW_USE_ROCM
+  std::unique_ptr<mlir::Pass> CreateLowerXlaGpuToScfPass(int64_t warp_size = 64);
+#else
+  std::unique_ptr<mlir::Pass> CreateLowerXlaGpuToScfPass(int64_t warp_size = 32);
+#endif  
 std::unique_ptr<mlir::Pass> CreateLowerXlaGpuLoopsToScfPass();
 std::unique_ptr<mlir::Pass> CreateMergePointersToSameSlicePass();
 std::unique_ptr<mlir::Pass> CreateOptimizeLoopsPass();

--- a/xla/backends/gpu/codegen/emitters/transforms/passes.td
+++ b/xla/backends/gpu/codegen/emitters/transforms/passes.td
@@ -181,7 +181,7 @@ def LowerXlaGpuToScfPass :
   ];
 
   let options = [
-    Option<"warp_size", "warp_size", "int64_t", /*default=*/"32", "Warp size.">,
+    Option<"warp_size", "warp_size", "int64_t", /*default=*/"64", "Warp size.">,
   ];
   let constructor = "CreateLowerXlaGpuToScfPass()";
 }

--- a/xla/backends/gpu/codegen/emitters/transpose.cc
+++ b/xla/backends/gpu/codegen/emitters/transpose.cc
@@ -93,14 +93,14 @@ TransposeFusion::TransposeFusion(const HloFusionAnalysis& analysis)
       permutation_(transpose_.permutation),
       input_shape_(
           Permute(transpose_.dimensions, InversePermutation(permutation_))),
-      base_block_size_(WarpSize(
+      base_block_size_(
 #ifdef TENSORFLOW_USE_ROCM
                       kTileSize
 #else		      
-		      analysis_.device_info()
+		      WarpSize(analysis_.device_info())
 			      
 #endif		      
-			      )) {
+			      ) {
   ConstHloInstructionSet transposes_to_tile;
   int index = 0;
   int64_t shmem_usage = 0;

--- a/xla/backends/gpu/codegen/triton/xla_triton_passes.h
+++ b/xla/backends/gpu/codegen/triton/xla_triton_passes.h
@@ -27,9 +27,13 @@ namespace mlir::triton::xla {
 
 #define GEN_PASS_DECL
 #include "xla/backends/gpu/codegen/triton/xla_triton_passes.h.inc"
-
-std::unique_ptr<mlir::Pass> CreateSparseAddEncodingPass(
+#ifdef TENSORFLOW_USE_ROCM
+  std::unique_ptr<mlir::Pass> CreateSparseAddEncodingPass(
+    int32_t num_warps = 4, int32_t threads_per_warp = 64, int32_t num_ctas = 1);
+#else 
+  std::unique_ptr<mlir::Pass> CreateSparseAddEncodingPass(
     int32_t num_warps = 4, int32_t threads_per_warp = 32, int32_t num_ctas = 1);
+#endif  
 std::unique_ptr<mlir::Pass> CreateSparseBlockedToMMAPass();
 std::unique_ptr<mlir::Pass> CreateSparseRemoveLayoutConversionPass();
 std::unique_ptr<mlir::Pass> CreateSparseLocalLoadToLLVMPass();

--- a/xla/backends/gpu/codegen/triton/xla_triton_passes.td
+++ b/xla/backends/gpu/codegen/triton/xla_triton_passes.td
@@ -23,7 +23,7 @@ def SparseAddEncodingPass : Pass<"sparse-add-encoding", "mlir::ModuleOp"> {
   let options = [
     Option<"num_warps_", "num-warps", "int32_t", /*default=*/"4",
            "Number of warps">,
-    Option<"threads_per_warp_", "threads-per-warp", "int32_t", /*default=*/"32",
+    Option<"threads_per_warp_", "threads-per-warp", "int32_t", /*default=*/"64",
            "Number of threads per warp">,
     Option<"num_ctas_", "num-ctas", "int32_t", /*default=*/"1",
            "Number of CTAs in a CGA">,

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -281,8 +281,7 @@ absl::StatusOr<int64_t> GetMaxRegistersPerBlock(hipDevice_t device) {
 }
 
 absl::StatusOr<int64_t> GetThreadsPerWarp(hipDevice_t device) {
-  // TODO(ROCm): This is almost certainly wrong but tests seem to rely on it.
-  return 32;
+  return GetSimpleAttribute<int64_t>(device, hipDeviceAttributeWarpSize);
 }
 
 absl::Status GetGridLimits(int* x, int* y, int* z, hipDevice_t device) {


### PR DESCRIPTION
In xla0.5.0, some algorithms depends on warp_size 32, so that thereads_per_warp has been manually set to 32. This PR tries to reset threads_per_warp to 64 correctly for current AMD GPU and at the same, fix unittest failure/numerical issues due to this change.    I have run unittest of jax, it shows that unittests have much less failure/numerical issues than original/base  branch  rocm-jaxlib-v0.5.0.  For example, pytest tests/pallas pass all unittests. 
=============== 1907 passed, 3307 skipped in 1281.18s (0:21:21) ================
