### PR TITLE
fixed SWDEV-530018

### DIFF
--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
@@ -125,7 +125,7 @@ absl::Status CreateTritonPipeline(mlir::OpPassManager* pm,
   pm->addPass(mlir::createCSEPass());
   pm->addPass(mlir::createSymbolDCEPass());
   pm->addPass(mt::createTritonAMDGPULowerInstructionSchedHintsPass(
-      cc.gfx_version(), num_stages, "default"));
+      cc.gfx_version(), num_stages, "none"));
   pm->addPass(mt::createConvertBuiltinFuncToLLVMPass(/*ftz=*/true));
   // There is no clusters in ROCm for now.
   out_cluster_info.clusterDimX = 1;


### PR DESCRIPTION
`error: failed to legalize operation 'amdgpu.instruction_sched_hint' that was explicitly marked illegal`

this is based on https://github.com/ROCm/xla/commit/2bd6f7eb52229050ed1347889e0408bfe58542cd and https://github.com/openxla/xla/commit/e9c6cd513af350cff57d42fb130becc9f4df1654