### PR TITLE
[rocm-jaxlib-v0.5.0] Fix rocm_stream_test

### DIFF
--- a/xla/stream_executor/rocm/rocm_stream_test.cc
+++ b/xla/stream_executor/rocm/rocm_stream_test.cc
@@ -254,7 +254,6 @@ TEST_F(RocmStreamTest, WaitForEvent) {
       stream->DoHostCallback([&callback_called]() { callback_called = true; }),
       IsOk());
 
-  EXPECT_FALSE(callback_called);
   EXPECT_THAT(stream->RecordEvent(&event), IsOk());
   EXPECT_THAT(stream->BlockHostUntilDone(), IsOk());
   EXPECT_TRUE(callback_called);


### PR DESCRIPTION
Cherry-picked from https://github.com/openxla/xla/pull/23988

The test was failing with:
```
[2024-11-18T10:57:59.388Z] [ RUN      ] RocmStreamTest.WaitForEvent
[2024-11-18T10:57:59.388Z] external/local_xla/xla/stream_executor/rocm/rocm_stream_test.cc:258: Failure
[2024-11-18T10:57:59.388Z] Value of: callback_called
[2024-11-18T10:57:59.388Z]   Actual: true
[2024-11-18T10:57:59.388Z] Expected: false
[2024-11-18T10:57:59.388Z] [  FAILED  ] RocmStreamTest.WaitForEvent (0 ms)
```

Removing this expect_false check to avoid timing issues with the callback.
