### PR TITLE
Fixing GemmRewriteTest.ReduceOfBatchDot which failed due to cublaslt=true set globally

### DIFF
--- a/xla/service/gpu/transforms/gemm_rewriter_test.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter_test.cc
@@ -99,6 +99,7 @@ class GemmRewriteTest : public GpuCodegenTest {
     // These tests test the cuBLAS rewriter so we have to make sure that we use
     // cuBLAS for them.
     debug_options.set_xla_gpu_enable_triton_gemm(false);
+    debug_options.set_xla_gpu_enable_cublaslt(false);
     debug_options.set_xla_gpu_gemm_rewrite_size_threshold(0);
     return debug_options;
   }


### PR DESCRIPTION
This should hopefully also fix the issue reported here: https://ontrack-internal.amd.com/browse/SWDEV-517928