### PR TITLE
Remove linking to libamd_comgr

### DIFF
--- a/third_party/tsl/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/tsl/third_party/gpus/rocm/BUILD.tpl
@@ -404,9 +404,6 @@ cc_library(
 
 cc_library(
     name = "amd_comgr",
-    srcs = glob([
-        "%{rocm_root}/lib/libamd_comgr.so*",
-    ]),
     hdrs = glob(["%{rocm_root}/include/amd_comgr/**"]),
     include_prefix = "rocm",
     includes = [


### PR DESCRIPTION
This is loaded by the runtime, so we should
not be directly depending on it.

Not even 100% sure we need the headers for compilation, but it can't really hurt to leave them.

This fixes a problem in JAX where our kernel objects were linked against comgr which would cause them to load it before runtime, which was causing runtime to fail because comgr changed their version between ROCm 6.3 and 6.4, and our early loading was then loading an invalid version for runtime.