### PR TITLE
Dev rocm mx datatypes (Internal Review Only)

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
@@ -322,7 +322,7 @@ static absl::Status AppendCommands(CommandBufferCmdSequence& cmd_sequence,
       return Internal(
           "Error trying to emit command for a CommandBufferThunk. Input HLO "
           "must already contain command buffers and XLA should not run command "
-          "buffer scheduling pass the second time. It it happens in the test, "
+          "buffer scheduling pass the second time. If it happens in the test, "
           "try explicitly disabling command buffers in tested HLO module.");
 
     default:

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -701,7 +701,7 @@ TEST(CommandBufferThunkTest, GemmCmd) {
       ShapeUtil::MakeShape(PrimitiveType::F32, {4, 3}), {}, {0},
       ShapeUtil::MakeShape(PrimitiveType::F32, {2, 3}), 1.0, 0.0, 0.0,
       PrecisionConfig::ALG_UNSET, std::nullopt,
-      se::blas::kDefaultComputePrecision, false, false,
+      se::blas::kDefaultComputePrecision, false, false, false,
       stream_executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 
@@ -831,7 +831,7 @@ TEST(CommandBufferThunkTest, DISABLED_DynamicSliceFusionCmd) {
       ShapeUtil::MakeShape(PrimitiveType::F32, {4, 3}), {}, {0},
       ShapeUtil::MakeShape(PrimitiveType::F32, {2, 3}), 1.0, 0.0, 0.0,
       PrecisionConfig::ALG_UNSET, std::nullopt,
-      se::blas::kDefaultComputePrecision, false, false,
+      se::blas::kDefaultComputePrecision, false, false, false,
       stream_executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 
@@ -976,7 +976,7 @@ TEST(CommandBufferThunkTest, CublasLtCmd) {
       /*precision_algorithm*/ PrecisionConfig::ALG_UNSET,
       /*algorithm*/ std::nullopt,
       /*compute_precision*/ se::blas::kDefaultComputePrecision,
-      /*grad_x*/ false, /*grad_y*/ false,
+      /*grad_x*/ false, /*grad_y*/ false, /*mx_mode*/ false,
       stream_executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
@@ -133,7 +133,7 @@ TEST_F(DynamicSliceThunkTest, SlicedGemm) {
       ShapeUtil::MakeShape(PrimitiveType::F32, {3, 1}), {}, {0},
       ShapeUtil::MakeShape(PrimitiveType::F32, {1, 1}), 1.0, 0.0, 0.0,
       PrecisionConfig::ALG_UNSET, std::nullopt,
-      se::blas::kDefaultComputePrecision, false, false,
+      se::blas::kDefaultComputePrecision, false, false, false,
       executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 
@@ -286,7 +286,7 @@ TEST_F(DynamicSliceThunkTest, MulipleSlicedOperandsGemm) {
       ShapeUtil::MakeShape(PrimitiveType::F32, {3, 1}), {}, {0},
       ShapeUtil::MakeShape(PrimitiveType::F32, {1, 1}), 1.0, 0.0, 0.0,
       PrecisionConfig::ALG_UNSET, std::nullopt,
-      se::blas::kDefaultComputePrecision, false, false,
+      se::blas::kDefaultComputePrecision, false, false, false,
       executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 
@@ -814,7 +814,7 @@ TEST_F(DynamicSliceThunkTest, SlicedGemmArbitraryArgumentOrder) {
       ShapeUtil::MakeShape(PrimitiveType::F32, {3, 1}), {}, {0},
       ShapeUtil::MakeShape(PrimitiveType::F32, {1, 1}), 1.0, 0.0, 0.0,
       PrecisionConfig::ALG_UNSET, std::nullopt,
-      se::blas::kDefaultComputePrecision, false, false,
+      se::blas::kDefaultComputePrecision, false, false, false,
       executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 
@@ -963,7 +963,7 @@ TEST_F(DynamicSliceThunkTest, SlicedGemmArbitraryNumberOfArguments) {
       ShapeUtil::MakeShape(PrimitiveType::F32, {3, 1}), {}, {0},
       ShapeUtil::MakeShape(PrimitiveType::F32, {1, 1}), 1.0, 0.0, 0.0,
       PrecisionConfig::ALG_UNSET, std::nullopt,
-      se::blas::kDefaultComputePrecision, false, false,
+      se::blas::kDefaultComputePrecision, false, false, false,
       executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 
@@ -1105,7 +1105,7 @@ TEST_F(DynamicSliceThunkTest, SlicedTupledOperandGemm) {
       ShapeUtil::MakeShape(PrimitiveType::F32, {3, 1}), {}, {0},
       ShapeUtil::MakeShape(PrimitiveType::F32, {1, 1}), 1.0, 0.0, 0.0,
       PrecisionConfig::ALG_UNSET, std::nullopt,
-      se::blas::kDefaultComputePrecision, false, false,
+      se::blas::kDefaultComputePrecision, false, false, false,
       executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 
@@ -1462,7 +1462,7 @@ TEST_F(DynamicSliceThunkTest, SlicedOperandsSameBufferGemm) {
       ShapeUtil::MakeShape(PrimitiveType::F32, {3, 1}), {}, {0},
       ShapeUtil::MakeShape(PrimitiveType::F32, {1, 1}), 1.0, 0.0, 0.0,
       PrecisionConfig::ALG_UNSET, std::nullopt,
-      se::blas::kDefaultComputePrecision, false, false,
+      se::blas::kDefaultComputePrecision, false, false, false,
       executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 
@@ -1649,7 +1649,7 @@ TEST_F(DynamicSliceThunkTest,
       /*precision_algorithm=*/PrecisionConfig::ALG_UNSET,
       /*algorithm=*/std::nullopt,
       /*compute_precision=*/se::blas::kDefaultComputePrecision,
-      /*grad_x=*/false, /*grad_y=*/false,
+      /*grad_x=*/false, /*grad_y=*/false, /*mx_mode*/ false,
       /*gpu_version=*/
       executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());

--- a/xla/literal_util.cc
+++ b/xla/literal_util.cc
@@ -339,6 +339,24 @@ void PopulateWithRandomFloatingPointData(Literal* literal,
   }
 }
 
+template <>
+void PopulateWithRandomFloatingPointData<tsl::float8_e8m0fnu, float>(
+    Literal* literal, std::minstd_rand0* engine) {
+  std::uniform_real_distribution<float> generator(0.0f, 2.0f);
+  for (tsl::float8_e8m0fnu& value : literal->data<tsl::float8_e8m0fnu>()) {
+    value = static_cast<tsl::float8_e8m0fnu>(generator(*engine));
+  }
+}
+
+template <>
+void PopulateWithRandomFloatingPointData<tsl::float4_e2m1fn, float>(
+    Literal* literal, std::minstd_rand0* engine) {
+  std::uniform_real_distribution<float> generator(-6.0f, 6.0f);
+  for (tsl::float4_e2m1fn& value : literal->data<tsl::float4_e2m1fn>()) {
+    value = static_cast<tsl::float4_e2m1fn>(generator(*engine));
+  }
+}
+
 template <typename FloatT>
 void PopulateWithFloatingPointData(
     Literal* literal, std::minstd_rand0* engine, bool no_duplicates,

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2129,6 +2129,7 @@ cc_library(
         "//xla/service/gpu/autotuning:gemm_fusion_autotuner",
         "//xla/service/gpu/llvm_gpu_backend:amdgpu_backend",
         "//xla/service/gpu/transforms:algebraic_simplifier",
+        "//xla/service/gpu/transforms:block_scaling_rewriter",
         "//xla/service/gpu/transforms:conv_padding_legalization",
         "//xla/service/gpu/transforms:conv_rewriter",
         "//xla/service/gpu/transforms:cublas_pad_for_gemms",

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -106,7 +106,9 @@ message GemmBackendConfig {
   optional bool grad_y = 17;
   bool damax_output = 18;
 
-  reserved 19;
+  bool mx_mode = 19;
+
+  reserved 20;
 }
 
 // Backend config for bitcast operation generated from MLIR MHLO dialect.

--- a/xla/service/gpu/cublas_cudnn.cc
+++ b/xla/service/gpu/cublas_cudnn.cc
@@ -48,6 +48,11 @@ bool IsCublasLtMatmulF8(const HloInstruction& hlo) {
          hlo.custom_call_target() == kCublasLtMatmulF8CallTarget;
 }
 
+bool IsCublasLtMatmulMX(const HloInstruction& hlo) {
+  return hlo.opcode() == HloOpcode::kCustomCall &&
+         hlo.custom_call_target() == kCublasLtMatmulMXCallTarget;
+}
+
 bool IsTriangularSolve(const HloInstruction& hlo) {
   return hlo.opcode() == HloOpcode::kCustomCall &&
          hlo.custom_call_target() == kTriangularSolveCallTarget;
@@ -56,6 +61,7 @@ bool IsTriangularSolve(const HloInstruction& hlo) {
 const absl::string_view kGemmCallTarget = "__cublas$gemm";
 const absl::string_view kCublasLtMatmulCallTarget = "__cublas$lt$matmul";
 const absl::string_view kCublasLtMatmulF8CallTarget = "__cublas$lt$matmul$f8";
+const absl::string_view kCublasLtMatmulMXCallTarget = "__cublas$lt$matmul$mx";
 const absl::string_view kTriangularSolveCallTarget = "__cublas$triangularSolve";
 
 const absl::string_view kCudnnConvBackwardInputCallTarget =

--- a/xla/service/gpu/cublas_cudnn.h
+++ b/xla/service/gpu/cublas_cudnn.h
@@ -99,6 +99,9 @@ bool IsCublasLtMatmul(const HloInstruction& hlo);
 // Scaled matrix multiplication in FP8. Calls into cublasLt.
 bool IsCublasLtMatmulF8(const HloInstruction& hlo);
 
+// Scaled matrix multiplication in FP8. Calls into cublasLt.
+bool IsCublasLtMatmulMX(const HloInstruction& hlo);
+
 // Triangular solve that calls into legacy cublas.
 bool IsTriangularSolve(const HloInstruction& hlo);
 
@@ -212,6 +215,9 @@ bool MHACallHasDropout(absl::string_view fmha_call_name);
 
 // A call to cuDNN for a block scaled dot.
 extern const absl::string_view kCudnnBlockScaledDotCallTarget;
+
+// A call to hipblaslt for a block scaled dot.
+extern const absl::string_view kCublasLtMatmulMXCallTarget;
 
 bool IsCustomCallToBlockScaledDot(const HloInstruction& hlo);
 

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -821,6 +821,60 @@ absl::Status IrEmitterUnnested::EmitCublasLtMatmulThunkF8(
   return absl::OkStatus();
 }
 
+absl::Status IrEmitterUnnested::EmitCublasLtMatmulThunkMX(
+    const HloCustomCallInstruction* instr) {
+  TF_RET_CHECK(instr->operand_count() == 4);
+  TF_ASSIGN_OR_RETURN(const auto gpu_config,
+                      instr->backend_config<xla::gpu::GpuBackendConfig>());
+  const xla::gpu::GemmBackendConfig& config = gpu_config.gemm_backend_config();
+  xla::gpu::GemmBackendConfig_Epilogue epilogue = config.epilogue();
+
+  TF_RET_CHECK(instr->shape().IsTuple());
+  xla::ShapeIndex output_index = xla::ShapeIndex{0};
+
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice a,
+                      GetAllocationSliceForHlo(instr->operand(0)));
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice b,
+                      GetAllocationSliceForHlo(instr->operand(1)));
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice a_scale,
+                      GetAllocationSliceForHlo(instr->operand(2)));
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice b_scale,
+                      GetAllocationSliceForHlo(instr->operand(3)));
+  BufferAllocation::Slice c;
+  TF_ASSIGN_OR_RETURN(c, GetAllocationSliceForHlo(instr, output_index));
+  BufferAllocation::Slice c_scale, d_scale, bias;  // not used
+
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice d,
+                      GetAllocationSliceForHlo(instr, output_index));
+  BufferAllocation::Slice d_amax, aux;  // not used
+
+  TF_ASSIGN_OR_RETURN(
+      auto gemm_config,
+      GemmConfig::For(static_cast<const HloInstruction*>(instr),
+                      ir_emitter_context_->gpu_compute_capability()));
+
+  // Use the first algorithm by default (i.e. fastest according to heuristics).
+  int64_t algorithm =
+      config.algorithm_case() == GemmBackendConfig::kSelectedAlgorithm
+          ? config.selected_algorithm()
+          : 0;
+
+  std::optional<BufferAllocation::Slice> workspace_buffer;
+  if (instr->shape().tuple_shapes().size() - config.damax_output() == 2) {
+    TF_ASSIGN_OR_RETURN(workspace_buffer,
+                        GetAllocationSliceForHlo(
+                            instr, {instr->shape().tuple_shapes_size() - 1}));
+  }
+
+  TF_ASSIGN_OR_RETURN(se::gpu::BlasLt::Epilogue blas_lt_epilogue,
+                      gpublas_lt::AsBlasLtEpilogue(epilogue));
+  auto thunk = std::make_unique<CublasLtMatmulThunk>(
+      instr, std::move(gemm_config), blas_lt_epilogue, algorithm, a, b, c, d,
+      bias, aux, a_scale, b_scale, c_scale, d_scale, d_amax, workspace_buffer);
+  AddThunkToThunkSequence(std::move(thunk));
+  return absl::OkStatus();
+}
+
 absl::Status IrEmitterUnnested::EmitConvolutionReorderThunk(
     const HloCustomCallInstruction* instr) {
   bool has_bias = instr->operand_count() > 1;
@@ -1626,6 +1680,13 @@ absl::Status IrEmitterUnnested::EmitAsyncCustomCallStart(
   }
   if (IsCublasLtMatmulF8(*wrapped)) {
     auto status = EmitCublasLtMatmulThunkF8(custom_call);
+    if (status.ok()) {
+      thunk_sequence_.back()->set_execution_stream_id(execution_stream_id);
+    }
+    return status;
+  }
+  if (IsCublasLtMatmulMX(*wrapped)) {
+    auto status = EmitCublasLtMatmulThunkMX(custom_call);
     if (status.ok()) {
       thunk_sequence_.back()->set_execution_stream_id(execution_stream_id);
     }
@@ -2807,6 +2868,9 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
       }
       if (IsCublasLtMatmulF8(*instr)) {
         return EmitCublasLtMatmulThunkF8(custom_call);
+      }
+      if (IsCublasLtMatmulMX(*instr)) {
+        return EmitCublasLtMatmulThunkMX(custom_call);
       }
       if (IsCudnnConvolutionReorder(*instr)) {
         return EmitConvolutionReorderThunk(custom_call);

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -119,6 +119,7 @@ class IrEmitterUnnested : public IrEmitter {
   absl::Status EmitGemmThunk(const HloCustomCallInstruction* instr);
   absl::Status EmitCublasLtMatmulThunk(const HloCustomCallInstruction* instr);
   absl::Status EmitCublasLtMatmulThunkF8(const HloCustomCallInstruction* instr);
+  absl::Status EmitCublasLtMatmulThunkMX(const HloCustomCallInstruction* instr);
   absl::Status EmitConvolutionReorderThunk(
       const HloCustomCallInstruction* instr);
   absl::Status EmitNormThunk(const HloCustomCallInstruction* instr);

--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -260,13 +260,13 @@ absl::StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
     double alpha_real, double alpha_imag, double beta,
     PrecisionConfig::Algorithm precision_algorithm,
     std::optional<int64_t> algorithm, int64_t compute_precision, bool grad_x,
-    bool grad_y, const se::GpuComputeCapability& gpu_version) {
+    bool grad_y, bool mx_mode, const se::GpuComputeCapability& gpu_version) {
   return GemmConfig::For(lhs_shape, lhs_batch_dims, lhs_contracting_dims,
                          rhs_shape, rhs_batch_dims, rhs_contracting_dims,
                          /*c_shape=*/output_shape, /*bias_shape_ptr=*/nullptr,
                          output_shape, alpha_real, alpha_imag, beta,
                          precision_algorithm, algorithm, compute_precision,
-                         grad_x, grad_y, gpu_version);
+                         grad_x, grad_y, mx_mode, gpu_version);
 }
 
 /*static*/ absl::StatusOr<GemmConfig> GemmConfig::For(
@@ -278,7 +278,7 @@ absl::StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
     double alpha_imag, double beta,
     PrecisionConfig::Algorithm precision_algorithm,
     std::optional<int64_t> algorithm, int64_t compute_precision, bool grad_x,
-    bool grad_y, const se::GpuComputeCapability& gpu_version) {
+    bool grad_y, bool mx_mode, const se::GpuComputeCapability& gpu_version) {
   absl::Span<const int64_t> lhs_col_dims = lhs_contracting_dims;
   TF_ASSIGN_OR_RETURN(
       std::vector<int64_t> lhs_row_dims,
@@ -396,7 +396,8 @@ absl::StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
                                         precision_algorithm,
                                         algorithm,
                                         grad_x,
-                                        grad_y});
+                                        grad_y,
+                                        mx_mode});
 }
 
 namespace {
@@ -470,7 +471,8 @@ bool IsTf32Allowed(PrecisionConfig::Algorithm algorithm,
       /*bias_shape_ptr=*/
       vector_bias_shape ? &vector_bias_shape.value() : nullptr, output_shape,
       config.alpha_real(), config.alpha_imag(), config.beta(),
-      precision_algorithm, algorithm, precision, grad_x, grad_y, gpu_version);
+      precision_algorithm, algorithm, precision, grad_x, grad_y,
+      config.mx_mode(), gpu_version);
 }
 
 absl::StatusOr<GemmConfig::DescriptorsTuple> GemmConfig::GetMatrixDescriptors(

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -116,7 +116,7 @@ struct GemmConfig : public se::gpu::GemmConfig {
       double alpha_real, double alpha_imag, double beta,
       PrecisionConfig::Algorithm precision_algorithm,
       std::optional<int64_t> algorithm, int64_t compute_precision, bool grad_x,
-      bool grad_y, const se::GpuComputeCapability& gpu_version);
+      bool grad_y, bool mx_mode, const se::GpuComputeCapability& gpu_version);
 
   // As above with additional `c_shape` and `bias_shape_ptr` parameter, both
   // which are only necessarily for F8 gemms.
@@ -129,7 +129,7 @@ struct GemmConfig : public se::gpu::GemmConfig {
       double alpha_imag, double beta,
       PrecisionConfig::Algorithm precision_algorithm,
       std::optional<int64_t> algorithm, int64_t compute_precision, bool grad_x,
-      bool grad_y, const se::GpuComputeCapability& gpu_version);
+      bool mx_mode, bool grad_y, const se::GpuComputeCapability& gpu_version);
 
   struct DescriptorsTuple {
     se::gpu::MatrixDescriptor lhs;

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -280,10 +280,13 @@ absl::Status NVPTXCompiler::OptimizeHloPostLayoutAssignment(
     // Rewrite normalization patterns into cuDNN Custom Calls.
     pre_pipeline.AddPass<CudnnNormRewriter>(cuda_compute_capability);
   }
-
+  
+  bool allow_cudnn =
+      cuda_compute_capability.IsAtLeastBlackwell() &&
+      gpu_target_config.dnn_version_info >= se::dnn::VersionInfo(9, 7);
   pre_pipeline.AddPass<BlockScalingRewriter>(
-      /*allow_cudnn=*/cuda_compute_capability.IsAtLeastBlackwell() &&
-      gpu_target_config.dnn_version_info >= se::dnn::VersionInfo(9, 7));
+      gpu_target_config.device_description, allow_cudnn,
+      /*allow_hipblaslt*/ false);
   pre_pipeline.AddPass<DotDimensionMerger>();
   pre_pipeline.AddPass<DotSparsityRewriter>();
 

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -296,8 +296,10 @@ cc_library(
         "//xla/service:hlo_creation_utils",
         "//xla/service:shape_inference",
         "//xla/service/gpu:cublas_cudnn",
+        "//xla/service/gpu:matmul_utils",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",
+        "//xla/service/gpu:backend_configs_cc",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:statusor",
@@ -306,13 +308,14 @@ cc_library(
     ],
 )
 
-xla_cc_test(
+xla_test(
     name = "block_scaling_rewriter_test",
     srcs = ["block_scaling_rewriter_test.cc"],
+    backends = ["gpu"],
     deps = [
         ":block_scaling_rewriter",
         "//xla/hlo/parser:hlo_parser",
-        "//xla/tests:hlo_test_base",
+        "//xla/service/gpu/tests:gpu_codegen_test",
         "//xla/tests:xla_internal_test_main",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/strings:string_view",
@@ -324,13 +327,27 @@ xla_test(
     name = "block_scaling_rewriter_cudnn_test",
     srcs = ["block_scaling_rewriter_cudnn_test.cc"],
     backends = ["b200"],
-    tags = ["test_migrated_to_hlo_runner_pjrt"],
     deps = [
         ":block_scaling_rewriter",
         "//xla:error_spec",
         "//xla/hlo/ir:hlo",
-        "//xla/tests:hlo_pjrt_interpreter_reference_mixin",
-        "//xla/tests:hlo_pjrt_test_base",
+        "//xla/service/gpu/tests:gpu_codegen_test",
+        "//xla/tests:xla_internal_test_main",
+        "//xla/tsl/platform:status_matchers",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+xla_test(
+    name = "block_scaling_rewriter_hipblaslt_test",
+    srcs = ["block_scaling_rewriter_hipblaslt_test.cc"],
+    backends = ["gpu"],
+    deps = [
+        ":block_scaling_rewriter",
+        "//xla:error_spec",
+        "//xla/hlo/ir:hlo",
+        "//xla/service/gpu/tests:gpu_codegen_test",
         "//xla/tests:xla_internal_test_main",
         "//xla/tsl/platform:status_matchers",
         "@com_google_absl//absl/strings:string_view",

--- a/xla/service/gpu/transforms/block_scaling_rewriter.h
+++ b/xla/service/gpu/transforms/block_scaling_rewriter.h
@@ -64,10 +64,17 @@ namespace xla::gpu {
 //
 class BlockScalingRewriter : public OpExpanderPass {
  public:
-  explicit BlockScalingRewriter(bool allow_cudnn)
-      : allow_cudnn_(allow_cudnn) {};
+  explicit BlockScalingRewriter(const se::DeviceDescription& device_description,
+                                const bool allow_cudnn,
+                                const bool allow_hipblaslt)
+      : device_description_(device_description),
+        allow_cudnn_(allow_cudnn),
+        allow_hipblaslt_(allow_hipblaslt) {};
 
   absl::string_view name() const override { return "block-scaling-rewriter"; }
+
+  bool IsCuda();
+  bool IsRocm();
 
   bool InstructionMatchesPattern(HloInstruction* instruction) override;
 
@@ -82,12 +89,16 @@ class BlockScalingRewriter : public OpExpanderPass {
   static constexpr absl::string_view kBlockScaledDotCustomCallTarget =
       "__op$block_scaled_dot";
 
-  // Common block size constants.
+  // Common block size constants for CUDA
   static constexpr int kBlockSizeMXFP8 = 32;
   static constexpr int kBlockSizeNVFP4 = 16;
+  // Common block size constants for ROCm
+  static constexpr int kBlockSizeHipblaslt = 32;
 
  private:
-  bool allow_cudnn_;
+  const se::DeviceDescription device_description_;
+  const bool allow_cudnn_;
+  const bool allow_hipblaslt_;
 };
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/transforms/block_scaling_rewriter_cudnn_test.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter_cudnn_test.cc
@@ -19,16 +19,20 @@ limitations under the License.
 #include "xla/error_spec.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/gpu/transforms/block_scaling_rewriter.h"
-#include "xla/tests/hlo_pjrt_interpreter_reference_mixin.h"
-#include "xla/tests/hlo_pjrt_test_base.h"
 #include "xla/tsl/platform/status_matchers.h"
+#include "xla/service/gpu/tests/gpu_codegen_test.h"
 
 namespace xla::gpu {
 namespace {
 
 using ::tsl::testing::IsOkAndHolds;
-using BlockScalingRewriterCudnnTest =
-    HloPjRtInterpreterReferenceMixin<HloPjRtTestBase>;
+
+class BlockScalingRewriterCudnnTest : public GpuCodegenTest {
+ protected:
+  const auto& device_desc() const {
+    return backend().default_stream_executor()->GetDeviceDescription();
+  }
+};
 
 TEST_F(BlockScalingRewriterCudnnTest, Mxfp8) {
   constexpr absl::string_view hlo_string = R"(
@@ -46,20 +50,28 @@ ENTRY main {
   EXPECT_TRUE(RunAndCompare(
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
-      [](HloModule* reference_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/false);
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/false);
         EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
-      [](HloModule* test_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/true);
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/true,
+                                  /*allow_hipblaslt=*/false);
         EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(false),
-                            "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(true),
-                            "CHECK: __cudnn$blockScaledDot");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cudnn$blockScaledDot");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/true,
+                           /*allow_hipblaslt=*/false),
+      "CHECK: __cudnn$blockScaledDot");
 }
 
 TEST_F(BlockScalingRewriterCudnnTest, Mxfp8_MixedTypes) {
@@ -78,20 +90,28 @@ ENTRY main {
   EXPECT_TRUE(RunAndCompare(
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
-      [](HloModule* reference_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/false);
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/false);
         EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
-      [](HloModule* test_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/true);
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/true,
+                                  /*allow_hipblaslt=*/false);
         EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(false),
-                            "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(true),
-                            "CHECK: __cudnn$blockScaledDot");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cudnn$blockScaledDot");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/true,
+                           /*allow_hipblaslt=*/false),
+      "CHECK: __cudnn$blockScaledDot");
 }
 
 // Scale E2M1FN inputs, as otherwise they become all zeros for the random
@@ -120,20 +140,28 @@ ENTRY main {
   EXPECT_TRUE(RunAndCompare(
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
-      [](HloModule* reference_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/false);
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/false);
         EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
-      [](HloModule* test_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/true);
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/true,
+                                  /*allow_hipblaslt=*/false);
         EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(false),
-                            "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(true),
-                            "CHECK: __cudnn$blockScaledDot");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cudnn$blockScaledDot");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/true,
+                           /*allow_hipblaslt=*/false),
+      "CHECK: __cudnn$blockScaledDot");
 }
 
 }  // namespace

--- a/xla/service/gpu/transforms/block_scaling_rewriter_hipblaslt_test.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter_hipblaslt_test.cc
@@ -1,0 +1,248 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/strings/string_view.h"
+#include "xla/error_spec.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/service/gpu/transforms/block_scaling_rewriter.h"
+#include "xla/tsl/platform/status_matchers.h"
+#include "xla/service/gpu/tests/gpu_codegen_test.h"
+
+namespace xla::gpu {
+namespace {
+
+using ::tsl::testing::IsOkAndHolds;
+
+class BlockScalingRewriterHipblasltTest : public GpuCodegenTest {
+ protected:
+  const auto& device_desc() const {
+    return backend().default_stream_executor()->GetDeviceDescription();
+  }
+
+  const auto& GpuCapability() const {
+    return device_desc().gpu_compute_capability();
+  }
+
+  bool IsRocm() const {
+    return std::holds_alternative<stream_executor::RocmComputeCapability>(
+        GpuCapability());
+  }
+
+  void SetUp() override {
+    if (!IsRocm()) { GTEST_SKIP(); }
+    auto rocm_cc = std::get<se::RocmComputeCapability>(GpuCapability());
+    if (rocm_cc.gfx_version() != "gfx950") { GTEST_SKIP(); }
+  };
+};
+
+TEST_F(BlockScalingRewriterHipblasltTest, Mxfp8) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %lhs = f8e4m3fn[32,256] parameter(0)
+  %rhs = f8e4m3fn[16,256] parameter(1)
+  %lhs_scale = f8e8m0fnu[32,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[16,8] parameter(3)
+  ROOT %result = f32[32,16] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cublas$lt$matmul$mx");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/true),
+      "CHECK: __cublas$lt$matmul$mx");
+}
+
+TEST_F(BlockScalingRewriterHipblasltTest, BatchedMxfp8) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %lhs = f8e4m3fn[1,32,256] parameter(0)
+  %rhs = f8e4m3fn[1,16,256] parameter(1)
+  %lhs_scale = f8e8m0fnu[1,32,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[1,16,8] parameter(3)
+  ROOT %result = f32[1,32,16] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cublas$lt$matmul$mx");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/true),
+      "CHECK: __cublas$lt$matmul$mx");
+}
+
+TEST_F(BlockScalingRewriterHipblasltTest, BatchedMxfp8_MixedTypes) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %lhs = f8e4m3fn[1,32,256] parameter(0)
+  %rhs = f8e5m2[1,16,256] parameter(1)
+  %lhs_scale = f8e8m0fnu[1,32,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[1,16,8] parameter(3)
+  ROOT %result = f32[1,32,16] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cublas$lt$matmul$mx");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/true),
+      "CHECK: __cublas$lt$matmul$mx");
+}
+
+TEST_F(BlockScalingRewriterHipblasltTest, BatchedMxfp4) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %lhs = f4e2m1fn[1,32,256] parameter(0)
+  %rhs = f4e2m1fn[1,16,256] parameter(1)
+  %lhs_scale = f8e8m0fnu[1,32,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[1,16,8] parameter(3)
+  ROOT %result = f32[1,32,16] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cublas$lt$matmul$mx");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/true),
+      "CHECK: __cublas$lt$matmul$mx");
+}
+
+TEST_F(BlockScalingRewriterHipblasltTest, BatchedMxfp4fp8) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %lhs = f4e2m1fn[1,32,256] parameter(0)
+  %rhs = f8e4m3fn[1,16,256] parameter(1)
+  %lhs_scale = f8e8m0fnu[1,32,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[1,16,8] parameter(3)
+  ROOT %result = f32[1,32,16] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), /*allow_cudnn=*/false,
+                                  /*allow_hipblaslt=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cublas$lt$matmul$mx");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), /*allow_cudnn=*/false,
+                           /*allow_hipblaslt=*/true),
+      "CHECK: __cublas$lt$matmul$mx");
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -123,6 +123,8 @@ class RocmComputeCapability {
     return gfx9_mi200_or_later() || gfx1200() || gfx1201();
   }
 
+  bool has_hipblaslt_mx_support() const { return gfx_version() == "gfx950"; }
+
   bool has_fp8_support() const {
     return has_ocp_fp8_support() || has_nanoo_fp8_support();
   }

--- a/xla/stream_executor/gpu/gpu_blas_lt.cc
+++ b/xla/stream_executor/gpu/gpu_blas_lt.cc
@@ -333,6 +333,7 @@ absl::StatusOr<GemmConfig> GemmConfig::FromProto(
       proto.has_algorithm() ? std::optional(proto.algorithm()) : std::nullopt,
       proto.grad_x(),
       proto.grad_y(),
+      proto.mx_mode(),
       compute_type};
 }
 

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -129,6 +129,7 @@ struct GemmConfig {  // plain GemmConfig which is extended with create functions
   std::optional<int64_t> algorithm;
   bool grad_x;
   bool grad_y;
+  bool mx_mode;
   std::optional<blas::ComputationType> compute_type;
 
   static absl::StatusOr<GemmConfig> FromProto(

--- a/xla/stream_executor/gpu/gpu_blas_lt.proto
+++ b/xla/stream_executor/gpu/gpu_blas_lt.proto
@@ -49,5 +49,6 @@ message GemmConfigProto {
   optional int64 algorithm = 10;
   bool grad_x = 11;
   bool grad_y = 12;
-  xla.BlasComputationTypeProto compute_type = 13;
+  bool mx_mode = 13;
+  xla.BlasComputationTypeProto compute_type = 14;
 }

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -179,13 +179,13 @@ absl::Status BlasLt::Init() {
 /*static*/ absl::StatusOr<BlasLt::MatmulDesc> BlasLt::MatmulDesc::Create(
     blas::ComputationType compute_type, blas::DataType scale_type,
     blas::Transpose trans_a, blas::Transpose trans_b, Epilogue epilogue,
-    PointerMode pointer_mode) {
+    PointerMode pointer_mode, bool mx_mode) {
   hipblasLtMatmulDesc_t hip_desc;
   VLOG(2) << "BlasLt::MatmulDesc::Create compute_type: " << int(compute_type)
           << " scale_type: " << int(scale_type)
           << " epilogue: " << int(epilogue) << " trans_a: " << int(trans_a)
           << " trans_b: " << int(trans_b) << " pointer_mode "
-          << int(pointer_mode);
+          << int(pointer_mode) << "mx_mode: " << mx_mode;
   auto hip_scale_type = AsHipblasDataType(scale_type);
   auto hip_compute_type = AsHipblasComputeType(compute_type);
   SE_HIPBLAS_RETURN_IF_ERROR(wrap::hipblasLtMatmulDescCreate(
@@ -195,7 +195,7 @@ absl::Status BlasLt::Init() {
       static_cast<int32_t>(epilogue) & static_cast<int32_t>(Epilogue::kBias);
   // Wrap hipblas handle immediately, so it is cleaned up if an error occurs.
   BlasLt::MatmulDesc desc(hip_desc, hip_compute_type, hip_scale_type,
-                          bias_flag != 0);
+                          bias_flag != 0, mx_mode);
   if (pointer_mode != PointerMode::kHost) {
     return absl::InternalError("hipblaslt does not support device pointers");
   }
@@ -251,7 +251,7 @@ auto BlasLt::MatmulPlan::GetAlgorithms(const Stream* stream,
              layout.type() == HIP_R_8F_E4M3_FNUZ ||
              layout.type() == HIP_R_8F_E5M2 || layout.type() == HIP_R_8F_E4M3;
     };
-    if (IsFP8(a_desc_) && IsFP8(b_desc_)) {
+    if ((IsFP8(a_desc_) && IsFP8(b_desc_)) || op_desc_.mx_mode()) {
       static int64_t dummy_pointer = 0xACEBALL;
       TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                  HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
@@ -260,6 +260,17 @@ auto BlasLt::MatmulPlan::GetAlgorithms(const Stream* stream,
                                  HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
                                  &dummy_pointer));
     }
+
+#if TF_ROCM_VERSION >= 70000
+    if (op_desc_.mx_mode()) {
+      hipblasLtMatmulMatrixScale_t MXScaleType =
+          HIPBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0;
+      TF_RETURN_IF_ERROR(SetAttr(
+          op_desc_.get(), HIPBLASLT_MATMUL_DESC_A_SCALE_MODE, MXScaleType));
+      TF_RETURN_IF_ERROR(SetAttr(
+          op_desc_.get(), HIPBLASLT_MATMUL_DESC_B_SCALE_MODE, MXScaleType));
+    }
+#endif
 
     int found_algorithm_count = 0;
     auto error = wrap::hipblasLtMatmulAlgoGetHeuristic(
@@ -303,7 +314,7 @@ auto BlasLt::GetMatmulPlan(const gpu::GemmConfig& cfg, Epilogue epilogue) const
   // this is only true if A and B are column-major. If A is row-major, A must
   // *not* be transposed, and if B is row-major, B must be transposed. We never
   // transpose A or B, and expect the caller to ensure A is row-major and B is
-  // column when A and B are FP8.
+  // column-major when A and B are FP8.
   auto trans_a = lhs_layout.transpose, trans_b = rhs_layout.transpose;
 
   if (xla::primitive_util::IsF8Type(lhs_layout.dtype) &&
@@ -337,9 +348,20 @@ auto BlasLt::GetMatmulPlan(const gpu::GemmConfig& cfg, Epilogue epilogue) const
 
   TF_ASSIGN_OR_RETURN(
       auto op_desc,
-      MatmulDesc::Create(*compute_type,
-                         gpu::GetScaleType(output_dtype, *compute_type),
-                         trans_a, trans_b, epilogue));
+      MatmulDesc::Create(
+          *compute_type, gpu::GetScaleType(output_dtype, *compute_type),
+          trans_a, trans_b, epilogue, PointerMode::kHost, cfg.mx_mode));
+
+#if TF_ROCM_VERSION >= 70000
+  if (op_desc.mx_mode()) {
+    hipblasLtMatmulMatrixScale_t MXScaleType =
+        HIPBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0;
+    TF_RETURN_IF_ERROR(SetAttr(
+        op_desc.get(), HIPBLASLT_MATMUL_DESC_A_SCALE_MODE, MXScaleType));
+    TF_RETURN_IF_ERROR(SetAttr(
+        op_desc.get(), HIPBLASLT_MATMUL_DESC_B_SCALE_MODE, MXScaleType));
+  }
+#endif
 
   TF_ASSIGN_OR_RETURN(auto a_desc, MatrixLayout::Create(lhs_layout));
   TF_ASSIGN_OR_RETURN(auto b_desc, MatrixLayout::Create(rhs_layout));
@@ -384,9 +406,15 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     return absl::InternalError(
         "Algorithm must be set before calling DoMatMul!");
   }
-  DeviceMemoryBase a = args.a, b = args.b;
+  DeviceMemoryBase a = args.a;
+  DeviceMemoryBase b = args.b;
+  DeviceMemoryBase a_scale = args.a_scale;
+  DeviceMemoryBase b_scale = args.b_scale;
   if (must_swap_operands_) {
     std::swap(a, b);
+    if (a_scale != nullptr && b_scale != nullptr) {
+      std::swap(a_scale, b_scale);
+    }
   }
 
   auto blas_lt = static_cast<BlasLt*>(gpu::BlasLt::Get(stream));
@@ -431,15 +459,15 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     }
 
 #if TF_ROCM_VERSION >= 60000
-    if (args.a_scale != nullptr) {
+    if (a_scale != nullptr) {
       TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                  HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
-                                 args.a_scale.opaque()));
+                                 a_scale.opaque()));
     }
-    if (args.b_scale != nullptr) {
+    if (b_scale != nullptr) {
       TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                  HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
-                                 args.b_scale.opaque()));
+                                 b_scale.opaque()));
     }
     if (args.c_scale != nullptr) {
       TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
@@ -452,8 +480,8 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
                                  args.d_scale.opaque()));
     }
 #else
-    if (!(args.a_scale == nullptr && args.b_scale == nullptr &&
-          args.c_scale == nullptr && args.d_scale == nullptr)) {
+    if (!(a_scale == nullptr && b_scale == nullptr && args.c_scale == nullptr &&
+          args.d_scale == nullptr)) {
       return absl::InternalError("hipblaslt does not support scale");
     }
 #endif
@@ -582,6 +610,58 @@ absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_8F_E5M2)
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_16F)
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_8F_E4M3, HIP_R_32F, HIP_R_32F)
+#endif
+
+#if TF_ROCM_VERSION >= 70000
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16F)
+
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_32F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_32F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16BF, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16BF, HIP_R_16F)
+
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_32F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_32F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16BF, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16BF, HIP_R_16F)
+
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16F)
+
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16F)
 #endif
 
   // Other data types:

--- a/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/xla/stream_executor/rocm/hip_blas_lt.h
@@ -61,7 +61,7 @@ class BlasLt : public gpu::BlasLt {
         blas::Transpose trans_a = blas::Transpose::kNoTranspose,
         blas::Transpose trans_b = blas::Transpose::kNoTranspose,
         Epilogue epilogue = Epilogue::kDefault,
-        PointerMode pointer_mode = PointerMode::kHost);
+        PointerMode pointer_mode = PointerMode::kHost, bool mx_mode = false);
 
     hipblasComputeType_t compute_type() const { return compute_type_; }
     hipDataType scale_type() const { return datatype_; }
@@ -69,20 +69,24 @@ class BlasLt : public gpu::BlasLt {
     hipblasPointerMode_t pointer_mode() const {
       return HIPBLAS_POINTER_MODE_HOST;
     }
+    bool mx_mode() const { return mx_mode_; }
+    
     hipblasLtMatmulDesc_t get() const { return handle_.get(); }
 
    private:
     MatmulDesc(hipblasLtMatmulDesc_t handle, hipblasComputeType_t compute_type,
-               hipDataType datatype, bool bias_epilogue)
+               hipDataType datatype, bool bias_epilogue, bool mx_mode)
         : handle_(handle, wrap::hipblasLtMatmulDescDestroy),
           compute_type_(compute_type),
           datatype_(datatype),
-          has_bias_epilogue_(bias_epilogue) {}
+          has_bias_epilogue_(bias_epilogue),
+          mx_mode_(mx_mode) {}
 
     Owned<hipblasLtMatmulDesc_t> handle_;
     hipblasComputeType_t compute_type_;
     hipDataType datatype_;
     bool has_bias_epilogue_;
+    bool mx_mode_;
   };
 
   struct MatmulPlan : public gpu::BlasLt::MatmulPlan {

--- a/xla/stream_executor/rocm/hip_blas_utils.cc
+++ b/xla/stream_executor/rocm/hip_blas_utils.cc
@@ -37,10 +37,8 @@ hipDataType AsHipblasDataType(blas::DataType type) {
   switch (type) {
     case blas::DataType::kF8E4M3:
     case blas::DataType::kF8E3M4:
-    case blas::DataType::kF4E2M1FN:
     case blas::DataType::kF8E8M0FNU:
-      LOG(FATAL) << "hipblaslt does not support, F8E4M3, F8E3M4, F4E2M1FN and "
-                    "F8E8M0FNU";
+      LOG(FATAL) << "hipblaslt does not support F8E4M3, F8E3M4, and F8E8M0FNU";
 #if TF_ROCM_VERSION >= 60000
     case blas::DataType::kF8E5M2FNUZ:
       return HIP_R_8F_E5M2_FNUZ;
@@ -49,7 +47,7 @@ hipDataType AsHipblasDataType(blas::DataType type) {
 #else
     case blas::DataType::kF8E5M2FNUZ:
     case blas::DataType::kF8E4M3FNUZ:
-      LOG(FATAL) << "hipblaslt only supports nanoo F8 in ROCm 6.0 and above";
+      LOG(FATAL) << "hipblaslt only supports NANOO F8 in ROCm 6.0 and above";
 #endif
 #if TF_ROCM_VERSION >= 60300
     case blas::DataType::kF8E5M2:
@@ -60,6 +58,13 @@ hipDataType AsHipblasDataType(blas::DataType type) {
     case blas::DataType::kF8E5M2:
     case blas::DataType::kF8E4M3FN:
       LOG(FATAL) << "hipblaslt only supports OCP F8 in ROCm 6.3 and above";
+#endif
+#if TF_ROCM_VERSION >= 70000
+    case blas::DataType::kF4E2M1FN:
+      return static_cast<hipDataType>(HIP_R_4F_E2M1_EXT);
+#else
+    case blas::DataType::kF4E2M1FN:
+      LOG(FATAL) << "hipblaslt only supports FP4 in ROCm 7.0 and above";
 #endif
     case blas::DataType::kHalf:
       return HIP_R_16F;


### PR DESCRIPTION
In this PR, we support MX datatypes for the ROCm platform. While the CUDA path uses **cuDNN**,  ROCm implements MX datatypes through **hipBLASLt**.

### Key updates
* **BlockScalingRewriter**  
  * Rewrites `__op$block_scaled_dot` into an HLO graph that invokes the hipBLASLt custom call `__cublaslt$matmul$mx`.

* **CublasLtMatmulThunk**  
  * Extends the existing lowering stage so the new custom call is finally dispatched to a hipBLASLt kernel.

Note:
* `GemmAlgorithmPicker` isn't enabled for MX datatypes. We will support it in a separate PR.

### Reference

- https://arxiv.org/pdf/2310.10537
- https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
- https://github.com/openxla/xla/pull/21800
- https://github.com/openxla/xla/pull/22256
