### PR TITLE
include convolution tests as they failing only on rocm7

### DIFF
--- a/build_tools/rocm/run_xla.sh
+++ b/build_tools/rocm/run_xla.sh
@@ -95,6 +95,3 @@ bazel \
     -//xla/tests:conv_depthwise_backprop_filter_test_gpu_amd_any \
     -//xla/tests:dot_operation_test_autotune_disabled_gpu_amd_any \
     -//xla/service/gpu/tests:gpu_index_test_gpu_amd_any \
-    -//xla/tests:convolution_test_gpu_alternative_layout_gpu_amd_any \
-    -//xla/tests:convolution_test_gpu_amd_any \
-    


### PR DESCRIPTION
Convolution tests are failing ony on rocm 7 due to: https://ontrack-internal.amd.com/browse/LWPMIOPEN-1614