### PR TITLE
Disable gemm_rewriter_test_gpu_amd_any

### DIFF
--- a/build_tools/rocm/run_xla.sh
+++ b/build_tools/rocm/run_xla.sh
@@ -95,3 +95,4 @@ bazel \
     -//xla/tests:conv_depthwise_backprop_filter_test_gpu_amd_any \
     -//xla/tests:dot_operation_test_autotune_disabled_gpu_amd_any \
     -//xla/service/gpu/tests:gpu_index_test_gpu_amd_any \
+    -//xla/service/gpu/tests:gpu_kernel_tiling_test_gpu_amd_any


### PR DESCRIPTION
This test is green on rocm7 but fails on CI rocm6.4