### PR TITLE
[rocm-jaxlib-v0.6.0] Pass AMDGPU_TARGETS to crosstool wrapper

### DIFF
--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -717,9 +717,6 @@ def _create_local_rocm_repository(repository_ctx):
             "%{hip_runtime_library}": "amdhip64",
             "%{crosstool_verbose}": _crosstool_verbose(repository_ctx),
             "%{gcc_host_compiler_path}": str(cc),
-            "%{rocm_amdgpu_targets}": ",".join(
-                ["\"%s\"" % c for c in rocm_config.amdgpu_targets],
-            ),
         },
     )
 

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -717,6 +717,9 @@ def _create_local_rocm_repository(repository_ctx):
             "%{hip_runtime_library}": "amdhip64",
             "%{crosstool_verbose}": _crosstool_verbose(repository_ctx),
             "%{gcc_host_compiler_path}": str(cc),
+            "%{rocm_amdgpu_targets}": ",".join(
+                ["\"%s\"" % c for c in rocm_config.amdgpu_targets],
+            ),
         },
     )
 


### PR DESCRIPTION
The fix was originally upstreamed to XLA by @hsharsha in https://github.com/openxla/xla/pull/17544, but Copybara did not apply the changes correctly.

Without this, specifying `TF_ROCM_AMDGPU_TARGETS` has no effect (targets are not being passed), and the compiler tries to build for all targets by default.