### PR TITLE
[xla:pjrt] Fix deadlock in tracked device buffer

### DIFF
--- a/xla/pjrt/tracked_device_buffer.cc
+++ b/xla/pjrt/tracked_device_buffer.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/algorithm/container.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -61,7 +62,7 @@ void BufferSequencingEvent::SetSequencingEvent(EventPool::Handle event,
     streams_defined_on_.push_back(stream);
     sequence_number_.store(event_.sequence_number(), std::memory_order_seq_cst);
   }
-  this->ExecuteFutureTasks();
+  defined_status_.emplace(absl::OkStatus());
 }
 
 bool BufferSequencingEvent::EventHasBeenRecorded() const {
@@ -146,45 +147,21 @@ void BufferSequencingEvent::ExecuteOrAddToFutureTasks(
   tsl::profiler::TraceMeProducer producer(
       "BufferSequencingEvent::ExecuteOrAddToFutureTasks",
       tsl::profiler::ContextType::kPjRt);
-  uint64_t context_id = producer.GetContextId();
-  auto wrapped_task = [task = std::move(task), context_id]() {
+
+  auto traced_task = [task = std::move(task),
+                      context_id = producer.GetContextId()]() {
     tsl::profiler::TraceMeConsumer consumer("BufferSequencingEvent::Execute",
                                             tsl::profiler::ContextType::kPjRt,
                                             context_id);
     task();
   };
-  {
-    absl::MutexLock lock(&mu_);
-    if (!defined_status_.IsConcrete()) {
-      on_ready_tasks_callback_[task_name] = std::move(wrapped_task);
-      return;
-    }
-    // Release the lock to avoid deadlock, in the case where the
-    // thread_pool_->Schedule() executes wrapped_task inline.
-    // This is rare but could happen. The callbacks could potentially try to
-    // acquire the mutex of this BufferSequencingEvent.
-  }
-  thread_pool_->Schedule(std::move(wrapped_task));
-}
 
-void BufferSequencingEvent::ExecuteFutureTasks() {
-  absl::flat_hash_map<std::string, std::function<void()>>
-      on_ready_tasks_callback;
-  {
-    absl::MutexLock lock(&mu_);
-    on_ready_tasks_callback = std::move(on_ready_tasks_callback_);
-    // Release the lock to avoid deadlock, in the case where the
-    // thread_pool_->Schedule() executes call_all_task_callbacks inline.
-    // This is rare but could happen. The callbacks could potentially try to
-    // acquire the mutex of this BufferSequencingEvent.
-  }
-  auto call_all_task_callbacks = [on_ready_tasks_callback =
-                                      std::move(on_ready_tasks_callback)]() {
-    for (auto& [task_name, task_callback] : on_ready_tasks_callback) {
-      task_callback();
-    }
-  };
-  thread_pool_->Schedule(std::move(call_all_task_callbacks));
+  // Execute the `task` when definition event becomes available. If it's already
+  // available, the task will be executed immediately.
+  defined_status_.AndThen(
+      [this, traced_task = std::move(traced_task)]() mutable {
+        thread_pool_->Schedule(std::move(traced_task));
+      });
 }
 
 ShapedBuffer RawSEDeviceMemory::AsShapedBuffer(

--- a/xla/pjrt/tracked_device_buffer.h
+++ b/xla/pjrt/tracked_device_buffer.h
@@ -113,29 +113,15 @@ class BufferSequencingEvent {
   }
 
   // Executes the `task` if the event is ready; otherwise adds the `task`
-  // callback to `on_ready_tasks_callback_` that can not be executed until the
-  // the event is ready.
+  // callback to `defined_status_` async value, to be executed when it becomes
+  // available.
   void ExecuteOrAddToFutureTasks(const std::string& task_name,
                                  std::function<void()> task);
 
-  // Executes all the callbacks in `on_ready_tasks_callback_`. Those callbacks
-  // can only proceed until the event is ready.
-  void ExecuteFutureTasks();
-
-  bool IsDefined() {
-    absl::MutexLock lock(&mu_);
-    return IsDefinedNoLock();
-  }
-
-  bool IsDefinedNoLock() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  bool IsDefined() { return defined_status_.IsConcrete(); }
 
   void SetDefinedStatus(absl::Status status) {
-    {
-      absl::MutexLock lock(&mu_);
-      defined_status_.emplace(status);
-    }
-
-    this->ExecuteFutureTasks();
+    defined_status_.emplace(status);
   }
 
   absl::Status GetDefinedStatus() {
@@ -182,12 +168,6 @@ class BufferSequencingEvent {
   // A list of all streams for which the buffer's content is known to be defined
   // at the tail of the queue, i.e., for any newly enqueued command.
   absl::InlinedVector<se::Stream*, 2> streams_defined_on_ ABSL_GUARDED_BY(mu_);
-
-  // A map of the task name and callback to execute when the
-  // TrackedDeviceBuffer's `definition_events_` are all recorded and ready to be
-  // consumed by other tasks.
-  absl::flat_hash_map<std::string, std::function<void()>>
-      on_ready_tasks_callback_ ABSL_GUARDED_BY(mu_);
 
   tsl::thread::ThreadPool* thread_pool_;
 


### PR DESCRIPTION
Replace `on_ready_tasks_callback_` with `AndThen` callbacks on the `AsyncValueRef`. Previously we could have a race between setting `definition_status_` available and adding a callback, and miss executing a task that can lead to deadlock.

PiperOrigin-RevId: 754441327