### PR TITLE
Add Triton pingpong pass only for gfx942.

### DIFF
--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
@@ -124,7 +124,7 @@ absl::Status CreateTritonPipeline(mlir::OpPassManager* pm,
   if (cc.has_amd_matrix_core()) {
     pm->addPass(mt::gpu::createTritonGPUReorderInstructions());
   }
-  if (/*(use_block_pingpong == "none") ==*/true) {
+  if (cc.gfx_version() == "gfx942") {
     pm->addPass(mlir::createTritonAMDGPUBlockPingpongPass(num_stages));
   }
   if (/*use_buffer_ops=*/false) {  // Not enabled by default.


### PR DESCRIPTION
Corresponding runtime flag should be added too.