### PR TITLE
Revert "fix deadlock in tracked device buffer"

### DIFF
--- a/xla/pjrt/tracked_device_buffer.h
+++ b/xla/pjrt/tracked_device_buffer.h
@@ -113,15 +113,29 @@ class BufferSequencingEvent {
   }
 
   // Executes the `task` if the event is ready; otherwise adds the `task`
-  // callback to `defined_status_` async value, to be executed when it becomes
-  // available.
+  // callback to `on_ready_tasks_callback_` that can not be executed until the
+  // the event is ready.
   void ExecuteOrAddToFutureTasks(const std::string& task_name,
                                  std::function<void()> task);
 
-  bool IsDefined() { return defined_status_.IsConcrete(); }
+  // Executes all the callbacks in `on_ready_tasks_callback_`. Those callbacks
+  // can only proceed until the event is ready.
+  void ExecuteFutureTasks();
+
+  bool IsDefined() {
+    absl::MutexLock lock(&mu_);
+    return IsDefinedNoLock();
+  }
+
+  bool IsDefinedNoLock() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   void SetDefinedStatus(absl::Status status) {
-    defined_status_.emplace(status);
+    {
+      absl::MutexLock lock(&mu_);
+      defined_status_.emplace(status);
+    }
+
+    this->ExecuteFutureTasks();
   }
 
   absl::Status GetDefinedStatus() {
@@ -168,6 +182,12 @@ class BufferSequencingEvent {
   // A list of all streams for which the buffer's content is known to be defined
   // at the tail of the queue, i.e., for any newly enqueued command.
   absl::InlinedVector<se::Stream*, 2> streams_defined_on_ ABSL_GUARDED_BY(mu_);
+
+  // A map of the task name and callback to execute when the
+  // TrackedDeviceBuffer's `definition_events_` are all recorded and ready to be
+  // consumed by other tasks.
+  absl::flat_hash_map<std::string, std::function<void()>>
+      on_ready_tasks_callback_ ABSL_GUARDED_BY(mu_);
 
   tsl::thread::ThreadPool* thread_pool_;
 


### PR DESCRIPTION
Reverts ROCm/xla#284
It cherry-picked only https://github.com/openxla/xla/commit/8a838a92071ebd506036576824be50a120a5905e with wrong preceding fixes instead of the previous important change https://github.com/openxla/xla/commit/989ee52c2b1a9912a179e9f655a929c841bed505