### PR TITLE
PR #28936: clean device description for rocm

### DIFF
--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -71,9 +71,11 @@ class RocmComputeCapability {
 
   bool gfx9_mi200() const { return gfx_version() == "gfx90a"; }
 
-  bool gfx9_mi300_series() const {
-    return gfx_version() == "gfx942" || gfx_version() == "gfx950";
-  }
+  bool gfx9_mi300() const { return gfx_version() == "gfx942"; }
+
+  bool gfx9_mi350() const { return gfx_version() == "gfx950"; }
+
+  bool gfx9_mi300_series() const { return gfx9_mi300() || gfx9_mi350(); }
 
   bool gfx9_mi100_or_later() const {
     static constexpr absl::string_view kList[] = {"gfx908", "gfx90a", "gfx942",
@@ -127,9 +129,11 @@ class RocmComputeCapability {
     return has_ocp_fp8_support() || has_nanoo_fp8_support();
   }
 
-  bool has_ocp_fp8_support() const { return gfx1200() || gfx1201() || gfx_version() == "gfx950"; }
+  bool has_ocp_fp8_support() const {
+    return gfx1200() || gfx1201() || gfx9_mi350();
+  }
 
-  bool has_nanoo_fp8_support() const { return gfx_version() == "gfx942"; }
+  bool has_nanoo_fp8_support() const { return gfx9_mi300(); }
 
   std::string ToString() const { return gcn_arch_name(); }
 


### PR DESCRIPTION
Imported from GitHub PR https://github.com/openxla/xla/pull/28936

Some cleaning for ROCm device description.
Copybara import of the project:

--
d517ea51af98b9a9336ac6dd777b1530fce5494f by scxfjiang <xuefei.jiang@amd.com>:

clean device description for rocm

Merging this change closes #28936

COPYBARA_INTEGRATE_REVIEW=https://github.com/openxla/xla/pull/28936 from ROCm:ci_clean_device_description_rocm d517ea51af98b9a9336ac6dd777b1530fce5494f PiperOrigin-RevId: 788931132

(cherry picked from commit 9c1d0261771b20df4d336161968aa5f187e54c85)