### PR TITLE
Update rocprofiler-sdk (v3) along with roctracer (v1) for rocm-jaxlib-v0.6.0

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -217,11 +217,70 @@ tsl_gpu_library(
     ],
 )
 
-tsl_gpu_library(
+config_setting(
+    name = "use_v1",
+    values = {"define": "xla_rocm_profiler=v1"},
+)
+
+config_setting(
+    name = "use_rocprofiler_sdk",
+    values = {"define": "xla_rocm_profiler=v3"},
+)
+
+cc_library(
+    name = "rocm_profiler_backend_cfg",
+    defines = select({
+        ":use_v1": ["XLA_GPU_ROCM_TRACER_BACKEND=1"],
+        ":use_rocprofiler_sdk": ["XLA_GPU_ROCM_TRACER_BACKEND=3"],
+        "//conditions:default": ["XLA_GPU_ROCM_TRACER_BACKEND=3"],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+  name = "rocm_tracer_utils",
+  srcs = ["rocm_tracer_utils.cc"],
+  hdrs = ["rocm_tracer_utils.h"],
+  tags = [
+        "gpu",
+        "manual",
+        "rocm-only",
+    ],
+  linkopts = [
+    "-Wl,--no-as-needed",
+    "-L/opt/rocm/lib",
+    "-Wl,-rpath,/opt/rocm/lib",
+    "-lhsa-runtime64",
+  ],
+  deps = [
+    "//xla/tsl/profiler/backends/cpu:annotation_stack",
+    "//xla/tsl/profiler/utils:time_utils",
+    "//xla/tsl/profiler/utils:math_utils",
+    "@com_google_absl//absl/strings:string_view",
+    "@com_google_absl//absl/container:flat_hash_map",
+    "@com_google_absl//absl/container:flat_hash_set",
+    "@com_google_absl//absl/container:node_hash_map",
+    "@com_google_absl//absl/container:node_hash_set",
+    "@tsl//tsl/platform:env_time",
+    "@tsl//tsl/platform:env",
+    "@tsl//tsl/platform:errors",
+    "@tsl//tsl/platform:logging",
+    "@tsl//tsl/platform:macros",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "rocm_collector",
-    srcs = if_rocm(["rocm_collector.cc"]),
-    hdrs = if_rocm(["rocm_collector.h"]),
-    copts = tf_profiler_copts() + tsl_copts(),
+    srcs = ["rocm_collector.cc"],
+    hdrs = ["rocm_collector.h"],
+    # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
+    linkopts = select({
+        "//conditions:default": [
+            "-L/opt/rocm/lib",      # search path for all ROCm shared objects
+            "-lrocprofiler-sdk",    # the library that owns the missing symbols
+        ],
+    }),
     tags = [
         "gpu",
         "rocm-only",
@@ -229,8 +288,9 @@ tsl_gpu_library(
         # TODO(b/360374983): Remove this tag once the target can be built without --config=rocm.
         "manual",
     ]),
-    visibility = ["//visibility:public"],
     deps = [
+        ":rocm_tracer_utils",
+        ":rocm_profiler_backend_cfg",
         "//xla/stream_executor/rocm:roctracer_wrapper",
         "//xla/tsl/profiler/backends/cpu:annotation_stack",
         "//xla/tsl/profiler/utils:parse_annotation",
@@ -245,11 +305,11 @@ tsl_gpu_library(
         "@com_google_absl//absl/container:node_hash_set",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
         "@tsl//tsl/platform:abi",
         "@tsl//tsl/platform:env_time",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:macros",
-        "@tsl//tsl/platform:mutex",
         "@tsl//tsl/platform:status",
         "@tsl//tsl/platform:thread_annotations",
         "@tsl//tsl/platform:types",
@@ -258,38 +318,131 @@ tsl_gpu_library(
     ],
 )
 
-tsl_gpu_library(
-    name = "rocm_tracer",
-    srcs = if_rocm(["rocm_tracer.cc"]),
-    hdrs = if_rocm(["rocm_tracer.h"]),
-    copts = tf_profiler_copts() + tsl_copts(),
+cc_library(
+    name = "rocm_tracer_headers",
+    hdrs = [
+        "rocm_tracer.h",
+        "rocm_profiler_sdk.h",
+        "rocm_tracer_v1.h",
+    ],
     tags = [
         "gpu",
-        "rocm-only",
-    ] + if_google([
-        # TODO(b/360374983): Remove this tag once the target can be built without --config=rocm.
         "manual",
-    ]),
+        "rocm-only",
+    ],
+    # PROPAGATE the layout macro to every dependent TU:
+    defines = select({
+        ":use_v1": ["XLA_GPU_ROCM_TRACER_BACKEND=1"],
+        ":use_rocprofiler_sdk": ["XLA_GPU_ROCM_TRACER_BACKEND=3"],
+        "//conditions:default": ["XLA_GPU_ROCM_TRACER_BACKEND=3"],
+    }),
     visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "rocm_tracer_impl",
+    srcs = select({
+        ":use_v1": ["rocm_tracer_v1.cc"],
+        ":use_rocprofiler_sdk": ["rocm_profiler_sdk.cc"],
+        "//conditions:default": ["rocm_profiler_sdk.cc"],
+    }),
+    tags = [
+        "gpu",
+        "manual",
+        "rocm-only",
+    ],
     deps = [
+        ":rocm_tracer_headers",
         ":rocm_collector",
         "//xla/stream_executor/rocm:roctracer_wrapper",
         "//xla/tsl/profiler/backends/cpu:annotation_stack",
         "//xla/tsl/profiler/utils:time_utils",
+        "//xla/tsl/profiler/utils:xplane_builder",
+        "//xla/tsl/profiler/utils:xplane_schema",
+        "//xla/tsl/profiler/utils:xplane_utils",
+        "//xla/tsl/util:env_var",
         "@com_google_absl//absl/container:fixed_array",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:node_hash_map",
         "@com_google_absl//absl/container:node_hash_set",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/synchronization",
+        "@local_config_rocm//rocm:rocm_headers",
         "@tsl//tsl/platform:env",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:macros",
         "@tsl//tsl/platform:platform_port",
         "@tsl//tsl/platform:status",
+        "@tsl//tsl/platform:thread_annotations",
         "@tsl//tsl/platform:types",
+        "@tsl//tsl/profiler/lib:profiler_factory",
+        "@tsl//tsl/profiler/lib:profiler_interface",
     ],
+)
+
+cc_library(
+    name = "rocm_tracer",
+    tags = [
+        "gpu",
+        "manual",
+        "rocm-only",
+    ],
+    deps = [":rocm_tracer_headers", ":rocm_tracer_impl"],
+    visibility = ["//visibility:public"],
+)
+
+# upstream it's called xla_cc_test as no GPU involved.
+xla_test(
+    name = "rocm_tracer_test",
+    size = "small",
+    srcs = ["rocm_tracer_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ] + if_google([
+        # Optional: only run internally if ROCm config is enabled
+        "manual",
+    ]),
+    deps = [
+        ":rocm_tracer",
+        ":rocm_tracer_utils",
+        "//xla/tsl/profiler/utils:xplane_builder",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:status_matchers",
+        "@tsl//tsl/platform:test",
+        "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
+xla_test(    
+  name = "rocm_collector_test",
+  size = "small",
+  srcs = ["rocm_collector_test.cc"],
+  tags = [
+      "gpu",
+      "rocm-only",
+  ] + if_google([
+      "manual",
+  ]),
+  deps = [
+    # ":rocm_tracer",
+    ":rocm_collector",
+    ":rocm_tracer_utils",
+    "//xla/tsl/profiler/utils:xplane_builder",
+    "@com_google_absl//absl/container:flat_hash_map",
+    "@com_google_googletest//:gtest_main",
+    "@tsl//tsl/platform:env_time",
+    "@tsl//tsl/platform:status_matchers",
+    "@tsl//tsl/platform:test",
+    "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    "@tsl//tsl/platform:env",
+    "@tsl//tsl/platform:errors",
+    "@tsl//tsl/platform:logging",
+    "@tsl//tsl/platform:macros",
+  ],
 )
 
 tsl_gpu_library(

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -428,7 +428,6 @@ xla_test(
       "manual",
   ]),
   deps = [
-    # ":rocm_tracer",
     ":rocm_collector",
     ":rocm_tracer_utils",
     "//xla/tsl/profiler/utils:xplane_builder",

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -636,15 +636,15 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
 
     if (api_event == api_events_map_.end()) {
       api_event = auxiliary_api_events_map_.find(activity_event.correlation_id);
-    }
 
-    if (api_event == auxiliary_api_events_map_.end()) {
-      OnEventsDropped(
-          "An event from activity was discarded."
-          "Could not find the counterpart HIP API.",
-          activity_event.correlation_id);
-      PrintRocmTracerEvent(activity_event, ". Dropped!");
-      continue;
+      if (api_event == auxiliary_api_events_map_.end()) {
+        OnEventsDropped(
+            "An event from activity was discarded."
+            "Could not find the counterpart HIP API.",
+            activity_event.correlation_id);
+        PrintRocmTracerEvent(activity_event, ". Dropped!");
+        continue;
+      }
     }
 
     switch (activity_event.type) {

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -1,4 +1,3 @@
-
 /* Copyright 2024 The OpenXLA Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,22 +17,17 @@ limitations under the License.
 
 #include "absl/container/fixed_array.h"
 #include "absl/container/flat_hash_set.h"
-#include "absl/container/node_hash_map.h"
+
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include "xla/stream_executor/rocm/roctracer_wrapper.h"
+
 #include "xla/tsl/profiler/backends/cpu/annotation_stack.h"
-#include "xla/tsl/profiler/utils/parse_annotation.h"
-#include "xla/tsl/profiler/utils/xplane_builder.h"
-#include "xla/tsl/profiler/utils/xplane_schema.h"
-#include "xla/tsl/profiler/utils/xplane_utils.h"
 #include "xla/tsl/util/env_var.h"
 #include "tsl/platform/abi.h"
 #include "tsl/platform/env_time.h"
 #include "tsl/platform/errors.h"
 #include "tsl/platform/macros.h"
-#include "tsl/platform/mutex.h"
 #include "tsl/platform/status.h"
 #include "tsl/platform/thread_annotations.h"
 #include "tsl/platform/types.h"
@@ -43,10 +37,8 @@ limitations under the License.
 namespace xla {
 namespace profiler {
 
-namespace se = ::stream_executor;
 using tensorflow::ProfileOptions;
-using tsl::mutex;
-using tsl::mutex_lock;
+using tsl::Status;
 using tsl::profiler::Annotation;
 using tsl::profiler::AnnotationStack;
 using tsl::profiler::FindOrAddMutablePlaneWithName;
@@ -56,33 +48,13 @@ using tsl::profiler::kDeviceVendorAMD;
 using tsl::profiler::kThreadIdOverhead;
 using tsl::profiler::ParseAnnotationStack;
 using tsl::profiler::ProfilerInterface;
-// using tsl::profiler::RegisterProfilerFactory;
 using tsl::profiler::StatType;
+using tsl::profiler::XEvent;
 using tsl::profiler::XEventBuilder;
 using tsl::profiler::XEventMetadata;
 using tsl::profiler::XLineBuilder;
 using tsl::profiler::XPlaneBuilder;
 using tsl::profiler::XSpace;
-
-void AnnotationMap::Add(uint32_t correlation_id,
-                        const std::string& annotation) {
-  if (annotation.empty()) return;
-  VLOG(3) << "Add annotation: "
-          << " correlation_id=" << correlation_id
-          << ", annotation: " << annotation;
-  absl::MutexLock lock(&map_.mutex);
-  if (map_.annotations.size() < max_size_) {
-    absl::string_view annotation_str =
-        *map_.annotations.insert(annotation).first;
-    map_.correlation_map.emplace(correlation_id, annotation_str);
-  }
-}
-
-absl::string_view AnnotationMap::LookUp(uint32_t correlation_id) {
-  absl::MutexLock lock(&map_.mutex);
-  auto it = map_.correlation_map.find(correlation_id);
-  return it != map_.correlation_map.end() ? it->second : absl::string_view();
-}
 
 //==========
 namespace {
@@ -110,18 +82,17 @@ std::string GetDeviceXLineName(
   return absl::StrCat(line_name, "(", absl::StrJoin(type_names, ","), ")");
 }
 
-}  // namespace
-
-static void DumpRocmTracerEvent(const RocmTracerEvent& event,
-                                uint64_t start_walltime_ns,
-                                uint64_t start_gputime_ns,
-                                const std::string& message) {
+void PrintRocmTracerEvent(const RocmTracerEvent& event,
+                          absl::string_view message = {},
+                          uint64_t start_walltime_ns = 0,
+                          uint64_t start_gputime_ns = 0) {
   std::ostringstream oss;
   oss << "correlation_id=" << event.correlation_id;
   oss << ",type=" << GetRocmTracerEventTypeName(event.type);
   oss << ",source=" << GetRocmTracerEventSourceName(event.source);
   oss << ",domain=" << GetRocmTracerEventDomainName(event.domain);
   oss << ",name=" << event.name;
+  oss << ",corr_id=" << event.correlation_id;
   oss << ",annotation=" << event.annotation;
   oss << ",start_time_us="
       << (start_walltime_ns + (start_gputime_ns - event.start_time_ns)) / 1000;
@@ -136,7 +107,6 @@ static void DumpRocmTracerEvent(const RocmTracerEvent& event,
     case RocmTracerEventType::MemcpyD2H:
     case RocmTracerEventType::MemcpyH2D:
     case RocmTracerEventType::MemcpyD2D:
-    case RocmTracerEventType::MemcpyP2P:
       oss << ",num_bytes=" << event.memcpy_info.num_bytes;
       oss << ",destination=" << event.memcpy_info.destination;
       oss << ",async=" << event.memcpy_info.async;
@@ -154,10 +124,11 @@ static void DumpRocmTracerEvent(const RocmTracerEvent& event,
       DCHECK(false);
       break;
   }
-  oss << message;
-  VLOG(3) << oss.str();
+  VLOG(3) << oss.str() << ' ' << message;
 }
 
+#if defined(XLA_GPU_ROCM_TRACER_BACKEND) && (XLA_GPU_ROCM_TRACER_BACKEND == 1)
+namespace se = ::stream_executor;
 static uint64_t get_timestamp() {
   uint64_t ts;
   if (se::wrap::roctracer_get_timestamp(&ts) != ROCTRACER_STATUS_SUCCESS) {
@@ -169,527 +140,411 @@ static uint64_t get_timestamp() {
   }
   return ts;
 }
+#else
+uint64_t get_timestamp() {
+  uint64_t ts;
+  rocprofiler_status_t CHECKSTATUS = rocprofiler_get_timestamp(&ts);
+  if (CHECKSTATUS != ROCPROFILER_STATUS_SUCCESS) {
+    const char* errstr = rocprofiler_get_status_string(CHECKSTATUS);
+    LOG(ERROR) << "function rocprofiler_get_timestamp failed with error "
+               << errstr;
+    return 0;
+  }
+  return ts;
+}
+#endif
 
-struct RocmDeviceOccupancyParams {
-  hipFuncAttributes attributes = {};
-  int block_size = 0;
-  size_t dynamic_smem_size = 0;
-  void* func_ptr;
+}  // namespace
 
-  friend bool operator==(const RocmDeviceOccupancyParams& lhs,
-                         const RocmDeviceOccupancyParams& rhs) {
-    return 0 == memcmp(&lhs, &rhs, sizeof(lhs));
+OccupancyStats PerDeviceCollector::GetOccupancy(
+    const RocmDeviceOccupancyParams& params) const {
+  // TODO(rocm-profiler): hipOccupancyMaxActiveBlocksPerMultiprocessor only
+  // return hipSuccess for HIP_API_ID_hipLaunchKernel
+  OccupancyStats stats;
+  int number_of_active_blocks;
+  hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &number_of_active_blocks, params.func_ptr, params.block_size,
+      params.dynamic_smem_size);
+
+  if (err != hipError_t::hipSuccess) {
+    return {};
   }
 
-  template <typename H>
-  friend H AbslHashValue(H hash_state,
-                         const RocmDeviceOccupancyParams& params) {
-    return H::combine(
-        std::move(hash_state), params.attributes.maxThreadsPerBlock,
-        params.attributes.numRegs, params.attributes.sharedSizeBytes,
-        params.attributes.maxDynamicSharedSizeBytes, params.block_size,
-        params.dynamic_smem_size, params.func_ptr);
-  }
-};
+  stats.occupancy_pct = number_of_active_blocks * params.block_size * 100;
+  stats.occupancy_pct /= device_properties_.maxThreadsPerMultiProcessor;
 
-struct OccupancyStats {
-  double occupancy_pct = 0.0;
-  int min_grid_size = 0;
-  int suggested_block_size = 0;
-};
+  err = hipOccupancyMaxPotentialBlockSize(
+      &stats.min_grid_size, &stats.suggested_block_size,
+      static_cast<const void*>(params.func_ptr), params.dynamic_smem_size, 0);
 
-struct CorrelationInfo {
-  CorrelationInfo(uint32_t t, uint32_t e) : thread_id(t), enqueue_time_ns(e) {}
-  uint32_t thread_id;
-  uint64_t enqueue_time_ns;
-};
-
-class PerDeviceCollector {
- private:
-  OccupancyStats GetOccupancy(const RocmDeviceOccupancyParams& params) const {
-    // TODO(rocm-profiler): hipOccupancyMaxActiveBlocksPerMultiprocessor only
-    // return hipSuccess for HIP_API_ID_hipLaunchKernel
-
-    OccupancyStats stats;
-    int number_of_active_blocks;
-    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
-        &number_of_active_blocks, params.func_ptr, params.block_size,
-        params.dynamic_smem_size);
-
-    if (err != hipError_t::hipSuccess) {
-      return {};
-    }
-
-    stats.occupancy_pct = number_of_active_blocks * params.block_size * 100;
-    stats.occupancy_pct /= device_properties_.maxThreadsPerMultiProcessor;
-
-    err = hipOccupancyMaxPotentialBlockSize(
-        &stats.min_grid_size, &stats.suggested_block_size,
-        static_cast<const void*>(params.func_ptr), params.dynamic_smem_size, 0);
-
-    if (err != hipError_t::hipSuccess) {
-      return {};
-    }
-
-    return stats;
+  if (err != hipError_t::hipSuccess) {
+    return {};
   }
 
-  void CreateXEvent(const RocmTracerEvent& event, XPlaneBuilder* plane,
-                    uint64_t start_gpu_ns, uint64_t end_gpu_ns,
-                    XLineBuilder* line) {
-    if (event.start_time_ns < start_gpu_ns || event.end_time_ns > end_gpu_ns ||
-        event.start_time_ns > event.end_time_ns) {
-      VLOG(2) << "events have abnormal timestamps:" << event.name
-              << " start time(ns): " << event.start_time_ns
-              << " end time(ns): " << event.end_time_ns
-              << " start gpu(ns):" << start_gpu_ns
-              << " end gpu(ns):" << end_gpu_ns
-              << " corr. id:" << event.correlation_id;
-      return;
-    }
-    std::string kernel_name = tsl::port::MaybeAbiDemangle(event.name.c_str());
-    if (kernel_name.empty()) {
-      kernel_name = GetRocmTracerEventTypeName(event.type);
-    }
-    XEventMetadata* event_metadata =
-        plane->GetOrCreateEventMetadata(std::move(kernel_name));
-    XEventBuilder xevent = line->AddEvent(*event_metadata);
-    VLOG(7) << "Adding event to line=" << line->Id();
-    xevent.SetTimestampNs(event.start_time_ns);
-    xevent.SetEndTimestampNs(event.end_time_ns);
-    if (event.source == RocmTracerEventSource::ApiCallback) {
-      xevent.AddStatValue(
-          *plane->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kDeviceId)),
-          event.device_id);
-    }
-    if (event.correlation_id != RocmTracerEvent::kInvalidCorrelationId) {
-      xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
-                              GetStatTypeStr(StatType::kCorrelationId)),
-                          event.correlation_id);
-    }
-    if (!event.roctx_range.empty()) {
-      xevent.AddStatValue(
-          *plane->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kNVTXRange)),
-          *plane->GetOrCreateStatMetadata(event.roctx_range));
-    }
+  return stats;
+}
 
-    if (event.type == RocmTracerEventType::Kernel &&
-        event.source == RocmTracerEventSource::Activity) {
-      RocmDeviceOccupancyParams params{};
-      params.attributes.maxThreadsPerBlock = INT_MAX;
-      params.attributes.numRegs =
-          static_cast<int>(event.kernel_info.registers_per_thread);
-      params.attributes.sharedSizeBytes =
-          event.kernel_info.static_shared_memory_usage;
-      // params.attributes.partitionedGCConfig = PARTITIONED_GC_OFF;
-      // params.attributes.shmemLimitConfig = FUNC_SHMEM_LIMIT_DEFAULT;
-      params.attributes.maxDynamicSharedSizeBytes = 0;
-      params.block_size = static_cast<int>(event.kernel_info.block_x *
-                                           event.kernel_info.block_y *
-                                           event.kernel_info.block_z);
+void PerDeviceCollector::CreateXEvent(const RocmTracerEvent& event,
+                                      XPlaneBuilder* plane,
+                                      uint64_t start_gpu_ns,
+                                      uint64_t end_gpu_ns, XLineBuilder* line) {
+  if (event.start_time_ns < start_gpu_ns || event.end_time_ns > end_gpu_ns ||
+      event.start_time_ns > event.end_time_ns) {
+    VLOG(2) << "events have abnormal timestamps:" << event.name
+            << " start time(ns): " << event.start_time_ns
+            << " end time(ns): " << event.end_time_ns
+            << " start gpu(ns):" << start_gpu_ns
+            << " end gpu(ns):" << end_gpu_ns
+            << " corr. id:" << event.correlation_id;
+    return;
+  }
+  std::string kernel_name = tsl::port::MaybeAbiDemangle(event.name.c_str());
+  if (kernel_name.empty()) {
+    kernel_name = GetRocmTracerEventTypeName(event.type);
+  }
+  XEventMetadata* event_metadata =
+      plane->GetOrCreateEventMetadata(std::move(kernel_name));
+  XEventBuilder xevent = line->AddEvent(*event_metadata);
+  VLOG(7) << "Adding event to line=" << line->Id();
+  xevent.SetTimestampNs(event.start_time_ns);
+  xevent.SetEndTimestampNs(event.end_time_ns);
+  if (event.source == RocmTracerEventSource::ApiCallback) {
+    xevent.AddStatValue(
+        *plane->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kDeviceId)),
+        event.device_id);
+  }
+  if (event.correlation_id != RocmTracerEvent::kInvalidCorrelationId) {
+    xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
+                            GetStatTypeStr(StatType::kCorrelationId)),
+                        event.correlation_id);
+  }
+  if (!event.roctx_range.empty()) {
+    xevent.AddStatValue(
+        *plane->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kNVTXRange)),
+        *plane->GetOrCreateStatMetadata(event.roctx_range));
+  }
 
-      params.dynamic_smem_size = event.kernel_info.dynamic_shared_memory_usage;
-      params.func_ptr = event.kernel_info.func_ptr;
+  if (event.type == RocmTracerEventType::Kernel &&
+      event.source == RocmTracerEventSource::Activity) {
+    RocmDeviceOccupancyParams params{};
+    params.attributes.maxThreadsPerBlock = INT_MAX;
+    params.attributes.numRegs =
+        static_cast<int>(event.kernel_info.registers_per_thread);
+    params.attributes.sharedSizeBytes =
+        event.kernel_info.static_shared_memory_usage;
+    // params.attributes.partitionedGCConfig = PARTITIONED_GC_OFF;
+    // params.attributes.shmemLimitConfig = FUNC_SHMEM_LIMIT_DEFAULT;
+    params.attributes.maxDynamicSharedSizeBytes = 0;
+    params.block_size =
+        static_cast<int>(event.kernel_info.block_x * event.kernel_info.block_y *
+                         event.kernel_info.block_z);
 
-      OccupancyStats& occ_stats = occupancy_cache_[params];
-      if (occ_stats.occupancy_pct == 0.0) {
-        occ_stats = GetOccupancy(params);
-      }
-      xevent.AddStatValue(*plane->GetOrCreateStatMetadata(GetStatTypeStr(
-                              StatType::kTheoreticalOccupancyPct)),
-                          occ_stats.occupancy_pct);
-      xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
-                              GetStatTypeStr(StatType::kOccupancyMinGridSize)),
-                          static_cast<tsl::int32>(occ_stats.min_grid_size));
-      xevent.AddStatValue(
-          *plane->GetOrCreateStatMetadata(
-              GetStatTypeStr(StatType::kOccupancySuggestedBlockSize)),
-          static_cast<tsl::int32>(occ_stats.suggested_block_size));
-      xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
-                              GetStatTypeStr(StatType::kKernelDetails)),
-                          *plane->GetOrCreateStatMetadata(ToXStat(
-                              event.kernel_info, occ_stats.occupancy_pct)));
-    } else if (event.type == RocmTracerEventType::MemcpyH2D ||
-               event.type == RocmTracerEventType::MemcpyD2H ||
-               event.type == RocmTracerEventType::MemcpyD2D ||
-               event.type == RocmTracerEventType::MemcpyP2P ||
-               event.type == RocmTracerEventType::MemcpyOther) {
-      VLOG(7) << "Add Memcpy stat";
-      const auto& memcpy_info = event.memcpy_info;
-      std::string memcpy_details = absl::StrCat(
-          // TODO(rocm-profiler): we need to discover the memory kind similar
-          // to CUDA
-          "kind:", "Unknown", " size:", memcpy_info.num_bytes,
-          " dest:", memcpy_info.destination, " async:", memcpy_info.async);
-      xevent.AddStatValue(
-          *plane->GetOrCreateStatMetadata(
-              GetStatTypeStr(StatType::kMemcpyDetails)),
-          *plane->GetOrCreateStatMetadata(std::move(memcpy_details)));
-    } else if (event.type == RocmTracerEventType::MemoryAlloc) {
-      VLOG(7) << "Add MemAlloc stat";
-      std::string value =
-          // TODO(rocm-profiler): we need to discover the memory kind similar
-          // to CUDA
-          absl::StrCat("kind:", "Unknown",
-                       " num_bytes:", event.memalloc_info.num_bytes);
-      xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
-                              GetStatTypeStr(StatType::kMemallocDetails)),
-                          *plane->GetOrCreateStatMetadata(std::move(value)));
-    } else if (event.type == RocmTracerEventType::MemoryFree) {
-      VLOG(7) << "Add MemFree stat";
-      std::string value =
-          // TODO(rocm-profiler): we need to discover the memory kind similar
-          // to CUDA
-          absl::StrCat("kind:", "Unknown",
-                       " num_bytes:", event.memalloc_info.num_bytes);
-      xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
-                              GetStatTypeStr(StatType::kMemFreeDetails)),
-                          *plane->GetOrCreateStatMetadata(std::move(value)));
-    } else if (event.type == RocmTracerEventType::Memset) {
-      VLOG(7) << "Add Memset stat";
-      auto value =
-          // TODO(rocm-profiler): we need to discover the memory kind similar
-          // to CUDA
-          absl::StrCat("kind:", "Unknown",
-                       " num_bytes:", event.memset_info.num_bytes,
-                       " async:", event.memset_info.async);
-      xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
-                              GetStatTypeStr(StatType::kMemsetDetails)),
-                          *plane->GetOrCreateStatMetadata(std::move(value)));
-    }
-    // TODO(rocm-profiler): we need to support the following event type
-    /* else if (event.type == CuptiTracerEventType::MemoryResidency) {
-      VLOG(7) << "Add MemoryResidency stat";
-      std::string value = absl::StrCat(
-          "kind:", GetMemoryKindName(event.memory_residency_info.kind),
-          " num_bytes:", event.memory_residency_info.num_bytes,
-          " addr:", event.memory_residency_info.address);
-      xevent.AddStatValue(*plane->GetOrCreateStatMetadata(GetStatTypeStr(
-                              StatType::kMemoryResidencyDetails)),
-                          *plane->GetOrCreateStatMetadata(std::move(value)));
-    } */
+    params.dynamic_smem_size = event.kernel_info.dynamic_shared_memory_usage;
+    params.func_ptr = event.kernel_info.func_ptr;
+  } else if (event.type == RocmTracerEventType::MemcpyH2D ||
+             event.type == RocmTracerEventType::MemcpyD2H ||
+             event.type == RocmTracerEventType::MemcpyD2D ||
+             event.type == RocmTracerEventType::MemcpyOther) {
+    VLOG(7) << "Add Memcpy stat";
+    const auto& memcpy_info = event.memcpy_info;
+    std::string memcpy_details = absl::StrCat(
+        // TODO(rocm-profiler): we need to discover the memory kind similar
+        // to CUDA
+        "kind:", "Unknown", " size:", memcpy_info.num_bytes,
+        " dest:", memcpy_info.destination, " async:", memcpy_info.async);
+    xevent.AddStatValue(
+        *plane->GetOrCreateStatMetadata(
+            GetStatTypeStr(StatType::kMemcpyDetails)),
+        *plane->GetOrCreateStatMetadata(std::move(memcpy_details)));
+  } else if (event.type == RocmTracerEventType::MemoryAlloc) {
+    VLOG(7) << "Add MemAlloc stat";
+    std::string value =
+        // TODO(rocm-profiler): we need to discover the memory kind similar
+        // to CUDA
+        absl::StrCat("kind:", "Unknown",
+                     " num_bytes:", event.memalloc_info.num_bytes);
+    xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
+                            GetStatTypeStr(StatType::kMemallocDetails)),
+                        *plane->GetOrCreateStatMetadata(std::move(value)));
+  } else if (event.type == RocmTracerEventType::MemoryFree) {
+    VLOG(7) << "Add MemFree stat";
+    std::string value =
+        // TODO(rocm-profiler): we need to discover the memory kind similar
+        // to CUDA
+        absl::StrCat("kind:", "Unknown",
+                     " num_bytes:", event.memalloc_info.num_bytes);
+    xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
+                            GetStatTypeStr(StatType::kMemFreeDetails)),
+                        *plane->GetOrCreateStatMetadata(std::move(value)));
+  } else if (event.type == RocmTracerEventType::Memset) {
+    VLOG(7) << "Add Memset stat";
+    auto value =
+        // TODO(rocm-profiler): we need to discover the memory kind similar
+        // to CUDA
+        absl::StrCat("kind:", "Unknown",
+                     " num_bytes:", event.memset_info.num_bytes,
+                     " async:", event.memset_info.async);
+    xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
+                            GetStatTypeStr(StatType::kMemsetDetails)),
+                        *plane->GetOrCreateStatMetadata(std::move(value)));
+  }
+  // TODO(rocm-profiler): we need to support the following event type
+  /* else if (event.type == CuptiTracerEventType::MemoryResidency) {
+    VLOG(7) << "Add MemoryResidency stat";
+    std::string value = absl::StrCat(
+        "kind:", GetMemoryKindName(event.memory_residency_info.kind),
+        " num_bytes:", event.memory_residency_info.num_bytes,
+        " addr:", event.memory_residency_info.address);
+    xevent.AddStatValue(*plane->GetOrCreateStatMetadata(GetStatTypeStr(
+                            StatType::kMemoryResidencyDetails)),
+                        *plane->GetOrCreateStatMetadata(std::move(value)));
+  } */
 
-    std::vector<Annotation> annotation_stack =
-        ParseAnnotationStack(event.annotation);
-    if (!annotation_stack.empty()) {
-      xevent.AddStatValue(
-          *plane->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kTfOp)),
-          *plane->GetOrCreateStatMetadata(annotation_stack.begin()->name));
-    }
-    // If multiple metadata have the same key name, show the values from the
-    // top of the stack (innermost annotation). Concatenate the values from
-    // "hlo_op".
-    absl::flat_hash_set<absl::string_view> key_set;
+  std::vector<Annotation> annotation_stack =
+      ParseAnnotationStack(event.annotation);
+  if (!annotation_stack.empty()) {
+    xevent.AddStatValue(
+        *plane->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kTfOp)),
+        *plane->GetOrCreateStatMetadata(annotation_stack.begin()->name));
+  }
+  // If multiple metadata have the same key name, show the values from the
+  // top of the stack (innermost annotation). Concatenate the values from
+  // "hlo_op".
+  absl::flat_hash_set<absl::string_view> key_set;
 
-    for (auto annotation = annotation_stack.rbegin();
-         annotation != annotation_stack.rend(); ++annotation) {
-      for (const Annotation::Metadata& metadata : annotation->metadata) {
-        if (key_set.insert(metadata.key).second) {
-          xevent.ParseAndAddStatValue(
-              *plane->GetOrCreateStatMetadata(metadata.key), metadata.value);
-        }
+  for (auto annotation = annotation_stack.rbegin();
+       annotation != annotation_stack.rend(); ++annotation) {
+    for (const Annotation::Metadata& metadata : annotation->metadata) {
+      if (key_set.insert(metadata.key).second) {
+        xevent.ParseAndAddStatValue(
+            *plane->GetOrCreateStatMetadata(metadata.key), metadata.value);
       }
     }
   }
+}
 
-  void SortByStartTime() {
-    mutex_lock lock(events_mutex);
-    std::sort(events.begin(), events.end(),
-              [](const RocmTracerEvent& event1, const RocmTracerEvent& event2) {
-                return event1.start_time_ns < event2.start_time_ns;
-              });
+void PerDeviceCollector::SortByStartTime() {
+  absl::MutexLock lock(&events_mutex_);
+  std::sort(events_.begin(), events_.end(),
+            [](const RocmTracerEvent& event1, const RocmTracerEvent& event2) {
+              return event1.start_time_ns < event2.start_time_ns;
+            });
+}
+
+bool PerDeviceCollector::IsHostEvent(const RocmTracerEvent& event,
+                                     tsl::int64* line_id) {
+  // DriverCallback(i.e. kernel launching) events are host events.
+  if (event.source == RocmTracerEventSource::ApiCallback) {
+    *line_id = event.thread_id;
+    return true;
+  } else {  // activities
+    *line_id = event.stream_id;
+    return false;
   }
 
-  bool IsHostEvent(const RocmTracerEvent& event, tsl::int64* line_id) {
-    // DriverCallback(i.e. kernel launching) events are host events.
-    if (event.source == RocmTracerEventSource::ApiCallback) {
-      *line_id = event.thread_id;
-      return true;
-    } else {  // activities
-      *line_id = event.stream_id;
-      return false;
-    }
+  // TODO(rocm-profiler): do we have such a report in rocm?
+  // Non-overhead activity events are device events.
+  /* if (event.type != CuptiTracerEventType::Overhead) {
+    *line_id = event.stream_id;
+    return false;
+  } */
+  // Overhead events can be associated with a thread or a stream, etc.
+  // If a valid thread id is specified, we consider it as a host event.
+  //
 
-    // TODO(rocm-profiler): do we have such a report in rocm?
-    // Non-overhead activity events are device events.
-    /* if (event.type != CuptiTracerEventType::Overhead) {
-      *line_id = event.stream_id;
-      return false;
-    } */
-    // Overhead events can be associated with a thread or a stream, etc.
-    // If a valid thread id is specified, we consider it as a host event.
-    //
+  if (event.stream_id != RocmTracerEvent::kInvalidStreamId) {
+    *line_id = event.stream_id;
+    return false;
+  } else if (event.thread_id != RocmTracerEvent::kInvalidThreadId &&
+             event.thread_id != 0) {
+    *line_id = event.thread_id;
+    return true;
+  } else {
+    *line_id = tsl::profiler::kThreadIdOverhead;
+    return false;
+  }
+}
 
-    if (event.stream_id != RocmTracerEvent::kInvalidStreamId) {
-      *line_id = event.stream_id;
-      return false;
-    } else if (event.thread_id != RocmTracerEvent::kInvalidThreadId &&
-               event.thread_id != 0) {
-      *line_id = event.thread_id;
-      return true;
-    } else {
-      *line_id = tsl::profiler::kThreadIdOverhead;
-      return false;
+void PerDeviceCollector::Export(uint64_t start_walltime_ns,
+                                uint64_t start_gputime_ns,
+                                uint64_t end_gputime_ns,
+                                XPlaneBuilder* device_plane,
+                                XPlaneBuilder* host_plane) {
+  int host_ev_cnt = 0, dev_ev_cnt = 0;
+  absl::MutexLock lock(&events_mutex_);
+  // Tracking event types per line.
+  absl::flat_hash_map<tsl::int64, absl::flat_hash_set<RocmTracerEventType>>
+      events_types_per_line;
+
+  for (const RocmTracerEvent& event : events_) {
+    int64_t line_id = RocmTracerEvent::kInvalidThreadId;
+    bool is_host_event = IsHostEvent(event, &line_id);
+
+    if (is_host_event)
+      host_ev_cnt++;
+    else
+      dev_ev_cnt++;
+
+    if (line_id == RocmTracerEvent::kInvalidThreadId ||
+        line_id == RocmTracerEvent::kInvalidStreamId) {
+      VLOG(3) << "Ignoring event, type=" << static_cast<int>(event.type);
+      continue;
     }
+    auto* plane = is_host_event ? host_plane : device_plane;
+    VLOG(9) << "Event" << " type=" << static_cast<int>(event.type)
+            << " line_id=" << line_id
+            << (is_host_event ? " host plane=" : " device plane=")
+            << plane->Name();
+
+    XLineBuilder line = plane->GetOrCreateLine(line_id);
+    line.SetTimestampNs(start_gputime_ns);
+    CreateXEvent(event, plane, start_gputime_ns, end_gputime_ns, &line);
   }
 
- public:
-  void Export(uint64_t start_walltime_ns, uint64_t start_gputime_ns,
-              uint64_t end_gputime_ns, XPlaneBuilder* device_plane,
-              XPlaneBuilder* host_plane) {
-    int host_ev_cnt = 0, dev_ev_cnt = 0;
-    mutex_lock l(events_mutex);
-    // Tracking event types per line.
-    absl::flat_hash_map<tsl::int64, absl::flat_hash_set<RocmTracerEventType>>
-        events_types_per_line;
-    for (const RocmTracerEvent& event : events) {
-      int64_t line_id = RocmTracerEvent::kInvalidThreadId;
-      bool is_host_event = IsHostEvent(event, &line_id);
+  device_plane->ForEachLine([&](XLineBuilder line) {
+    line.SetName(
+        GetDeviceXLineName(line.Id(), events_types_per_line[line.Id()]));
+  });
+  host_plane->ForEachLine([&](XLineBuilder line) {
+    line.SetName(absl::StrCat("Host Threads/", line.Id()));
+  });
+  events_.clear();
+}
 
-      if (is_host_event) {
-        host_ev_cnt++;
-      } else {
-        dev_ev_cnt++;
-      }
+void PerDeviceCollector::AddEvent(RocmTracerEvent&& event) {
+  absl::MutexLock lock(&events_mutex_);
+  events_.emplace_back(std::move(event));
+}
 
-      if (line_id == RocmTracerEvent::kInvalidThreadId ||
-          line_id == RocmTracerEvent::kInvalidStreamId) {
-        VLOG(3) << "Ignoring event, type=" << static_cast<int>(event.type);
-        continue;
-      }
-      auto* plane = is_host_event ? host_plane : device_plane;
-      VLOG(9) << "Event"
-              << " type=" << static_cast<int>(event.type)
-              << " line_id=" << line_id
-              << (is_host_event ? " host plane=" : " device plane=")
-              << plane->Name();
-      XLineBuilder line = plane->GetOrCreateLine(line_id);
-      line.SetTimestampNs(start_gputime_ns);
-      CreateXEvent(event, plane, start_gputime_ns, end_gputime_ns, &line);
-      events_types_per_line[line_id].emplace(event.type);
-    }
-    device_plane->ForEachLine([&](XLineBuilder line) {
-      line.SetName(
-          GetDeviceXLineName(line.Id(), events_types_per_line[line.Id()]));
-    });
-    host_plane->ForEachLine([&](XLineBuilder line) {
-      line.SetName(absl::StrCat("Host Threads/", line.Id()));
-    });
-    events.clear();
+void PerDeviceCollector::GetDeviceCapabilities(int32_t device_ordinal,
+                                               XPlaneBuilder* device_plane) {
+  device_plane->AddStatValue(*device_plane->GetOrCreateStatMetadata(
+                                 GetStatTypeStr(StatType::kDevVendor)),
+                             kDeviceVendorAMD);
+
+  if (hipGetDeviceProperties(&device_properties_, device_ordinal) != hipSuccess)
+    return;
+
+  auto clock_rate_in_khz = device_properties_.clockRate;  // this is also in Khz
+  if (clock_rate_in_khz) {
+    device_plane->AddStatValue(
+        *device_plane->GetOrCreateStatMetadata(
+            GetStatTypeStr(StatType::kDevCapClockRateKHz)),
+        clock_rate_in_khz);
   }
 
-  PerDeviceCollector() = default;
-
-  void AddEvent(const RocmTracerEvent& event) {
-    mutex_lock l(events_mutex);
-    if (event.source == RocmTracerEventSource::ApiCallback) {
-      // Cupti api callback events were used to populate launch times etc.
-      if (event.correlation_id != RocmTracerEvent::kInvalidCorrelationId) {
-        correlation_info_.insert(
-            {event.correlation_id,
-             CorrelationInfo(event.thread_id, event.start_time_ns)});
-      }
-      events.emplace_back(std::move(event));
-    } else {
-      // Cupti activity events measure device times etc.
-      events.emplace_back(std::move(event));
-    }
-  }
-
-  void GetDeviceCapabilities(int32_t device_ordinal,
-                             XPlaneBuilder* device_plane) {
+  auto core_count = device_properties_.multiProcessorCount;
+  if (core_count) {
     device_plane->AddStatValue(*device_plane->GetOrCreateStatMetadata(
-                                   GetStatTypeStr(StatType::kDevVendor)),
-                               kDeviceVendorAMD);
-
-    if (hipGetDeviceProperties(&device_properties_, device_ordinal) !=
-        hipSuccess)
-      return;
-
-    auto clock_rate_in_khz =
-        device_properties_.clockRate;  // this is also in Khz
-    if (clock_rate_in_khz) {
-      device_plane->AddStatValue(
-          *device_plane->GetOrCreateStatMetadata(
-              GetStatTypeStr(StatType::kDevCapClockRateKHz)),
-          clock_rate_in_khz);
-    }
-
-    auto core_count = device_properties_.multiProcessorCount;
-    if (core_count) {
-      device_plane->AddStatValue(
-          *device_plane->GetOrCreateStatMetadata(
-              GetStatTypeStr(StatType::kDevCapCoreCount)),
-          core_count);
-    }
-
-    auto mem_clock_khz = device_properties_.memoryClockRate;
-    auto mem_bus_width_bits = device_properties_.memoryBusWidth;
-
-    if (mem_clock_khz && mem_bus_width_bits) {
-      // Times 2 because HBM is DDR memory; it gets two data bits per each
-      // data lane.
-      auto memory_bandwidth =
-          uint64_t{2} * (mem_clock_khz) * 1000 * (mem_bus_width_bits) / 8;
-      device_plane->AddStatValue(
-          *device_plane->GetOrCreateStatMetadata(
-              GetStatTypeStr(StatType::kDevCapMemoryBandwidth)),
-          memory_bandwidth);
-    }
-
-    size_t total_memory = device_properties_.totalGlobalMem;
-    if (total_memory) {
-      device_plane->AddStatValue(
-          *device_plane->GetOrCreateStatMetadata(
-              GetStatTypeStr(StatType::kDevCapMemorySize)),
-          static_cast<uint64_t>(total_memory));
-    }
-
-    auto compute_capability_major = device_properties_.major;
-    if (compute_capability_major) {
-      device_plane->AddStatValue(
-          *device_plane->GetOrCreateStatMetadata(
-              GetStatTypeStr(StatType::kDevCapComputeCapMajor)),
-          compute_capability_major);
-    }
-    auto compute_capability_minor = device_properties_.minor;
-    if (compute_capability_minor) {
-      device_plane->AddStatValue(
-          *device_plane->GetOrCreateStatMetadata(
-              GetStatTypeStr(StatType::kDevCapComputeCapMinor)),
-          compute_capability_minor);
-    }
+                                   GetStatTypeStr(StatType::kDevCapCoreCount)),
+                               core_count);
   }
 
- private:
-  mutex events_mutex;
-  std::vector<RocmTracerEvent> events TF_GUARDED_BY(events_mutex);
-  absl::flat_hash_map<uint32_t, CorrelationInfo> correlation_info_
-      TF_GUARDED_BY(events_mutex);
-  absl::flat_hash_map<RocmDeviceOccupancyParams, OccupancyStats>
-      occupancy_cache_;
-  hipDeviceProp_t device_properties_;
-};
+  auto mem_clock_khz = device_properties_.memoryClockRate;
+  auto mem_bus_width_bits = device_properties_.memoryBusWidth;
 
-class RocmTraceCollectorImpl : public profiler::RocmTraceCollector {
- public:
-  RocmTraceCollectorImpl(const RocmTraceCollectorOptions& options,
-                         uint64_t start_walltime_ns, uint64_t start_gputime_ns)
-      : RocmTraceCollector(options),
-        num_callback_events_(0),
-        num_activity_events_(0),
-        start_walltime_ns_(start_walltime_ns),
-        start_gputime_ns_(start_gputime_ns),
-        num_gpus_(options.num_gpus) {}
-
-  void AddEvent(RocmTracerEvent&& event, bool is_auxiliary) override;
-  void Flush() override;
-  void Export(XSpace* space) override;
-
-  void OnEventsDropped(const std::string& reason,
-                       uint32_t correlation_id) override {
-    LOG(INFO) << "RocmTracerEvent dropped (correlation_id=" << correlation_id
-              << ",) : " << reason << ".";
+  if (mem_clock_khz && mem_bus_width_bits) {
+    // Times 2 because HBM is DDR memory; it gets two data bits per each
+    // data lane.
+    auto memory_bandwidth =
+        uint64_t{2} * (mem_clock_khz) * 1000 * (mem_bus_width_bits) / 8;
+    device_plane->AddStatValue(
+        *device_plane->GetOrCreateStatMetadata(
+            GetStatTypeStr(StatType::kDevCapMemoryBandwidth)),
+        memory_bandwidth);
   }
 
- private:
-  std::atomic<int> num_callback_events_;
-  std::atomic<int> num_activity_events_;
-  uint64_t start_walltime_ns_;
-  uint64_t start_gputime_ns_;
-  int num_gpus_;
+  size_t total_memory = device_properties_.totalGlobalMem;
+  if (total_memory) {
+    device_plane->AddStatValue(*device_plane->GetOrCreateStatMetadata(
+                                   GetStatTypeStr(StatType::kDevCapMemorySize)),
+                               static_cast<uint64_t>(total_memory));
+  }
 
-  mutex event_maps_mutex_;
-  absl::flat_hash_map<uint32_t, RocmTracerEvent> api_events_map_
-      TF_GUARDED_BY(event_maps_mutex_);
-
-  /* Some apis such as MEMSETD32 (based on an observation with ResNet50),
-   trigger multiple HIP ops domain activities. We keep them in a vector and
-   merge them with api activities at flush time.
- */
-  absl::flat_hash_map<uint32_t, std::vector<RocmTracerEvent>>
-      activity_ops_events_map_ TF_GUARDED_BY(event_maps_mutex_);
-  // This is for the APIs that we track because we need some information from
-  // them to populate the corresponding activity that we actually track.
-  absl::flat_hash_map<uint32_t, RocmTracerEvent> auxiliary_api_events_map_
-      TF_GUARDED_BY(event_maps_mutex_);
-
-  const std::vector<RocmTracerEvent> ApiActivityInfoExchange()
-      TF_EXCLUSIVE_LOCKS_REQUIRED(event_maps_mutex_);
-
-  absl::node_hash_map<uint32_t, PerDeviceCollector> per_device_collector_;
-};
-//==========
+  auto compute_capability_major = device_properties_.major;
+  if (compute_capability_major) {
+    device_plane->AddStatValue(
+        *device_plane->GetOrCreateStatMetadata(
+            GetStatTypeStr(StatType::kDevCapComputeCapMajor)),
+        compute_capability_major);
+  }
+  auto compute_capability_minor = device_properties_.minor;
+  if (compute_capability_minor) {
+    device_plane->AddStatValue(
+        *device_plane->GetOrCreateStatMetadata(
+            GetStatTypeStr(StatType::kDevCapComputeCapMinor)),
+        compute_capability_minor);
+  }
+}
 
 void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
                                       bool is_auxiliary) {
-  mutex_lock lock(event_maps_mutex_);
+  absl::MutexLock lock(&event_maps_mutex_);
 
-  if (event.source == RocmTracerEventSource::ApiCallback && !is_auxiliary) {
-    if (num_callback_events_ > options_.max_callback_api_events) {
-      OnEventsDropped("max callback event capacity reached",
-                      event.correlation_id);
-      DumpRocmTracerEvent(event, 0, 0, ". Dropped!");
-      return;
-    }
-    num_callback_events_++;
-  } else if (event.source == RocmTracerEventSource::Activity &&
-             event.domain == RocmTracerEventDomain::HIP_API) {
-    // we do not count HIP_OPS activities.
-    if (num_activity_events_ > options_.max_activity_api_events) {
-      OnEventsDropped("max activity event capacity reached",
-                      event.correlation_id);
-      DumpRocmTracerEvent(event, 0, 0, ". Dropped!");
-      return;
-    }
-    num_activity_events_++;
-  }
-
-  bool emplace_result = false;
   if (event.source == RocmTracerEventSource::ApiCallback) {
-    auto& target_api_event_map =
-        (is_auxiliary) ? auxiliary_api_events_map_ : api_events_map_;
-    std::tie(std::ignore, emplace_result) =
-        target_api_event_map.emplace(event.correlation_id, std::move(event));
+    if (!is_auxiliary) {
+      if (num_callback_events_ >= options_.max_callback_api_events) {
+        OnEventsDropped("max callback event capacity reached",
+                        event.correlation_id);
+        PrintRocmTracerEvent(event, ". Dropped!");
+        return;
+      }
+      num_callback_events_++;
+    }
+    auto& map = is_auxiliary ? auxiliary_api_events_map_ : api_events_map_;
+    auto [it, added] = map.emplace(event.correlation_id, std::move(event));
+
+    if (!added) {
+      OnEventsDropped("event with duplicate correlation_id was received.",
+                      event.correlation_id);
+      PrintRocmTracerEvent(event, ". Dropped!");
+    }
   } else if (event.source == RocmTracerEventSource::Activity) {
-    auto result = activity_ops_events_map_.emplace(
+    if (event.domain == RocmTracerEventDomain::HIP_API) {
+      // we do not count HIP_OPS activities.
+      if (num_activity_events_ >= options_.max_activity_api_events) {
+        OnEventsDropped("max activity event capacity reached",
+                        event.correlation_id);
+        PrintRocmTracerEvent(event, ". Dropped!");
+        return;
+      }
+      num_activity_events_++;
+    }
+
+    auto [it, _] = activity_ops_events_map_.emplace(
         event.correlation_id, std::vector<RocmTracerEvent>{});
-    result.first->second.push_back(std::move(event));
-    emplace_result = true;  // we always accept Hip-Ops events
-  }
-  if (!emplace_result) {
-    OnEventsDropped("event with duplicate correlation_id was received.",
-                    event.correlation_id);
-    DumpRocmTracerEvent(event, 0, 0, ". Dropped!");
+    it->second.push_back(std::move(event));
+  } else {
+    VLOG(3) << "Dropping unknown event: " << (int)event.source
+            << " domain: " << (int)event.domain;
   }
 }
 
 void RocmTraceCollectorImpl::Flush() {
-  mutex_lock lock(event_maps_mutex_);
-  auto& aggregated_events_ = ApiActivityInfoExchange();
+  absl::MutexLock lock(&event_maps_mutex_);
+  auto aggregated_events = ApiActivityInfoExchange();
 
   VLOG(3) << "RocmTraceCollector collected " << num_callback_events_
           << " callback events, " << num_activity_events_
           << " activity events, and aggregated them into "
-          << aggregated_events_.size() << " events.";
+          << aggregated_events.size() << " events.";
 
   // device ids for GPUs filled in by roctracer are not zero indexed.
   // They are offset by number of CPUs on the machine
   tsl::uint32 min_device_id = INT32_MAX;
-  ;
-  for (auto& event : aggregated_events_) {
+
+  for (const auto& event : aggregated_events) {
     if (event.device_id < min_device_id) {
       min_device_id = event.device_id;
     }
   }
 
-  for (auto event : aggregated_events_) {
-    event.device_id = event.device_id - min_device_id;
-    if (event.device_id < num_gpus_) {
-      per_device_collector_[event.device_id].AddEvent(event);
+  for (auto& event : aggregated_events) {
+    auto id = event.device_id - min_device_id;
+    if (id < num_gpus_) {
+      per_device_collector_[id].AddEvent(std::move(event));
     } else {
-      OnEventsDropped("Invalid device id for an event.", event.correlation_id);
-      DumpRocmTracerEvent(event, 0, 0, ". Dropped!");
+      PrintRocmTracerEvent(event, ". Dropped due to invalid device ID!");
     }
   }
 
@@ -703,24 +558,24 @@ void RocmTraceCollectorImpl::Export(XSpace* space) {
   XPlaneBuilder host_plane(FindOrAddMutablePlaneWithName(
       space, tsl::profiler::kRoctracerApiPlaneName));
 
-  for (int device_ordinal = 0; device_ordinal < num_gpus_; ++device_ordinal) {
-    std::string name = GpuPlaneName(device_ordinal);
+  VLOG(3) << "Calling RocmTraceCollectorImpl::Export num_gpus " << num_gpus_;
+
+  for (int id = 0; id < num_gpus_; id++) {
+    std::string name = GpuPlaneName(id);
     XPlaneBuilder device_plane(FindOrAddMutablePlaneWithName(space, name));
-    device_plane.SetId(device_ordinal);
+    device_plane.SetId(id);
     // Calculate device capabilities before flushing, so that device
     // properties are available to the occupancy calculator in export().
-    per_device_collector_[device_ordinal].GetDeviceCapabilities(device_ordinal,
-                                                                &device_plane);
-    per_device_collector_[device_ordinal].Export(
-        start_walltime_ns_, start_gputime_ns_, end_gputime_ns, &device_plane,
-        &host_plane);
+    per_device_collector_[id].GetDeviceCapabilities(id, &device_plane);
+    per_device_collector_[id].Export(start_walltime_ns_, start_gputime_ns_,
+                                     end_gputime_ns, &device_plane,
+                                     &host_plane);
     NormalizeTimeStamps(&device_plane, start_walltime_ns_);
   }
   NormalizeTimeStamps(&host_plane, start_walltime_ns_);
 }
 
-const std::vector<RocmTracerEvent>
-RocmTraceCollectorImpl::ApiActivityInfoExchange() {
+std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
   /* Different from CUDA, roctracer activity records are not enough to fill a
     TF event. For most of the activities, we need to enable the corresponding
     API callsbacks (we call them auxiliary API callbacks) to capture the
@@ -730,55 +585,53 @@ RocmTraceCollectorImpl::ApiActivityInfoExchange() {
   */
 
   std::vector<RocmTracerEvent> aggregated_events;
+  aggregated_events.reserve(api_events_map_.size());
 
   // Copy info from activity events to API callback events
-  for (auto& api_iter : api_events_map_) {
-    RocmTracerEvent& api_event = api_iter.second;
-    auto activity_event =
-        activity_ops_events_map_.find(api_event.correlation_id);
+  for (auto& [key, api_event] : api_events_map_) {
+    auto iact = activity_ops_events_map_.find(api_event.correlation_id);
 
-    if (activity_event == activity_ops_events_map_.end()) {
-      OnEventsDropped(
-          "An event from HIP API discarded."
-          "Could not find the counterpart activity.",
-          api_event.correlation_id);
-      DumpRocmTracerEvent(api_event, 0, 0, ". Dropped!");
-    } else {
-      api_event.device_id = activity_event->second.front().device_id;
-      api_event.stream_id = activity_event->second.front().stream_id;
-      switch (api_event.type) {
-        case RocmTracerEventType::Kernel:
-        case RocmTracerEventType::Memset:
-        case RocmTracerEventType::MemoryAlloc:
-        case RocmTracerEventType::MemoryFree:
-        case RocmTracerEventType::Synchronization: {
-          aggregated_events.push_back(api_event);
-          break;
-        }
-        case RocmTracerEventType::MemcpyD2H:
-        case RocmTracerEventType::MemcpyH2D:
-        case RocmTracerEventType::MemcpyD2D:
-        case RocmTracerEventType::MemcpyOther: {
-          api_event.memcpy_info.destination =
-              activity_event->second.front().device_id;
-          aggregated_events.push_back(api_event);
-          break;
-        }
-        default:
-          OnEventsDropped("Missing API-Activity information exchange. Dropped!",
-                          api_event.correlation_id);
-          DumpRocmTracerEvent(api_event, 0, 0, ". Dropped!");
-          LOG(WARNING) << "A ROCm API event type with unimplemented activity "
-                          "merge dropped! "
-                          "Type="
-                       << GetRocmTracerEventTypeName(api_event.type);
-      }
+    if (iact == activity_ops_events_map_.end()) {
+      PrintRocmTracerEvent(api_event, ". Dropped!");
+      VLOG(1) << api_event.name << "  could not find activity counterpart!";
+      continue;
     }
-  }
+    const auto& item = iact->second.front();
+    api_event.device_id = item.device_id;
+    api_event.stream_id = item.stream_id;
+    switch (api_event.type) {
+      case RocmTracerEventType::Kernel:
+      case RocmTracerEventType::Memset:
+      case RocmTracerEventType::MemoryAlloc:
+      case RocmTracerEventType::MemoryFree:
+      case RocmTracerEventType::Synchronization: {
+        aggregated_events.push_back(api_event);
+        break;
+      }
+      case RocmTracerEventType::MemcpyD2H:
+      case RocmTracerEventType::MemcpyH2D:
+      case RocmTracerEventType::MemcpyD2D:
+      case RocmTracerEventType::MemcpyOther: {
+        // api_event.memcpy_info.destination = item.device_id;
+        api_event.memcpy_info = item.memcpy_info;
+        aggregated_events.push_back(api_event);
+        break;
+      }
+      default:
+        OnEventsDropped("Missing API-Activity information exchange. Dropped!",
+                        api_event.correlation_id);
+        PrintRocmTracerEvent(api_event, ". Dropped!");
+        LOG(WARNING) << "A ROCm API event type with unimplemented activity "
+                        "merge dropped! "
+                        "Type="
+                     << GetRocmTracerEventTypeName(api_event.type);
+    }  // switch
+  }  // for
 
   // Make sure for all activity events we have API callback events
   for (auto& activity_iter : activity_ops_events_map_) {
     RocmTracerEvent& activity_event = activity_iter.second.front();
+
     auto api_event = api_events_map_.find(activity_event.correlation_id);
 
     if (api_event == api_events_map_.end()) {
@@ -790,56 +643,53 @@ RocmTraceCollectorImpl::ApiActivityInfoExchange() {
           "An event from activity was discarded."
           "Could not find the counterpart HIP API.",
           activity_event.correlation_id);
-      DumpRocmTracerEvent(activity_event, 0, 0, ". Dropped!");
-    } else {
-      switch (activity_event.type) {
-        // KERNEL ACTIVITY
-        case RocmTracerEventType::Kernel: {
-          activity_event.name = api_event->second.name;
-          activity_event.kernel_info = api_event->second.kernel_info;
-          aggregated_events.push_back(activity_event);
-          break;
-        }
-        // MEMCPY ACTIVITY
-        case RocmTracerEventType::MemcpyD2H:
-        case RocmTracerEventType::MemcpyH2D:
-        case RocmTracerEventType::MemcpyD2D:
-        case RocmTracerEventType::MemcpyOther: {
-          activity_event.memcpy_info = api_event->second.memcpy_info;
-          aggregated_events.push_back(activity_event);
-          break;
-        }
-        // MEMSET ACTIVITY
-        case RocmTracerEventType::Memset: {
-          activity_event.memset_info = api_event->second.memset_info;
-          aggregated_events.push_back(activity_event);
-          break;
-        }
-        // MALLOC ACTIVITY, FREE ACTIVITY
-        case RocmTracerEventType::MemoryAlloc:
-        case RocmTracerEventType::MemoryFree: {
-          activity_event.device_id = api_event->second.device_id;
-          aggregated_events.push_back(activity_event);
-          break;
-        }
-        // SYNCHRONIZATION ACTIVITY
-        case RocmTracerEventType::Synchronization: {
-          activity_event.device_id = api_event->second.device_id;
-          aggregated_events.push_back(activity_event);
-          break;
-        }
-        default:
-          OnEventsDropped("Missing API-Activity information exchange. Dropped!",
-                          activity_event.correlation_id);
-          DumpRocmTracerEvent(activity_event, 0, 0, ". Dropped!");
-          LOG(WARNING) << "A ROCm activity event with unimplemented API "
-                          "callback merge dropped! "
-                          "Type="
-                       << GetRocmTracerEventTypeName(activity_event.type);
-          break;
-      }
+      PrintRocmTracerEvent(activity_event, ". Dropped!");
+      continue;
     }
-  }
+
+    switch (activity_event.type) {
+      case RocmTracerEventType::Kernel:
+#if defined(XLA_GPU_ROCM_TRACER_BACKEND) && (XLA_GPU_ROCM_TRACER_BACKEND == 1)
+        activity_event.name = api_event->second.name;
+#endif
+        activity_event.kernel_info = api_event->second.kernel_info;
+        PrintRocmTracerEvent(activity_event,
+                             ". activity event from api_event.");
+        aggregated_events.push_back(activity_event);
+        break;
+
+      case RocmTracerEventType::MemcpyD2H:
+      case RocmTracerEventType::MemcpyH2D:
+      case RocmTracerEventType::MemcpyD2D:
+      case RocmTracerEventType::MemcpyOther:
+        // activity_event.memcpy_info = api_event->second.memcpy_info;
+        aggregated_events.push_back(activity_event);
+        break;
+      case RocmTracerEventType::Memset:
+        activity_event.memset_info = api_event->second.memset_info;
+        aggregated_events.push_back(activity_event);
+        break;
+
+      case RocmTracerEventType::MemoryAlloc:
+      case RocmTracerEventType::MemoryFree:
+        activity_event.device_id = api_event->second.device_id;
+        aggregated_events.push_back(activity_event);
+        break;
+
+      case RocmTracerEventType::Synchronization:
+        activity_event.device_id = api_event->second.device_id;
+        aggregated_events.push_back(activity_event);
+        break;
+      default:
+        OnEventsDropped("Missing API-Activity information exchange. Dropped!",
+                        activity_event.correlation_id);
+        PrintRocmTracerEvent(activity_event, ". Dropped!");
+        LOG(WARNING) << "A ROCm activity event with unimplemented API "
+                        "callback merge dropped! "
+                        "Type="
+                     << GetRocmTracerEventTypeName(activity_event.type);
+    }  // switch
+  }  // for
 
   return aggregated_events;
 }

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -18,61 +18,29 @@ limitations under the License.
 
 #include <cstdint>
 #include <limits>
+#include <tuple>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/node_hash_map.h"
 #include "absl/container/node_hash_set.h"
+#include "tsl/profiler/protobuf/xplane.pb.h"
+#include "tsl/profiler/lib/profiler_factory.h"
+#include "tsl/profiler/lib/profiler_interface.h"
+#include "xla/tsl/profiler/utils/parse_annotation.h"
 #include "xla/tsl/profiler/utils/xplane_builder.h"
+#include "xla/tsl/profiler/utils/xplane_schema.h"
+#include "xla/tsl/profiler/utils/xplane_utils.h"
+
+#include "xla/stream_executor/rocm/roctracer_wrapper.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 
 namespace xla {
 namespace profiler {
 
+using tsl::profiler::XEvent;
+using tsl::profiler::XLineBuilder;
+using tsl::profiler::XPlaneBuilder;
 using tsl::profiler::XSpace;
-
-struct MemcpyDetails {
-  // The amount of data copied for memcpy events.
-  size_t num_bytes;
-  // The destination device for peer-2-peer communication (memcpy). The source
-  // device is implicit: it's the current device.
-  uint32_t destination;
-  // Whether or not the memcpy is asynchronous.
-  bool async;
-};
-
-struct MemAllocDetails {
-  // The amount of data requested for cudaMalloc events.
-  uint64_t num_bytes;
-};
-
-struct MemsetDetails {
-  // The number of memory elements getting set
-  size_t num_bytes;
-  // Whether or not the memset is asynchronous.
-  bool async;
-};
-
-struct KernelDetails {
-  // The number of registers used in this kernel.
-  uint32_t registers_per_thread;
-  // The amount of shared memory space used by a thread block.
-  uint32_t static_shared_memory_usage;
-  // The amount of dynamic memory space used by a thread block.
-  uint32_t dynamic_shared_memory_usage;
-  // X-dimension of a thread block.
-  uint32_t block_x;
-  // Y-dimension of a thread block.
-  uint32_t block_y;
-  // Z-dimension of a thread block.
-  uint32_t block_z;
-  // X-dimension of a grid.
-  uint32_t grid_x;
-  // Y-dimension of a grid.
-  uint32_t grid_y;
-  // Z-dimension of a grid.
-  uint32_t grid_z;
-
-  // kernel address. Used for calculating core occupancy
-  void* func_ptr;
-};
 
 inline std::string ToXStat(const KernelDetails& kernel_info,
                            double occupancy_pct) {
@@ -86,118 +54,68 @@ inline std::string ToXStat(const KernelDetails& kernel_info,
       " occ_pct:", occupancy_pct);
 }
 
-enum class RocmTracerEventType {
-  Unsupported = 0,
-  Kernel,
-  MemcpyH2D,
-  MemcpyD2H,
-  MemcpyD2D,
-  MemcpyP2P,
-  MemcpyOther,
-  MemoryAlloc,
-  MemoryFree,
-  Memset,
-  Synchronization,
-  Generic,
+struct RocmDeviceOccupancyParams {
+  hipFuncAttributes attributes = {};
+  int block_size = 0;
+  size_t dynamic_smem_size = 0;
+  void* func_ptr;
+
+  friend bool operator==(const RocmDeviceOccupancyParams& a,
+                         const RocmDeviceOccupancyParams& b) noexcept {
+    // Compare only the fields that affect occupancy decisions.
+    return std::tuple{a.attributes.binaryVersion,
+                      a.attributes.cacheModeCA,
+                      a.attributes.constSizeBytes,
+                      a.attributes.localSizeBytes,
+                      a.attributes.maxDynamicSharedSizeBytes,
+                      a.attributes.maxThreadsPerBlock,
+                      a.attributes.numRegs,
+                      a.attributes.preferredShmemCarveout,
+                      a.attributes.ptxVersion,
+                      a.block_size,
+                      a.dynamic_smem_size,
+                      a.func_ptr} ==
+           std::tuple{b.attributes.binaryVersion,
+                      b.attributes.cacheModeCA,
+                      b.attributes.constSizeBytes,
+                      b.attributes.localSizeBytes,
+                      b.attributes.maxDynamicSharedSizeBytes,
+                      b.attributes.maxThreadsPerBlock,
+                      b.attributes.numRegs,
+                      b.attributes.preferredShmemCarveout,
+                      b.attributes.ptxVersion,
+                      b.block_size,
+                      b.dynamic_smem_size,
+                      b.func_ptr};
+  }
+
+  friend bool operator!=(const RocmDeviceOccupancyParams& a,
+                         const RocmDeviceOccupancyParams& b) noexcept {
+    return !(a == b);
+  }
+
+  template <typename H>
+  friend H AbslHashValue(H hash_state,
+                         const RocmDeviceOccupancyParams& params) {
+    return H::combine(
+        std::move(hash_state), params.attributes.maxThreadsPerBlock,
+        params.attributes.numRegs, params.attributes.sharedSizeBytes,
+        params.attributes.maxDynamicSharedSizeBytes, params.block_size,
+        params.dynamic_smem_size, params.func_ptr);
+  }
 };
 
-const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type);
-
-enum class RocmTracerEventSource {
-  Invalid = 0,
-  ApiCallback,
-  Activity,
-};
-
-const char* GetRocmTracerEventSourceName(const RocmTracerEventSource& source);
-
-enum class RocmTracerEventDomain {
-  InvalidDomain = 0,
-  HIP_API,
-  HIP_OPS,
-};
-const char* GetRocmTracerEventDomainName(const RocmTracerEventDomain& domain);
-// RocmTracerSyncTypes forward declaration
-enum class RocmTracerSyncTypes;
-
-struct SynchronizationDetails {
-  RocmTracerSyncTypes sync_type;
-};
-
-struct RocmTracerEvent {
-  static constexpr uint32_t kInvalidDeviceId =
-      std::numeric_limits<uint32_t>::max();
-  static constexpr uint64_t kInvalidThreadId =
-      std::numeric_limits<uint64_t>::max();
-  static constexpr uint32_t kInvalidCorrelationId =
-      std::numeric_limits<uint32_t>::max();
-  static constexpr uint64_t kInvalidStreamId =
-      std::numeric_limits<uint64_t>::max();
-  RocmTracerEventType type;
-  RocmTracerEventSource source = RocmTracerEventSource::Invalid;
-  RocmTracerEventDomain domain;
-  std::string name;
-  // This points to strings in AnnotationMap, which should outlive the point
-  // where serialization happens.
-  absl::string_view annotation;
-  absl::string_view roctx_range;
-  uint64_t start_time_ns = 0;
-  uint64_t end_time_ns = 0;
-  uint32_t device_id = kInvalidDeviceId;
-  uint32_t correlation_id = kInvalidCorrelationId;
-  uint64_t thread_id = kInvalidThreadId;
-  int64_t stream_id = kInvalidStreamId;
-  union {
-    MemcpyDetails memcpy_info;                    // If type == Memcpy*
-    MemsetDetails memset_info;                    // If type == Memset*
-    MemAllocDetails memalloc_info;                // If type == MemoryAlloc
-    KernelDetails kernel_info;                    // If type == Kernel
-    SynchronizationDetails synchronization_info;  // If type == Synchronization
-  };
-};
-
-struct RocmTraceCollectorOptions {
-  // Maximum number of events to collect from callback API; if -1, no limit.
-  // if 0, the callback API is enabled to build a correlation map, but no
-  // events are collected.
-  uint64_t max_callback_api_events;
-  // Maximum number of events to collect from activity API; if -1, no limit.
-  uint64_t max_activity_api_events;
-  // Maximum number of annotation strings that we can accommodate.
-  uint64_t max_annotation_strings;
-  // Number of GPUs involved.
-  uint32_t num_gpus;
-};
-
-class AnnotationMap {
- public:
-  explicit AnnotationMap(uint64_t max_size) : max_size_(max_size) {}
-  void Add(uint32_t correlation_id, const std::string& annotation);
-  absl::string_view LookUp(uint32_t correlation_id);
-
- private:
-  struct AnnotationMapImpl {
-    // The population/consumption of annotations might happen from multiple
-    // callback/activity api related threads.
-    absl::Mutex mutex;
-    // Annotation tends to be repetitive, use a hash_set to store the strings,
-    // an use the reference to the string in the map.
-    absl::node_hash_set<std::string> annotations;
-    absl::flat_hash_map<uint32_t, absl::string_view> correlation_map;
-  };
-  const uint64_t max_size_;
-  AnnotationMapImpl map_;
-
- public:
-  // Disable copy and move.
-  AnnotationMap(const AnnotationMap&) = delete;
-  AnnotationMap& operator=(const AnnotationMap&) = delete;
+// FIXME: rocprofiler-sdk does not have this one yet
+struct OccupancyStats {
+  double occupancy_pct = 0.0;
+  int min_grid_size = 0;
+  int suggested_block_size = 0;
 };
 
 class RocmTraceCollector {
  public:
   explicit RocmTraceCollector(const RocmTraceCollectorOptions& options)
-      : options_(options), annotation_map_(options.max_annotation_strings) {}
+      : options_(options) {}
   virtual ~RocmTraceCollector() {}
 
   virtual void AddEvent(RocmTracerEvent&& event, bool is_auxiliary) = 0;
@@ -206,19 +124,91 @@ class RocmTraceCollector {
   virtual void Flush() = 0;
   virtual void Export(XSpace* space) = 0;
 
-  AnnotationMap* annotation_map() { return &annotation_map_; }
-
  protected:
   RocmTraceCollectorOptions options_;
-
- private:
-  AnnotationMap annotation_map_;
 
  public:
   // Disable copy and move.
   RocmTraceCollector(const RocmTraceCollector&) = delete;
   RocmTraceCollector& operator=(const RocmTraceCollector&) = delete;
 };
+
+class PerDeviceCollector {
+ public:
+  void Export(uint64_t start_walltime_ns, uint64_t start_gputime_ns,
+              uint64_t end_gputime_ns, XPlaneBuilder* device_plane,
+              XPlaneBuilder* host_plane);
+
+  PerDeviceCollector() = default;
+
+  void AddEvent(RocmTracerEvent&& event);
+  void GetDeviceCapabilities(int32_t device_ordinal,
+                             XPlaneBuilder* device_plane);
+
+ private:
+  OccupancyStats GetOccupancy(const RocmDeviceOccupancyParams& params) const;
+  void CreateXEvent(const RocmTracerEvent& event, XPlaneBuilder* plane,
+                    uint64_t start_gpu_ns, uint64_t end_gpu_ns,
+                    XLineBuilder* line);
+  void SortByStartTime();
+  bool IsHostEvent(const RocmTracerEvent& event, tsl::int64* line_id);
+
+ private:
+  absl::Mutex events_mutex_;
+  std::vector<RocmTracerEvent> events_ ABSL_GUARDED_BY(events_mutex_);
+  absl::flat_hash_map<RocmDeviceOccupancyParams, OccupancyStats>
+      occupancy_cache_;
+  hipDeviceProp_t device_properties_;
+};  // PerDeviceCollector
+
+class RocmTraceCollectorImpl : public RocmTraceCollector {
+ public:
+  RocmTraceCollectorImpl(const RocmTraceCollectorOptions& options,
+                         uint64_t start_walltime_ns, uint64_t start_gputime_ns)
+      : RocmTraceCollector(options),
+        num_callback_events_(0),
+        num_activity_events_(0),
+        start_walltime_ns_(start_walltime_ns),
+        start_gputime_ns_(start_gputime_ns),
+        num_gpus_(options.num_gpus) {}
+
+  void AddEvent(RocmTracerEvent&& event, bool is_auxiliary) override;
+  void Flush() override;
+  void Export(XSpace* space) override;
+
+  void OnEventsDropped(const std::string& reason,
+                       uint32_t correlation_id) override {
+    LOG(INFO) << "RocmTracerEvent dropped (correlation_id=" << correlation_id
+              << ",) : " << reason << ".";
+  }
+
+ private:
+  std::atomic<int> num_callback_events_;
+  std::atomic<int> num_activity_events_;
+  uint64_t start_walltime_ns_;
+  uint64_t start_gputime_ns_;
+  int num_gpus_;
+
+  absl::Mutex event_maps_mutex_;
+  absl::flat_hash_map<uint32_t, RocmTracerEvent> api_events_map_
+      ABSL_GUARDED_BY(event_maps_mutex_);
+
+  /* Some apis such as MEMSETD32 (based on an observation with ResNet50),
+   trigger multiple HIP ops domain activities. We keep them in a vector and
+   merge them with api activities at flush time.
+ */
+  absl::flat_hash_map<uint32_t, std::vector<RocmTracerEvent>>
+      activity_ops_events_map_ ABSL_GUARDED_BY(event_maps_mutex_);
+  // This is for the APIs that we track because we need some information from
+  // them to populate the corresponding activity that we actually track.
+  absl::flat_hash_map<uint32_t, RocmTracerEvent> auxiliary_api_events_map_
+      ABSL_GUARDED_BY(event_maps_mutex_);
+
+  std::vector<RocmTracerEvent> ApiActivityInfoExchange()
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(event_maps_mutex_);
+
+  absl::node_hash_map<uint32_t, PerDeviceCollector> per_device_collector_;
+};  // RocmTraceCollectorImpl
 
 std::unique_ptr<RocmTraceCollector> CreateRocmCollector(
     const RocmTraceCollectorOptions& options, const uint64_t start_walltime_ns,

--- a/xla/backends/profiler/gpu/rocm_collector_test.cc
+++ b/xla/backends/profiler/gpu/rocm_collector_test.cc
@@ -1,0 +1,249 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tsl/platform/test.h"
+
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "absl/synchronization/blocking_counter.h"
+#include "absl/synchronization/notification.h"
+#include "google/protobuf/stubs/common.h"  // ShutdownProtobufLibrary
+#include "xla/backends/profiler/gpu/rocm_collector.h"
+#include "xla/tsl/profiler/utils/xplane_schema.h"  // tsl::profiler::GpuPlaneName
+
+namespace xla {
+namespace profiler {
+namespace test {
+
+namespace tp = ::tensorflow::profiler;  // Protobufs: XSpace/XPlane
+namespace tps = ::tsl::profiler;        // Schema helpers: GpuPlaneName
+
+class RocmCollectorSanitizerTest : public ::testing::Test {
+ protected:
+  static void TearDownTestSuite() {
+    // Helps LeakSanitizer in some environments with protobuf singletons.
+    google::protobuf::ShutdownProtobufLibrary();
+  }
+};
+
+// Read-only helper: find a plane by name without mutating the XSpace.
+static const tp::XPlane* FindPlaneConst(const tp::XSpace& space,
+                                        absl::string_view name) {
+  for (const auto& p : space.planes()) {
+    if (p.name() == name) return &p;
+  }
+  return nullptr;
+}
+
+// Safely get an event metadata name from the protobuf Map.
+static std::string GetEventMetadataName(const tp::XPlane& plane, int64_t id) {
+  const auto& md_map = plane.event_metadata();
+  auto it = md_map.find(id);
+  if (it == md_map.end()) return {};
+  return it->second.name();
+}
+
+TEST_F(RocmCollectorSanitizerTest, TestAddKernelEventAndExport_TSANSafe) {
+  RocmTraceCollectorOptions options;
+  options.max_callback_api_events = 100;
+  options.max_activity_api_events = 100;
+  options.max_annotation_strings = 100;
+  options.num_gpus = 1;
+
+  constexpr uint64_t kStartWallTimeNs = 1000;
+  constexpr uint64_t kStartGpuTimeNs = 2000;
+
+  RocmTraceCollectorImpl collector(options, kStartWallTimeNs, kStartGpuTimeNs);
+
+  constexpr uint32_t kCorrelationId = 42;
+  constexpr uint64_t kStartTimeNs = 3000;
+  constexpr uint64_t kEndTimeNs = 4000;
+
+  // 1) API-callback side (host).
+  {
+    RocmTracerEvent api_event{};  // value-init all fields to zero/known state
+    api_event.type = RocmTracerEventType::Kernel;
+    api_event.source = RocmTracerEventSource::ApiCallback;
+    api_event.domain = RocmTracerEventDomain::HIP_API;
+    api_event.name = "test_rocm_kernel";  // string literal => static storage
+    api_event.correlation_id = kCorrelationId;
+    api_event.thread_id = 999;
+    api_event.device_id = 0;  // set explicitly
+    api_event.stream_id = 123;
+    api_event.kernel_info = {
+        /*.registers_per_thread=*/32,
+        /*.static_shared_memory_usage=*/1024,
+        /*.dynamic_shared_memory_usage=*/0,
+        /*.block_x=*/256,
+        /*.block_y=*/1,
+        /*.block_z=*/1,
+        /*.grid_x=*/100,
+        /*.grid_y=*/1,
+        /*.grid_z=*/1,
+        /*.func_ptr=*/nullptr,  // avoid accidental deref/symbolization
+    };
+    collector.AddEvent(std::move(api_event), /*is_auxiliary=*/false);
+  }
+
+  // 2) Activity side (device).
+  {
+    RocmTracerEvent act_event{};
+    act_event.type = RocmTracerEventType::Kernel;
+    act_event.source = RocmTracerEventSource::Activity;
+    act_event.domain = RocmTracerEventDomain::HIP_OPS;
+    act_event.name = "test_rocm_kernel";
+    act_event.correlation_id = kCorrelationId;
+    act_event.start_time_ns = kStartTimeNs;
+    act_event.end_time_ns = kEndTimeNs;
+    act_event.device_id = 0;  // keep within [0, num_gpus)
+    act_event.stream_id = 123;
+    collector.AddEvent(std::move(act_event), /*is_auxiliary=*/false);
+  }
+
+  // 3) Quiesce/merge before export.
+  collector.Flush();
+
+  tp::XSpace space;
+  collector.Export(&space);
+
+  // 4) Verify without any "find-or-add" helpers.
+  const std::string plane_name = tps::GpuPlaneName(/*device_ordinal=*/0);
+  const tp::XPlane* gpu_plane = FindPlaneConst(space, plane_name);
+  ASSERT_NE(gpu_plane, nullptr) << "GPU plane not found: " << plane_name;
+
+  ASSERT_GT(gpu_plane->lines_size(), 0);
+  const auto& line = gpu_plane->lines(0);
+  ASSERT_GT(line.events_size(), 0);
+
+  const auto& ev = line.events(0);
+  // Offsets are relative to the line timestamp (start_gputime_ns).
+  EXPECT_EQ(ev.offset_ps(), (kStartTimeNs - kStartGpuTimeNs) * 1000);
+  EXPECT_EQ(ev.duration_ps(), (kEndTimeNs - kStartTimeNs) * 1000);
+
+  const std::string md_name = GetEventMetadataName(*gpu_plane, ev.metadata_id());
+  ASSERT_FALSE(md_name.empty());
+  EXPECT_EQ(md_name, "test_rocm_kernel");
+}
+
+// Concurrency test: multiple threads add matched API+Activity pairs.
+// We coordinate starts, join all threads, then Flush and Export.
+TEST_F(RocmCollectorSanitizerTest, ConcurrentAddAndExport_TSANSafe) {
+  RocmTraceCollectorOptions options;
+  options.max_callback_api_events = 10'000;
+  options.max_activity_api_events = 10'000;
+  options.max_annotation_strings = 1'000;
+  options.num_gpus = 1;
+
+  constexpr uint64_t kStartWallTimeNs = 1'000'000;
+  constexpr uint64_t kStartGpuTimeNs = 2'000'000;
+
+  RocmTraceCollectorImpl collector(options, kStartWallTimeNs, kStartGpuTimeNs);
+
+  constexpr int kThreads = 8;
+  constexpr int kEventsPerThread = 64;
+
+  absl::BlockingCounter ready(kThreads);
+  absl::Notification go;
+
+  auto worker = [&](int tid) {
+    ready.DecrementCount();
+    go.WaitForNotification();
+
+    const uint64_t base_start = 3'000'000 + static_cast<uint64_t>(tid) * 10'000;
+    const uint64_t dur_ns = 5'000;
+
+    for (int i = 0; i < kEventsPerThread; ++i) {
+      const uint32_t cid = static_cast<uint32_t>(tid * 10'000 + i);
+      const uint64_t t0 = base_start + static_cast<uint64_t>(i) * 100;
+      const uint64_t t1 = t0 + dur_ns;
+
+      RocmTracerEvent api{};
+      api.type = RocmTracerEventType::Kernel;
+      api.source = RocmTracerEventSource::ApiCallback;
+      api.domain = RocmTracerEventDomain::HIP_API;
+      api.name = "kernel_concurrent";  // string literal (static)
+      api.correlation_id = cid;
+      api.thread_id = 1000 + tid;
+      api.device_id = 0;
+      api.stream_id = 1000 + tid;  // one line per worker
+      collector.AddEvent(std::move(api), /*is_auxiliary=*/false);
+
+      RocmTracerEvent act{};
+      act.type = RocmTracerEventType::Kernel;
+      act.source = RocmTracerEventSource::Activity;
+      act.domain = RocmTracerEventDomain::HIP_OPS;
+      act.name = "kernel_concurrent";
+      act.correlation_id = cid;
+      act.start_time_ns = t0;
+      act.end_time_ns = t1;
+      act.device_id = 0;
+      act.stream_id = 1000 + tid;
+      collector.AddEvent(std::move(act), /*is_auxiliary=*/false);
+    }
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) threads.emplace_back(worker, t);
+
+  ready.Wait();
+  go.Notify();
+  for (auto& th : threads) th.join();
+
+  collector.Flush();
+
+  tp::XSpace space;
+  collector.Export(&space);
+
+  const std::string plane_name = tps::GpuPlaneName(/*device_ordinal=*/0);
+  const tp::XPlane* gpu_plane = FindPlaneConst(space, plane_name);
+  ASSERT_NE(gpu_plane, nullptr) << "GPU plane not found: " << plane_name;
+
+  uint64_t total_events = 0;
+  for (const auto& l : gpu_plane->lines()) total_events += l.events_size();
+  ASSERT_EQ(total_events, static_cast<uint64_t>(kThreads * kEventsPerThread));
+
+  // Spot check: first line has events and metadata resolves.
+  if (gpu_plane->lines_size() > 0 && gpu_plane->lines(0).events_size() > 0) {
+    const auto& ev = gpu_plane->lines(0).events(0);
+    const std::string md_name =
+        GetEventMetadataName(*gpu_plane, ev.metadata_id());
+    ASSERT_FALSE(md_name.empty());
+    EXPECT_EQ(md_name, "kernel_concurrent");
+    EXPECT_GT(ev.duration_ps(), 0);
+  }
+}
+
+}  // namespace test
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_profiler_sdk.cc
+++ b/xla/backends/profiler/gpu/rocm_profiler_sdk.cc
@@ -1,0 +1,581 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This translation unit is **self‑contained**: it provides minimal stub
+// implementations for the rocprofiler callbacks that XLA needs to register
+// (toolInit / toolFinialize / code_object_callback).  They do nothing except
+// keep the compiler and linker happy.  Once real logging is implemented, you
+// can replace the stubs with the actual logic.
+
+#include "xla/backends/profiler/gpu/rocm_profiler_sdk.h"
+#include "xla/backends/profiler/gpu/rocm_collector.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <time.h>
+#include <unistd.h>
+#include <chrono>
+#include <unistd.h>  // For standard sysconf
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/node_hash_map.h"
+#include "absl/strings/str_format.h"
+#include "xla/tsl/profiler/backends/cpu/annotation_stack.h"
+#include "xla/tsl/profiler/utils/time_utils.h"
+#include "tsl/platform/env.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/logging.h"
+#include "tsl/platform/macros.h"
+#include "tsl/platform/mem.h"
+#include "tsl/platform/stacktrace.h"
+
+// for rocprofiler-sdk
+namespace xla {
+namespace profiler {
+
+using tsl::profiler::AnnotationStack;
+
+// represents an invalid or uninitialized device ID used in RocmTracer events.
+constexpr uint32_t RocmTracerEvent::kInvalidDeviceId;
+
+inline auto GetCallbackTracingNames() {
+  return rocprofiler::sdk::get_callback_tracing_names();
+}
+
+std::vector<rocprofiler_agent_v0_t> GetGpuDeviceAgents();
+
+//-----------------------------------------------------------------------------
+// copy api calls
+bool isCopyApi(uint32_t id) {
+  switch (id) {
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2D:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2DAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2DFromArray:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2DFromArrayAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2DToArray:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2DToArrayAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy3D:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy3DAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyAtoH:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyDtoD:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyDtoDAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyDtoH:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyDtoHAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyFromArray:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyFromSymbol:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyFromSymbolAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyHtoA:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyHtoD:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyHtoDAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyParam2D:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyParam2DAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyPeer:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyPeerAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyToArray:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyToSymbol:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyToSymbolAsync:
+    case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyWithStream:
+      return true;
+      break;
+    default:;
+  }
+  return false;
+}
+
+// ----------------------------------------------------------------------------
+// Stub implementations for RocmTracer static functions expected by
+// rocprofiler-sdk.
+// ----------------------------------------------------------------------------
+RocmTracer& RocmTracer::GetRocmTracerSingleton() {
+  static RocmTracer obj;
+  return obj;
+}
+
+bool RocmTracer::IsAvailable() const {
+  return !activity_tracing_enabled_ && !api_tracing_enabled_;  // &&NumGpus()
+}
+
+/*static*/ uint64_t RocmTracer::GetTimestamp() {
+  uint64_t ts;
+  if (rocprofiler_get_timestamp(&ts) != ROCPROFILER_STATUS_SUCCESS) {
+    LOG(ERROR) << "function rocprofiler_get_timestamp failed with error ";
+    return 0;
+  }
+  return ts;
+}
+
+void RocmTracer::Enable(const RocmTracerOptions& options,
+                        RocmTraceCollector* collector) {
+  absl::MutexLock lock(&collector_mutex_);
+  if (collector_ != nullptr) {
+    LOG(WARNING) << "ROCM tracer is already running!";
+    return;
+  }
+  options_ = options;
+  collector_ = collector;
+  AnnotationMap(options_->max_annotation_strings);
+  api_tracing_enabled_ = true;
+  activity_tracing_enabled_ = true;
+  rocprofiler_start_context(context_);
+  LOG(INFO) << "GpuTracer started with number of GPUs = " << NumGpus();
+}
+
+void RocmTracer::HipApiEvent(const rocprofiler_record_header_t* hdr,
+                             RocmTracerEvent* trace_event) {
+  const auto& rec =
+      *static_cast<const rocprofiler_buffer_tracing_hip_api_record_t*>(
+          hdr->payload);
+
+  trace_event->type = RocmTracerEventType::Kernel;
+  trace_event->source = RocmTracerEventSource::ApiCallback;
+  trace_event->domain = RocmTracerEventDomain::HIP_API;
+  trace_event->name = "??";
+  trace_event->start_time_ns = rec.start_timestamp;
+  trace_event->end_time_ns = rec.end_timestamp;
+  trace_event->device_id = RocmTracerEvent::kInvalidDeviceId;
+  trace_event->correlation_id = rec.correlation_id.internal;
+  trace_event->annotation =
+      annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->thread_id = rec.thread_id;
+  trace_event->stream_id = RocmTracerEvent::kInvalidStreamId;
+  trace_event->kernel_info = KernelDetails{};
+
+  {
+    // bounds-check name table: kind and operation
+    absl::MutexLock lock(&kernel_lock_);
+    const size_t kind = static_cast<size_t>(rec.kind);
+    if (kind < name_info_.size()) {
+      const auto& vec = name_info_[kind];
+      const size_t op = static_cast<size_t>(rec.operation);
+      if (op < vec.operations.size()) {
+        trace_event->name = vec[op];
+      } else {
+        static std::atomic<int> once{0};
+        if (once.fetch_add(1) == 0) {
+          LOG(ERROR) << "HIP op OOB: kind " << kind << " op = " << op
+                     << " vec.size() = " << vec.operations.size();
+        }
+        trace_event->name = "HIP_UNKNOWN_OP";
+      }
+    } else {
+      static std::atomic<int> once{0};
+      if (once.fetch_add(1) == 0) {
+        LOG(ERROR) << "HIP kind OOB: kind = " << kind
+                   << " name_info_.size() = " << name_info_.size();
+      }
+      trace_event->name = "HIP_UNKNOWN_KIND";
+    }
+  }
+
+  if (isCopyApi(rec.operation)) {
+    // actually one needs to set the real type
+    trace_event->type = RocmTracerEventType::MemcpyOther;
+  }
+}
+
+void RocmTracer::MemcpyEvent(const rocprofiler_record_header_t* hdr,
+                             RocmTracerEvent* trace_event) {
+  const auto& rec =
+      *static_cast<const rocprofiler_buffer_tracing_memory_copy_record_t*>(
+          hdr->payload);
+
+#define OO(src, target)                              \
+  case ROCPROFILER_MEMORY_COPY_##src:                \
+    trace_event->type = RocmTracerEventType::target; \
+    trace_event->name = #target;                     \
+    break;
+
+  switch (rec.operation) {
+    OO(NONE, MemcpyOther)
+    OO(HOST_TO_HOST, MemcpyOther)
+    OO(HOST_TO_DEVICE, MemcpyH2D)
+    OO(DEVICE_TO_HOST, MemcpyD2H)
+    OO(DEVICE_TO_DEVICE, MemcpyD2D)
+    default:
+      LOG(WARNING) << "Unexpected memcopy operation " << rec.operation;
+      trace_event->type = RocmTracerEventType::MemcpyOther;
+  }
+#undef OO
+  const auto &src_gpu = agents_[static_cast<uint32_t>(rec.src_agent_id.handle)],
+             &dst_gpu = agents_[static_cast<uint32_t>(rec.dst_agent_id.handle)];
+
+  // Assign device_id based on copy direction
+  if (trace_event->type == RocmTracerEventType::MemcpyH2D &&
+      dst_gpu.type == ROCPROFILER_AGENT_TYPE_GPU) {
+    trace_event->device_id = dst_gpu.id.handle;  // Destination is GPU
+  } else if (trace_event->type == RocmTracerEventType::MemcpyD2H &&
+             src_gpu.type == ROCPROFILER_AGENT_TYPE_GPU) {
+    trace_event->device_id = src_gpu.id.handle;  // Source is GPU
+  } else if (trace_event->type == RocmTracerEventType::MemcpyD2D) {
+    // Prefer destination GPU for D2D
+    trace_event->device_id = dst_gpu.id.handle;
+  } else {
+    // Fallback for MemcpyOther or HOST_TO_HOST
+    if (dst_gpu.type == ROCPROFILER_AGENT_TYPE_GPU) {
+      trace_event->device_id = dst_gpu.id.handle;
+    } else if (src_gpu.type == ROCPROFILER_AGENT_TYPE_GPU) {
+      trace_event->device_id = src_gpu.id.handle;
+    } else {
+      LOG(WARNING) << "No GPU ID available for memory copy operation: "
+                   << trace_event->name << ", src_agent_type=" << src_gpu.type
+                   << ", dst_agent_type=" << dst_gpu.type;
+      trace_event->device_id = 0;  // Invalid ID or default
+    }
+  }
+
+  trace_event->source = RocmTracerEventSource::Activity;
+  trace_event->domain = RocmTracerEventDomain::HIP_OPS;
+  trace_event->start_time_ns = rec.start_timestamp;
+  trace_event->end_time_ns = rec.end_timestamp;
+  trace_event->correlation_id = rec.correlation_id.internal;
+  trace_event->annotation =
+      annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->thread_id = rec.thread_id;
+  // we do not know valid stream ID for memcpy
+  // rec.stream_id.handle;
+  trace_event->stream_id = RocmTracerEvent::kInvalidStreamId;
+  trace_event->memcpy_info = MemcpyDetails{
+      .num_bytes = rec.bytes,
+      .destination = static_cast<uint32_t>(dst_gpu.id.handle),
+      .async = false,
+  };
+
+  VLOG(2) << "copy bytes: " << trace_event->memcpy_info.num_bytes
+            << " stream: " << trace_event->stream_id << " src_id "
+            << trace_event->device_id << " dst_id "
+            << trace_event->memcpy_info.destination;
+}
+
+void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
+                             RocmTracerEvent* trace_event) {
+  const auto& rec =
+      *static_cast<const rocprofiler_buffer_tracing_kernel_dispatch_record_t*>(
+          hdr->payload);
+
+  const auto& kinfo = rec.dispatch_info;
+  trace_event->type = RocmTracerEventType::Kernel;
+  trace_event->source = RocmTracerEventSource::Activity;
+  trace_event->domain = RocmTracerEventDomain::HIP_OPS;
+  trace_event->name = "??";
+  trace_event->start_time_ns = rec.start_timestamp;
+  trace_event->end_time_ns = rec.end_timestamp;
+  trace_event->device_id = kinfo.agent_id.handle;
+  trace_event->correlation_id = rec.correlation_id.internal;
+  trace_event->annotation =
+      annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->thread_id = rec.thread_id;
+  trace_event->stream_id = kinfo.queue_id.handle;
+  trace_event->kernel_info = KernelDetails{
+      .registers_per_thread = 0,
+      .static_shared_memory_usage = 0,
+      .dynamic_shared_memory_usage = 0,
+      .block_x = kinfo.workgroup_size.x,
+      .block_y = kinfo.workgroup_size.y,
+      .block_z = kinfo.workgroup_size.z,
+      .grid_x = kinfo.grid_size.x,
+      .grid_y = kinfo.grid_size.y,
+      .grid_z = kinfo.grid_size.z,
+      .func_ptr = nullptr,
+  };
+
+  auto it = kernel_info_.find(kinfo.kernel_id);
+  if (it != kernel_info_.end()) trace_event->name = it->second.name;
+}
+
+void RocmTracer::TracingCallback(rocprofiler_context_id_t context,
+                                 rocprofiler_buffer_id_t buffer_id,
+                                 rocprofiler_record_header_t** headers,
+                                 size_t num_headers, uint64_t drop_count) {
+  if (collector() == nullptr) return;
+  if (num_headers == 0) return;
+  assert(drop_count == 0 && "drop count should be zero for lossless policy");
+
+  if (headers == nullptr) {
+    LOG(ERROR)
+        << "rocprofiler invoked a buffer callback with a null pointer to the "
+           "array of headers. this should never happen";
+    return;
+  }
+
+  for (size_t i = 0; i < num_headers; i++) {
+    RocmTracerEvent event;
+    auto header = headers[i];
+
+    if (header->category != ROCPROFILER_BUFFER_CATEGORY_TRACING) continue;
+
+    switch (header->kind) {
+      case ROCPROFILER_BUFFER_TRACING_HIP_RUNTIME_API:
+        HipApiEvent(header, &event);
+        break;
+
+      case ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH:
+        KernelEvent(header, &event);
+        break;
+
+      case ROCPROFILER_BUFFER_TRACING_MEMORY_COPY:
+        MemcpyEvent(header, &event);
+        break;
+
+      default:
+        continue;
+    }  // switch
+
+    absl::MutexLock lock(&collector_mutex_);
+    if (collector()) {
+      collector()->AddEvent(std::move(event), false);
+    }
+  }  // for
+}
+
+void RocmTracer::CodeObjectCallback(
+    rocprofiler_callback_tracing_record_t record, void* callback_data) {
+  if (record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
+      record.operation == ROCPROFILER_CODE_OBJECT_LOAD) {
+    if (record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD) {
+      // mainly for debugging
+      LOG(WARNING)
+          << "Callback phase unload without registering kernel names ...";
+    }
+  } else if (record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
+             record.operation ==
+                 ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER) {
+    auto* data = static_cast<kernel_symbol_data_t*>(record.payload);
+    if (record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD) {
+      absl::MutexLock lock(&kernel_lock_);
+      kernel_info_.emplace(
+          data->kernel_id,
+          ProfilerKernelInfo{tsl::port::MaybeAbiDemangle(data->kernel_name),
+                             *data});
+    } else if (record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD) {
+      // FIXME: clear these?  At minimum need kernel names at shutdown, async
+      // completion We don't erase it just in case a buffer callback still needs
+      // this kernel_info_.erase(data->kernel_id);
+    }
+  }
+}
+
+static void code_object_callback(rocprofiler_callback_tracing_record_t record,
+                                 rocprofiler_user_data_t* user_data,
+                                 void* callback_data) {
+  RocmTracer::GetRocmTracerSingleton().CodeObjectCallback(record,
+                                                          callback_data);
+}
+
+static void tool_tracing_callback(rocprofiler_context_id_t context,
+                                  rocprofiler_buffer_id_t buffer_id,
+                                  rocprofiler_record_header_t** headers,
+                                  size_t num_headers, void* user_data,
+                                  uint64_t drop_count) {
+  RocmTracer::GetRocmTracerSingleton().TracingCallback(
+      context, buffer_id, headers, num_headers, drop_count);
+}
+
+int RocmTracer::toolInit(rocprofiler_client_finalize_t fini_func,
+                         void* tool_data) {
+  // Gather API names with rocprofiler-sdk api call
+  name_info_ = GetCallbackTracingNames();
+
+  // Gather agent info
+  num_gpus_ = 0;
+  for (const auto& agent : GetGpuDeviceAgents()) {
+    LOG(INFO) << "agent id = " << agent.id.handle
+              << ", dev = " << agent.device_id
+              << ", name = " << (agent.name ? agent.name : "null");
+    agents_[agent.id.handle] = agent;
+    if (agent.type == ROCPROFILER_AGENT_TYPE_GPU) {
+      num_gpus_++;
+    }
+  }
+
+  // Utility context to gather code‑object info
+  rocprofiler_create_context(&utility_context_);
+
+  // buffered tracing
+  auto code_object_ops = std::vector<rocprofiler_tracing_operation_t>{
+      ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER};
+  // rocprofiler-sdk api call for code_object callbacks
+  rocprofiler_configure_callback_tracing_service(
+      utility_context_, ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT,
+      code_object_ops.data(), code_object_ops.size(), code_object_callback,
+      nullptr);
+
+  rocprofiler_start_context(utility_context_);
+  LOG(INFO) << "rocprofiler start utilityContext";
+
+  // a multiple of the page size, and the gap allows the buffer to absorb bursts
+  // of GPU events
+  constexpr auto buffer_size_bytes = 100 * 4096;
+  constexpr auto buffer_watermark_bytes = 20 * 4096;
+
+  // Utility context to gather code‑object info
+  rocprofiler_create_context(&context_);
+  // rocprofiler-sdk api call for buffer callbacks
+  rocprofiler_create_buffer(context_, buffer_size_bytes, buffer_watermark_bytes,
+                            ROCPROFILER_BUFFER_POLICY_LOSSLESS,
+                            tool_tracing_callback, tool_data, &buffer_);
+
+  rocprofiler_configure_buffer_tracing_service(
+      context_, ROCPROFILER_BUFFER_TRACING_HIP_RUNTIME_API, nullptr, 0,
+      buffer_);
+
+  rocprofiler_configure_buffer_tracing_service(
+      context_, ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH, nullptr, 0,
+      buffer_);
+
+  rocprofiler_configure_buffer_tracing_service(
+      context_, ROCPROFILER_BUFFER_TRACING_MEMORY_COPY, nullptr, 0, buffer_);
+
+  {
+    // for annotations
+    const rocprofiler_tracing_operation_t* hip_ops = nullptr;
+    size_t hip_ops_count = 0;
+    // rocprofiler-sdk api callbacks
+    rocprofiler_configure_callback_tracing_service(
+        context_, ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API, hip_ops,
+        hip_ops_count,
+        [](rocprofiler_callback_tracing_record_t record,
+           rocprofiler_user_data_t*, void*) {
+          if (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+            const std::string& annotation =
+                tsl::profiler::AnnotationStack::Get();
+            if (!annotation.empty()) {
+              RocmTracer::GetRocmTracerSingleton().annotation_map()->Add(
+                  record.correlation_id.internal, annotation);
+            }
+          }
+        },
+        nullptr);
+  }
+
+  auto client_thread = rocprofiler_callback_thread_t{};
+  rocprofiler_create_callback_thread(&client_thread);
+  rocprofiler_assign_callback_thread(buffer_, client_thread);
+
+  int isValid = 0;
+  rocprofiler_context_is_valid(context_, &isValid);
+  if (isValid == 0) {
+    context_.handle = 0;  // Leak on failure.
+    return -1;
+  }
+
+  return 0;
+}
+
+void RocmTracer::toolFinalize(void* tool_data) {
+  auto& obj = RocmTracer::GetRocmTracerSingleton();
+  LOG(INFO) << "Calling toolFinalize!";
+  rocprofiler_stop_context(obj.utility_context_);
+  obj.utility_context_.handle = 0;
+  rocprofiler_stop_context(obj.context_);
+  // flush buffer here or in disable?
+  obj.context_.handle = 0;
+}
+
+void RocmTracer::Disable() {
+  absl::MutexLock lock(&collector_mutex_);
+  collector_->Flush();
+  collector_ = nullptr;
+  api_tracing_enabled_ = false;
+  activity_tracing_enabled_ = false;
+  LOG(INFO) << "GpuTracer stopped";
+}
+
+// ----------------------------------------------------------------------------
+// Helper that returns all device agents (GPU + CPU for now).
+// ----------------------------------------------------------------------------
+std::vector<rocprofiler_agent_v0_t> GetGpuDeviceAgents() {
+  std::vector<rocprofiler_agent_v0_t> agents;
+
+  rocprofiler_query_available_agents_cb_t iterate_cb =
+      [](rocprofiler_agent_version_t agents_ver, const void** agents_arr,
+         size_t num_agents, void* udata) {
+        if (agents_ver != ROCPROFILER_AGENT_INFO_VERSION_0) {
+          LOG(ERROR) << "unexpected rocprofiler agent version: " << agents_ver;
+          return ROCPROFILER_STATUS_ERROR;
+        }
+        auto* agents_vec =
+            static_cast<std::vector<rocprofiler_agent_v0_t>*>(udata);
+        for (size_t i = 0; i < num_agents; ++i) {
+          const auto* agent =
+              static_cast<const rocprofiler_agent_v0_t*>(agents_arr[i]);
+          agents_vec->push_back(*agent);
+        }
+        return ROCPROFILER_STATUS_SUCCESS;
+      };
+
+  rocprofiler_query_available_agents(ROCPROFILER_AGENT_INFO_VERSION_0,
+                                     iterate_cb, sizeof(rocprofiler_agent_t),
+                                     static_cast<void*>(&agents));
+  return agents;
+}
+
+static int toolInitStatic(rocprofiler_client_finalize_t finalize_func,
+                          void* tool_data) {
+  return RocmTracer::GetRocmTracerSingleton().toolInit(finalize_func,
+                                                       tool_data);
+}
+
+// ----------------------------------------------------------------------------
+// C‑linkage entry‑point expected by rocprofiler-sdk.
+// ----------------------------------------------------------------------------
+extern "C" rocprofiler_tool_configure_result_t* rocprofiler_configure(
+    uint32_t version, const char* runtime_version, uint32_t priority,
+    rocprofiler_client_id_t* id) {
+  auto& obj = RocmTracer::GetRocmTracerSingleton();  // Ensure constructed,
+                                                     // critical for tracing.
+
+  id->name = "XLA-with-rocprofiler-sdk";
+  obj.client_id_ = id;
+
+  LOG(INFO) << "Configure rocprofiler-sdk...";
+
+  const uint32_t major = version / 10000;
+  const uint32_t minor = (version % 10000) / 100;
+  const uint32_t patch = version % 100;
+
+  LOG(INFO) << absl::StrFormat(
+      "%s Configure XLA with rocprofv3... (priority=%u) is using "
+      "rocprofiler-sdk v%u.%u.%u (%s)",
+      id->name, static_cast<unsigned>(priority), static_cast<unsigned>(major),
+      static_cast<unsigned>(minor), static_cast<unsigned>(patch),
+      runtime_version ? runtime_version : "unknown");
+
+  // rocprofiler-sdk api call
+  static rocprofiler_tool_configure_result_t cfg{
+      sizeof(rocprofiler_tool_configure_result_t), &toolInitStatic,
+      &RocmTracer::toolFinalize, nullptr};
+
+  return &cfg;
+}
+
+}  // namespace profiler
+}  // namespace xla
+
+// force to initialize the hooks before hipInit, if we don't use this
+// some high-level framwork, e.g., maxtext, calls hipInit before 
+// rocprofiler_configure, then no tracing callbacks will be triggered,
+// as a result, there is no gpu trace events.  
+void __attribute__((constructor)) init_rocm_lib() {
+  rocprofiler_force_configure(xla::profiler::rocprofiler_configure);
+}

--- a/xla/backends/profiler/gpu/rocm_profiler_sdk.h
+++ b/xla/backends/profiler/gpu/rocm_profiler_sdk.h
@@ -1,0 +1,139 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_PROFILER_SDK_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_PROFILER_SDK_H_
+
+#include "xla/stream_executor/rocm/roctracer_wrapper.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+
+#include "absl/container/fixed_array.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/container/node_hash_set.h"
+#include "absl/types/optional.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/macros.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/types.h"
+
+namespace xla {
+namespace profiler {
+// forward declare (interface)
+class RocmTraceCollector;
+
+struct RocmTracerOptions {
+  // maximum number of annotation strings that AnnotationMap in RocmTracer can
+  // store. e.g. 1M
+  uint64_t max_annotation_strings;
+};
+
+// The class use to enable rocprofiler-sdk buffered callback/activity tracing
+// and forward the collected trace events to RocmTraceCollector. There should be
+// only one RocmTracer per process.
+class RocmTracer {
+ public:
+  // Returns a reference to the singleton instance of RocmTracer.
+  // This ensures that only one global instance exists throughout the process
+  // lifetime. The first call to this function lazily constructs the instance in
+  // a thread-safe manner. Subsequent calls return the same instance, enabling
+  // centralized tracer state management.
+  static RocmTracer& GetRocmTracerSingleton();
+
+  // Only one profile session can be live in the same time.
+  bool IsAvailable() const;
+
+  void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector_);
+  void Disable();
+
+  static uint64_t GetTimestamp();
+  uint32_t NumGpus() const { return num_gpus_; };
+  RocmTraceCollector* collector() { return collector_; }
+
+  int toolInit(rocprofiler_client_finalize_t finalize_func, void* tool_data);
+  static void toolFinalize(void* tool_data);
+
+  void TracingCallback(rocprofiler_context_id_t context,
+                       rocprofiler_buffer_id_t buffer_id,
+                       rocprofiler_record_header_t** headers,
+                       size_t num_headers, uint64_t drop_count);
+
+  void CodeObjectCallback(rocprofiler_callback_tracing_record_t record,
+                          void* callback_data);
+
+  AnnotationMap* annotation_map() { return &annotation_map_; }
+
+ protected:
+  // protected constructor for injecting mock cupti interface for testing.
+  RocmTracer() = default;
+
+  void HipApiEvent(const rocprofiler_record_header_t* hdr, RocmTracerEvent* ev);
+  void KernelEvent(const rocprofiler_record_header_t* hdr, RocmTracerEvent* ev);
+  void MemcpyEvent(const rocprofiler_record_header_t* hdr, RocmTracerEvent* ev);
+
+ private:
+  uint32_t num_gpus_{0};
+  std::optional<RocmTracerOptions> options_;
+  RocmTraceCollector* collector_{nullptr};
+  absl::Mutex collector_mutex_;
+
+  bool api_tracing_enabled_{false};
+  bool activity_tracing_enabled_{false};
+
+  AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
+
+ public:
+  // Type alias for rocprofiler-sdk kernel symbol registration callback data
+  // structure
+  using kernel_symbol_data_t =
+      rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;
+
+  struct ProfilerKernelInfo {
+    std::string name;
+    kernel_symbol_data_t data;
+  };
+
+  using kernel_info_map_t =
+      std::unordered_map<rocprofiler_kernel_id_t, ProfilerKernelInfo>;
+
+  using agent_info_map_t = std::unordered_map<uint64_t, rocprofiler_agent_v0_t>;
+
+  using callback_name_info = rocprofiler::sdk::callback_name_info;
+
+  rocprofiler_client_id_t* client_id_{nullptr};
+  // Contexts ----------------------------------------------------------
+  // for registering kernel names
+  rocprofiler_context_id_t utility_context_{};
+  // for buffered callback services
+  rocprofiler_context_id_t context_{};
+  rocprofiler_buffer_id_t buffer_{};
+
+  // Maps & misc -------------------------------------------------------
+  kernel_info_map_t kernel_info_{};
+  absl::Mutex kernel_lock_;
+
+  callback_name_info name_info_;
+  agent_info_map_t agents_;
+
+ public:
+  // Disable copy and move.
+  RocmTracer(const RocmTracer&) = delete;
+  RocmTracer& operator=(const RocmTracer&) = delete;
+};
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_PROFILER_SDK_H_

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -1,4 +1,4 @@
-/* Copyright 2024 The OpenXLA Authors. All Rights Reserved.
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,202 +13,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
-#define XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_FACADE_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_FACADE_H_
 
-#include <optional>
+// Backend: 3=v3 (rocprofiler-sdk), 1=v1 (roctracer). Default to v3.
+#ifndef XLA_GPU_ROCM_TRACER_BACKEND
+#define XLA_GPU_ROCM_TRACER_BACKEND 3
+#endif
 
-#include "absl/container/fixed_array.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
-#include "absl/container/node_hash_set.h"
-#include "xla/backends/profiler/gpu/rocm_collector.h"
-#include "xla/stream_executor/rocm/roctracer_wrapper.h"
-#include "tsl/platform/errors.h"
-#include "tsl/platform/macros.h"
-#include "tsl/platform/status.h"
-#include "tsl/platform/types.h"
+#if XLA_GPU_ROCM_TRACER_BACKEND == 3
+#include "xla/backends/profiler/gpu/rocm_profiler_sdk.h"
+#else
+#include "xla/backends/profiler/gpu/rocm_tracer_v1.h"
+#endif
 
-namespace xla {
-namespace profiler {
-
-enum class RocmTracerSyncTypes {
-  InvalidSync = 0,
-  StreamSynchronize,  // caller thread wait stream to become empty
-  EventSynchronize,   // caller thread will block until event happens
-  StreamWait          // compute stream will wait for event to happen
-};
-
-struct RocmTracerOptions {
-  std::set<uint32_t> api_tracking_set;  // actual api set we want to profile
-
-  // map of domain --> ops for which we need to enable the API callbacks
-  // If the ops vector is empty, then enable API callbacks for entire domain
-  absl::flat_hash_map<activity_domain_t, std::vector<uint32_t> > api_callbacks;
-
-  // map of domain --> ops for which we need to enable the Activity records
-  // If the ops vector is empty, then enable Activity records for entire domain
-  absl::flat_hash_map<activity_domain_t, std::vector<uint32_t> >
-      activity_tracing;
-};
-
-class RocmTracer;
-
-class RocmApiCallbackImpl {
- public:
-  RocmApiCallbackImpl(const RocmTracerOptions& options, RocmTracer* tracer,
-                      RocmTraceCollector* collector)
-      : options_(options), tracer_(tracer), collector_(collector) {}
-
-  absl::Status operator()(uint32_t domain, uint32_t cbid, const void* cbdata);
-
- private:
-  void AddKernelEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
-                                 uint64_t enter_time, uint64_t exit_time);
-  void AddNormalMemcpyEventUponApiExit(uint32_t cbid,
-                                       const hip_api_data_t* data,
-                                       uint64_t enter_time, uint64_t exit_time);
-  void AddMemcpyPeerEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
-                                     uint64_t enter_time, uint64_t exit_time);
-  void AddMemsetEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
-                                 uint64_t enter_time, uint64_t exit_time);
-  void AddMallocFreeEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
-                                     uint32_t device_id, uint64_t enter_time,
-                                     uint64_t exit_time);
-  void AddStreamSynchronizeEventUponApiExit(uint32_t cbid,
-                                            const hip_api_data_t* data,
-                                            uint64_t enter_time,
-                                            uint64_t exit_time);
-  void AddSynchronizeEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
-                                      uint64_t enter_time, uint64_t exit_time);
-
-  RocmTracerOptions options_;
-  RocmTracer* tracer_ = nullptr;
-  RocmTraceCollector* collector_ = nullptr;
-  tsl::mutex api_call_start_mutex_;
-  // TODO(rocm-profiler): replace this with absl hashmap
-  // keep a map from the corr. id to enter time for API callbacks.
-  std::map<uint32_t, uint64_t> api_call_start_time_
-      TF_GUARDED_BY(api_call_start_mutex_);
-};
-
-class RocmActivityCallbackImpl {
- public:
-  RocmActivityCallbackImpl(const RocmTracerOptions& options, RocmTracer* tracer,
-                           RocmTraceCollector* collector)
-      : options_(options), tracer_(tracer), collector_(collector) {}
-
-  absl::Status operator()(const char* begin, const char* end);
-
- private:
-  void AddHipKernelActivityEvent(const roctracer_record_t* record);
-  void AddNormalHipMemcpyActivityEvent(const roctracer_record_t* record);
-  void AddHipMemsetActivityEvent(const roctracer_record_t* record);
-  void AddHipMallocActivityEvent(const roctracer_record_t* record);
-  void AddHipStreamSynchronizeActivityEvent(const roctracer_record_t* record);
-  void AddHccKernelActivityEvent(const roctracer_record_t* record);
-  void AddNormalHipOpsMemcpyActivityEvent(const roctracer_record_t* record);
-  void AddHipOpsMemsetActivityEvent(const roctracer_record_t* record);
-  RocmTracerOptions options_;
-  RocmTracer* tracer_ = nullptr;
-  RocmTraceCollector* collector_ = nullptr;
-};
-
-// The class uses roctracer callback/activity API and forward the collected
-// trace events to RocmTraceCollector. There should be only one RocmTracer
-// per process.
-class RocmTracer {
- public:
-  // Returns a pointer to singleton RocmTracer.
-  static RocmTracer* GetRocmTracerSingleton();
-
-  // Only one profile session can be live in the same time.
-  bool IsAvailable() const;
-
-  void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector);
-  void Disable();
-
-  absl::Status ApiCallbackHandler(uint32_t domain, uint32_t cbid,
-                                  const void* cbdata);
-  absl::Status ActivityCallbackHandler(const char* begin, const char* end);
-
-  static uint64_t GetTimestamp();
-  static int NumGpus();
-
-  void AddToPendingActivityRecords(uint32_t correlation_id) {
-    pending_activity_records_.Add(correlation_id);
-  }
-
-  void RemoveFromPendingActivityRecords(uint32_t correlation_id) {
-    pending_activity_records_.Remove(correlation_id);
-  }
-
-  void ClearPendingActivityRecordsCount() { pending_activity_records_.Clear(); }
-
-  size_t GetPendingActivityRecordsCount() {
-    return pending_activity_records_.Count();
-  }
-
- protected:
-  // protected constructor for injecting mock cupti interface for testing.
-  explicit RocmTracer() : num_gpus_(NumGpus()) {}
-
- private:
-  absl::Status EnableApiTracing();
-  absl::Status DisableApiTracing();
-
-  absl::Status EnableActivityTracing();
-  absl::Status DisableActivityTracing();
-
-  int num_gpus_;
-  std::optional<RocmTracerOptions> options_;
-  RocmTraceCollector* collector_ = nullptr;
-
-  bool api_tracing_enabled_ = false;
-  bool activity_tracing_enabled_ = false;
-
-  RocmApiCallbackImpl* api_cb_impl_;
-  RocmActivityCallbackImpl* activity_cb_impl_;
-
-  class PendingActivityRecords {
-   public:
-    // add a correlation id to the pending set
-    void Add(uint32_t correlation_id) {
-      absl::MutexLock lock(&mutex);
-      pending_set.insert(correlation_id);
-    }
-    // remove a correlation id from the pending set
-    void Remove(uint32_t correlation_id) {
-      absl::MutexLock lock(&mutex);
-      pending_set.erase(correlation_id);
-    }
-    // clear the pending set
-    void Clear() {
-      absl::MutexLock lock(&mutex);
-      pending_set.clear();
-    }
-    // count the number of correlation ids in the pending set
-    size_t Count() {
-      absl::MutexLock lock(&mutex);
-      return pending_set.size();
-    }
-
-   private:
-    // set of co-relation ids for which the hcc activity record is pending
-    absl::flat_hash_set<uint32_t> pending_set;
-    // the callback which processes the activity records (and consequently
-    // removes items from the pending set) is called in a separate thread
-    // from the one that adds item to the list.
-    absl::Mutex mutex;
-  };
-  PendingActivityRecords pending_activity_records_;
-
- public:
-  // Disable copy and move.
-  RocmTracer(const RocmTracer&) = delete;
-  RocmTracer& operator=(const RocmTracer&) = delete;
-};
-
-}  // namespace profiler
-}  // namespace xla
-#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_FACADE_H_

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -1,0 +1,121 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tsl/platform/test.h"
+#include <gtest/gtest.h>
+
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "xla/backends/profiler/gpu/rocm_tracer.h"
+#include "xla/backends/profiler/gpu/rocm_collector.h"
+
+namespace xla {
+namespace profiler {
+namespace test {
+
+// Minimal mock collector implementation based on RocmTraceCollectorImpl.
+class TestRocmTraceCollector : public RocmTraceCollectorImpl {
+ public:
+  TestRocmTraceCollector(const RocmTraceCollectorOptions& options,
+                         uint64_t start_walltime_ns, uint64_t start_gputime_ns)
+      : RocmTraceCollectorImpl(options, start_walltime_ns, start_gputime_ns) {}
+
+  void Export(XSpace* space) override {
+    exported_ = true;
+    exported_space_ = space;
+  }
+
+  void OnEventsDropped(const std::string& reason,
+                       uint32_t correlation_id) override {
+    dropped_reason_ = reason;
+    dropped_id_ = correlation_id;
+  }
+
+  bool exported() const { return exported_; }
+  const std::string& dropped_reason() const { return dropped_reason_; }
+  uint32_t dropped_id() const { return dropped_id_; }
+  XSpace* exported_space() const { return exported_space_; }
+
+ private:
+  bool exported_ = false;
+  std::string dropped_reason_;
+  uint32_t dropped_id_ = 0;
+  XSpace* exported_space_ = nullptr;
+};
+
+// Utility to create valid options for the test collector.
+std::unique_ptr<TestRocmTraceCollector> CreateTestCollector() {
+  RocmTraceCollectorOptions options;
+  options.max_callback_api_events = 2 * 1024 * 1024;
+  options.max_activity_api_events = 2 * 1024 * 1024;
+  options.max_annotation_strings = 1024 * 1024;
+  options.num_gpus = 1;
+
+  uint64_t walltime_ns = RocmTracer::GetTimestamp();
+  uint64_t gputime_ns = RocmTracer::GetTimestamp();
+
+  return std::make_unique<TestRocmTraceCollector>(options, walltime_ns,
+                                                  gputime_ns);
+}
+
+TEST(RocmTracerTest, SingletonInstance) {
+  LOG(INFO) << "Before RocmTracer::GetRocmTracerSingleton()";
+  RocmTracer& tracer1 = RocmTracer::GetRocmTracerSingleton();
+  RocmTracer& tracer2 = RocmTracer::GetRocmTracerSingleton();
+  LOG(INFO) << "Before RocmTracer::GetRocmTracerSingleton()";
+  EXPECT_EQ(&tracer1, &tracer2) << "RocmTracer must be a singleton";
+}
+
+TEST(RocmTracerTest, InitialStateIsAvailable) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  EXPECT_TRUE(tracer.IsAvailable())
+      << "Tracer should be available before Enable()";
+}
+
+TEST(RocmTracerTest, EnableAndDisableLifecycle) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  auto collector = CreateTestCollector();
+
+  RocmTracerOptions tracer_options{/*max_annotation_strings=*/128};
+  tracer.Enable(tracer_options, collector.get());
+
+  EXPECT_FALSE(tracer.IsAvailable())
+      << "Tracer should not be available after Enable()";
+  EXPECT_EQ(tracer.collector(), collector.get())
+      << "Collector should be set after Enable()";
+  ASSERT_NE(tracer.annotation_map(), nullptr)
+      << "Annotation map should be initialized";
+
+  tracer.Disable();
+
+  EXPECT_TRUE(tracer.IsAvailable())
+      << "Tracer should be available after Disable()";
+}
+
+TEST(RocmTracerTest, AnnotationMapWorks) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  AnnotationMap* map = tracer.annotation_map();
+  ASSERT_NE(map, nullptr);
+
+  uint64_t id = 42;
+  std::string annotation = "matmul_fused_op";
+  map->Add(id, annotation);
+
+  absl::string_view result = map->LookUp(id);
+  EXPECT_EQ(result, annotation);
+}
+
+}  // namespace test
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -1,0 +1,101 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+
+// for rocprofiler-sdk
+namespace xla {
+namespace profiler {
+
+//-----------------------------------------------------------------------------
+const char* GetRocmTracerEventSourceName(const RocmTracerEventSource& source) {
+  switch (source) {
+    case RocmTracerEventSource::ApiCallback:
+      return "ApiCallback";
+      break;
+    case RocmTracerEventSource::Activity:
+      return "Activity";
+      break;
+    case RocmTracerEventSource::Invalid:
+      return "Invalid";
+      break;
+    default:
+      DCHECK(false);
+      return "";
+  }
+  return "";
+}
+
+// FIXME(rocm-profiler): These domain names are not consistent with the
+// GetActivityDomainName function
+const char* GetRocmTracerEventDomainName(const RocmTracerEventDomain& domain) {
+  switch (domain) {
+    case RocmTracerEventDomain::HIP_API:
+      return "HIP_API";
+      break;
+    case RocmTracerEventDomain::HIP_OPS:
+      return "HIP_OPS";
+      break;
+    default:
+      LOG(WARNING) << "RocmTracerEventDomain::InvalidDomain";
+      DCHECK(false);
+      return "";
+  }
+  return "";
+}
+
+const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type) {
+#define OO(x)                  \
+  case RocmTracerEventType::x: \
+    return #x;
+  switch (type) {
+    OO(Kernel)
+    OO(MemcpyH2D)
+    OO(MemcpyD2H)
+    OO(MemcpyD2D)
+    OO(MemcpyOther)
+    OO(MemoryAlloc)
+    OO(MemoryFree)
+    OO(Memset)
+    OO(Synchronization)
+    OO(Generic)
+    default:;
+  }
+#undef OO
+  DCHECK(false);
+  return "";
+}
+
+void AnnotationMap::Add(uint32_t correlation_id,
+                        const std::string& annotation) {
+  if (annotation.empty()) return;
+  VLOG(3) << "Add annotation: " << " correlation_id=" << correlation_id
+          << ", annotation: " << annotation;
+  absl::MutexLock lock(&map_.mutex);
+  if (map_.annotations.size() < max_size_) {
+    absl::string_view annotation_str =
+        *map_.annotations.insert(annotation).first;
+    map_.correlation_map.emplace(correlation_id, annotation_str);
+  }
+}
+
+absl::string_view AnnotationMap::LookUp(uint32_t correlation_id) {
+  absl::MutexLock lock(&map_.mutex);
+  auto it = map_.correlation_map.find(correlation_id);
+  return it != map_.correlation_map.end() ? it->second : absl::string_view();
+}
+
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -1,0 +1,206 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_UTILS_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_UTILS_H_
+
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <time.h>
+#include <unistd.h>
+#include <chrono>
+#include <unistd.h>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/string_view.h"
+#include "absl/container/node_hash_set.h"
+#include "absl/container/node_hash_map.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/tsl/profiler/backends/cpu/annotation_stack.h"
+#include "xla/tsl/profiler/utils/time_utils.h"
+
+#include "tsl/platform/errors.h"
+#include "tsl/platform/macros.h"
+
+namespace xla {
+namespace profiler {
+
+struct MemcpyDetails {
+  // The amount of data copied for memcpy events.
+  size_t num_bytes;
+  // The destination device for peer-2-peer communication (memcpy). The source
+  // device is implicit: it's the current device.
+  uint32_t destination;
+  // Whether or not the memcpy is asynchronous.
+  bool async;
+};
+
+struct MemAllocDetails {
+  // The amount of data requested for cudaMalloc events.
+  uint64_t num_bytes;
+};
+
+struct MemsetDetails {
+  // The number of memory elements getting set
+  size_t num_bytes;
+  // Whether or not the memset is asynchronous.
+  bool async;
+};
+
+struct KernelDetails {
+  // The number of registers used in this kernel.
+  uint32_t registers_per_thread;
+  // The amount of shared memory space used by a thread block.
+  uint32_t static_shared_memory_usage;
+  // The amount of dynamic memory space used by a thread block.
+  uint32_t dynamic_shared_memory_usage;
+  // X-dimension of a thread block.
+  uint32_t block_x;
+  // Y-dimension of a thread block.
+  uint32_t block_y;
+  // Z-dimension of a thread block.
+  uint32_t block_z;
+  // X-dimension of a grid.
+  uint32_t grid_x;
+  // Y-dimension of a grid.
+  uint32_t grid_y;
+  // Z-dimension of a grid.
+  uint32_t grid_z;
+
+  // kernel address. Used for calculating core occupancy
+  void* func_ptr;
+};
+
+enum class RocmTracerEventType {
+  Unsupported = 0,
+  Kernel,
+  MemcpyH2D,
+  MemcpyD2H,
+  MemcpyD2D,
+  MemcpyP2P,
+  MemcpyOther,
+  MemoryAlloc,
+  MemoryFree,
+  Memset,
+  Synchronization,
+  Generic,
+};
+
+const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type);
+
+enum class RocmTracerEventSource {
+  Invalid = 0,
+  ApiCallback,
+  Activity,
+};
+
+const char* GetRocmTracerEventSourceName(const RocmTracerEventSource& source);
+
+enum class RocmTracerEventDomain {
+  InvalidDomain = 0,
+  HIP_API,
+  HIP_OPS,
+};
+
+const char* GetRocmTracerEventDomainName(const RocmTracerEventDomain& domain);
+
+// RocmTracerSyncTypes forward declaration
+enum class RocmTracerSyncTypes;
+
+struct SynchronizationDetails {
+  RocmTracerSyncTypes sync_type;
+};
+
+struct RocmTracerEvent {
+  static constexpr uint32_t kInvalidDeviceId =
+      std::numeric_limits<uint32_t>::max();
+  static constexpr uint64_t kInvalidThreadId =
+      std::numeric_limits<uint64_t>::max();
+  static constexpr uint32_t kInvalidCorrelationId =
+      std::numeric_limits<uint32_t>::max();
+  static constexpr uint64_t kInvalidStreamId =
+      std::numeric_limits<uint64_t>::max();
+  RocmTracerEventType type;
+  RocmTracerEventSource source = RocmTracerEventSource::Invalid;
+  RocmTracerEventDomain domain;
+  std::string name;
+  // This points to strings in AnnotationMap, which should outlive the point
+  // where serialization happens.
+  absl::string_view annotation;
+  absl::string_view roctx_range;
+  uint64_t start_time_ns = 0;
+  uint64_t end_time_ns = 0;
+  uint32_t device_id = kInvalidDeviceId;
+  uint32_t correlation_id = kInvalidCorrelationId;
+  uint64_t thread_id = kInvalidThreadId;
+  uint64_t stream_id = kInvalidStreamId;
+
+  union {
+    MemcpyDetails memcpy_info;                    // If type == Memcpy*
+    MemsetDetails memset_info;                    // If type == Memset*
+    MemAllocDetails memalloc_info;                // If type == MemoryAlloc
+    KernelDetails kernel_info;                    // If type == Kernel
+    SynchronizationDetails synchronization_info;  // If type == Synchronization
+  };
+};
+
+struct RocmTraceCollectorOptions {
+  // Maximum number of events to collect from callback API; if -1, no limit.
+  // if 0, the callback API is enabled to build a correlation map, but no
+  // events are collected.
+  uint64_t max_callback_api_events;
+  // Maximum number of events to collect from activity API; if -1, no limit.
+  uint64_t max_activity_api_events;
+  // Maximum number of annotation strings that we can accommodate.
+  uint64_t max_annotation_strings;
+  // Number of GPUs involved.
+  uint32_t num_gpus;
+};
+
+class AnnotationMap {
+ public:
+  explicit AnnotationMap(uint64_t max_size) : max_size_(max_size) {}
+  void Add(uint32_t correlation_id, const std::string& annotation);
+  absl::string_view LookUp(uint32_t correlation_id);
+
+ private:
+  struct AnnotationMapImpl {
+    // The population/consumption of annotations might happen from multiple
+    // callback/activity api related threads.
+    absl::Mutex mutex;
+    // Annotation tends to be repetitive, use a hash_set to store the strings,
+    // an use the reference to the string in the map.
+    absl::node_hash_set<std::string> annotations;
+    absl::flat_hash_map<uint32_t, absl::string_view> correlation_map;
+  };
+  const uint64_t max_size_;
+  AnnotationMapImpl map_;
+
+ public:
+  // Disable copy and move.
+  AnnotationMap(const AnnotationMap&) = delete;
+  AnnotationMap& operator=(const AnnotationMap&) = delete;
+};
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_UTILS_H_

--- a/xla/backends/profiler/gpu/rocm_tracer_v1.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_v1.cc
@@ -1,4 +1,4 @@
-/* Copyright 2024 The OpenXLA Authors. All Rights Reserved.
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "xla/backends/profiler/gpu/rocm_tracer.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_v1.h"
 
 #include <cstdint>
 
@@ -217,73 +217,6 @@ void DumpActivityRecord(const roctracer_record_t* record,
 
 }  // namespace
 
-const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type) {
-  switch (type) {
-    case RocmTracerEventType::Kernel:
-      return "Kernel";
-    case RocmTracerEventType::MemcpyH2D:
-      return "MemcpyH2D";
-    case RocmTracerEventType::MemcpyD2H:
-      return "MemcpyD2H";
-    case RocmTracerEventType::MemcpyD2D:
-      return "MemcpyD2D";
-    case RocmTracerEventType::MemcpyP2P:
-      return "MemcpyP2P";
-    case RocmTracerEventType::MemcpyOther:
-      return "MemcpyOther";
-    case RocmTracerEventType::MemoryAlloc:
-      return "MemoryAlloc";
-    case RocmTracerEventType::MemoryFree:
-      return "MemoryFree";
-    case RocmTracerEventType::Memset:
-      return "Memset";
-    case RocmTracerEventType::Synchronization:
-      return "Synchronization";
-    case RocmTracerEventType::Generic:
-      return "Generic";
-    default:
-      DCHECK(false);
-      return "";
-  }
-  return "";
-}
-
-const char* GetRocmTracerEventSourceName(const RocmTracerEventSource& source) {
-  switch (source) {
-    case RocmTracerEventSource::ApiCallback:
-      return "ApiCallback";
-      break;
-    case RocmTracerEventSource::Activity:
-      return "Activity";
-      break;
-    case RocmTracerEventSource::Invalid:
-      return "Invalid";
-      break;
-    default:
-      DCHECK(false);
-      return "";
-  }
-  return "";
-}
-
-// FIXME(rocm-profiler): These domain names are not consistent with the
-// GetActivityDomainName function
-const char* GetRocmTracerEventDomainName(const RocmTracerEventDomain& domain) {
-  switch (domain) {
-    case RocmTracerEventDomain::HIP_API:
-      return "HIP_API";
-      break;
-    case RocmTracerEventDomain::HIP_OPS:
-      return "HIP_OPS";
-      break;
-    default:
-      VLOG(3) << "RocmTracerEventDomain::InvalidDomain";
-      DCHECK(false);
-      return "";
-  }
-  return "";
-}
-
 absl::Status RocmApiCallbackImpl::operator()(uint32_t domain, uint32_t cbid,
                                              const void* cbdata) {
   /* Some APIs such as hipMalloc, implicitly work on th devices set by the
@@ -332,7 +265,8 @@ absl::Status RocmApiCallbackImpl::operator()(uint32_t domain, uint32_t cbid,
     // Set up the map from correlation id to annotation string.
     const std::string& annotation = AnnotationStack::Get();
     if (!annotation.empty()) {
-      collector_->annotation_map()->Add(data->correlation_id, annotation);
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->Add(
+          data->correlation_id, annotation);
     }
 
     if (options_.api_tracking_set.find(cbid) ==
@@ -1030,12 +964,16 @@ void RocmActivityCallbackImpl::AddHipKernelActivityEvent(
   event.domain = RocmTracerEventDomain::HIP_API;
   event.type = RocmTracerEventType::Kernel;
   event.source = RocmTracerEventSource::Activity;
-  // event.name =  /* we use the API name instead*/
-  //    se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
+  event.name = /* we use the API name instead*/
+      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
   event.correlation_id = record->correlation_id;
   // TODO(rocm-profiler): CUDA uses device id and correlation ID for finding
   // annotations.
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
 
   event.start_time_ns = record->begin_ns;
   event.end_time_ns = record->end_ns;
@@ -1065,7 +1003,11 @@ void RocmActivityCallbackImpl::AddNormalHipMemcpyActivityEvent(
   event.start_time_ns = record->begin_ns;
   event.end_time_ns = record->end_ns;
   event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
   // TODO(roc-profiler): record->bytes is not a valid value
   // event.memcpy_info.num_bytes = record->bytes;
   event.name =
@@ -1129,7 +1071,11 @@ void RocmActivityCallbackImpl::AddHipMemsetActivityEvent(
   event.name =
       se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
   event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
 
   event.type = RocmTracerEventType::Memset;
 
@@ -1183,7 +1129,11 @@ void RocmActivityCallbackImpl::AddHipMallocActivityEvent(
   event.name =
       se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
   event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
   // similar to CUDA we set this to the default stream
   event.stream_id = 0;
   event.start_time_ns = record->begin_ns;
@@ -1210,7 +1160,11 @@ void RocmActivityCallbackImpl::AddHipStreamSynchronizeActivityEvent(
   event.name =
       se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
   event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
   event.start_time_ns = record->begin_ns;
 
   // making sure it does not have 0ns duration. Otherwise, it may not show up in
@@ -1249,7 +1203,11 @@ void RocmActivityCallbackImpl::AddHccKernelActivityEvent(
   event.type = RocmTracerEventType::Kernel;
   event.source = RocmTracerEventSource::Activity;
   event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
   event.start_time_ns = record->begin_ns;
   event.end_time_ns = record->end_ns;
   event.device_id = record->device_id;
@@ -1277,7 +1235,11 @@ void RocmActivityCallbackImpl::AddNormalHipOpsMemcpyActivityEvent(
   event.name =  // name is stored for debug
       se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
   event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
 
   event.start_time_ns = record->begin_ns;
   event.end_time_ns = record->end_ns;
@@ -1311,7 +1273,11 @@ void RocmActivityCallbackImpl::AddHipOpsMemsetActivityEvent(
   event.name =  // name is stored for debug
       se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
   event.correlation_id = record->correlation_id;
-  event.annotation = collector_->annotation_map()->LookUp(event.correlation_id);
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
 
   event.start_time_ns = record->begin_ns;
   event.end_time_ns = record->end_ns;
@@ -1323,8 +1289,8 @@ void RocmActivityCallbackImpl::AddHipOpsMemsetActivityEvent(
   collector_->AddEvent(std::move(event), false);
 }
 
-/* static */ RocmTracer* RocmTracer::GetRocmTracerSingleton() {
-  static auto* singleton = new RocmTracer();
+RocmTracer& RocmTracer::GetRocmTracerSingleton() {
+  static RocmTracer singleton;
   return singleton;
 }
 

--- a/xla/backends/profiler/gpu/rocm_tracer_v1.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_v1.h
@@ -1,0 +1,219 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_V1_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_V1_H_
+
+#include <optional>
+
+#include "absl/container/fixed_array.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/container/node_hash_set.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "xla/backends/profiler/gpu/rocm_collector.h"
+#include "xla/stream_executor/rocm/roctracer_wrapper.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/macros.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/types.h"
+
+namespace xla {
+namespace profiler {
+
+enum class RocmTracerSyncTypes {
+  InvalidSync = 0,
+  StreamSynchronize,  // caller thread wait stream to become empty
+  EventSynchronize,   // caller thread will block until event happens
+  StreamWait          // compute stream will wait for event to happen
+};
+
+struct RocmTracerOptions {
+  std::set<uint32_t> api_tracking_set;  // actual api set we want to profile
+
+  // map of domain --> ops for which we need to enable the API callbacks
+  // If the ops vector is empty, then enable API callbacks for entire domain
+  absl::flat_hash_map<activity_domain_t, std::vector<uint32_t> > api_callbacks;
+
+  // map of domain --> ops for which we need to enable the Activity records
+  // If the ops vector is empty, then enable Activity records for entire domain
+  absl::flat_hash_map<activity_domain_t, std::vector<uint32_t> >
+      activity_tracing;
+};
+
+class RocmTracer;
+
+class RocmApiCallbackImpl {
+ public:
+  RocmApiCallbackImpl(const RocmTracerOptions& options, RocmTracer* tracer,
+                      RocmTraceCollector* collector)
+      : options_(options), tracer_(tracer), collector_(collector) {}
+
+  absl::Status operator()(uint32_t domain, uint32_t cbid, const void* cbdata);
+
+ private:
+  void AddKernelEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
+                                 uint64_t enter_time, uint64_t exit_time);
+  void AddNormalMemcpyEventUponApiExit(uint32_t cbid,
+                                       const hip_api_data_t* data,
+                                       uint64_t enter_time, uint64_t exit_time);
+  void AddMemcpyPeerEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
+                                     uint64_t enter_time, uint64_t exit_time);
+  void AddMemsetEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
+                                 uint64_t enter_time, uint64_t exit_time);
+  void AddMallocFreeEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
+                                     uint32_t device_id, uint64_t enter_time,
+                                     uint64_t exit_time);
+  void AddStreamSynchronizeEventUponApiExit(uint32_t cbid,
+                                            const hip_api_data_t* data,
+                                            uint64_t enter_time,
+                                            uint64_t exit_time);
+  void AddSynchronizeEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
+                                      uint64_t enter_time, uint64_t exit_time);
+
+  RocmTracerOptions options_;
+  RocmTracer* tracer_ = nullptr;
+  RocmTraceCollector* collector_ = nullptr;
+  tsl::mutex api_call_start_mutex_;
+  // TODO(rocm-profiler): replace this with absl hashmap
+  // keep a map from the corr. id to enter time for API callbacks.
+  std::map<uint32_t, uint64_t> api_call_start_time_
+      TF_GUARDED_BY(api_call_start_mutex_);
+};
+
+class RocmActivityCallbackImpl {
+ public:
+  RocmActivityCallbackImpl(const RocmTracerOptions& options, RocmTracer* tracer,
+                           RocmTraceCollector* collector)
+      : options_(options), tracer_(tracer), collector_(collector) {}
+
+  absl::Status operator()(const char* begin, const char* end);
+
+ private:
+  void AddHipKernelActivityEvent(const roctracer_record_t* record);
+  void AddNormalHipMemcpyActivityEvent(const roctracer_record_t* record);
+  void AddHipMemsetActivityEvent(const roctracer_record_t* record);
+  void AddHipMallocActivityEvent(const roctracer_record_t* record);
+  void AddHipStreamSynchronizeActivityEvent(const roctracer_record_t* record);
+  void AddHccKernelActivityEvent(const roctracer_record_t* record);
+  void AddNormalHipOpsMemcpyActivityEvent(const roctracer_record_t* record);
+  void AddHipOpsMemsetActivityEvent(const roctracer_record_t* record);
+  RocmTracerOptions options_;
+  RocmTracer* tracer_ = nullptr;
+  RocmTraceCollector* collector_ = nullptr;
+};
+
+// The class uses roctracer callback/activity API and forward the collected
+// trace events to RocmTraceCollector. There should be only one RocmTracer
+// per process.
+class RocmTracer {
+ public:
+  // Returns a pointer to singleton RocmTracer.
+  static RocmTracer& GetRocmTracerSingleton();
+
+  // Only one profile session can be live in the same time.
+  bool IsAvailable() const;
+
+  void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector);
+  void Disable();
+
+  absl::Status ApiCallbackHandler(uint32_t domain, uint32_t cbid,
+                                  const void* cbdata);
+  absl::Status ActivityCallbackHandler(const char* begin, const char* end);
+
+  static uint64_t GetTimestamp();
+  static int NumGpus();
+
+  void AddToPendingActivityRecords(uint32_t correlation_id) {
+    pending_activity_records_.Add(correlation_id);
+  }
+
+  void RemoveFromPendingActivityRecords(uint32_t correlation_id) {
+    pending_activity_records_.Remove(correlation_id);
+  }
+
+  void ClearPendingActivityRecordsCount() { pending_activity_records_.Clear(); }
+
+  size_t GetPendingActivityRecordsCount() {
+    return pending_activity_records_.Count();
+  }
+
+  profiler::AnnotationMap* annotation_map() { return &annotation_map_; }
+
+ protected:
+  // protected constructor for injecting mock cupti interface for testing.
+  explicit RocmTracer() : num_gpus_(NumGpus()) {}
+
+ private:
+  absl::Status EnableApiTracing();
+  absl::Status DisableApiTracing();
+
+  absl::Status EnableActivityTracing();
+  absl::Status DisableActivityTracing();
+
+  int num_gpus_;
+  std::optional<RocmTracerOptions> options_;
+  RocmTraceCollector* collector_ = nullptr;
+
+  bool api_tracing_enabled_ = false;
+  bool activity_tracing_enabled_ = false;
+
+  RocmApiCallbackImpl* api_cb_impl_;
+  RocmActivityCallbackImpl* activity_cb_impl_;
+
+  profiler::AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
+
+  class PendingActivityRecords {
+   public:
+    // add a correlation id to the pending set
+    void Add(uint32_t correlation_id) {
+      absl::MutexLock lock(&mutex);
+      pending_set.insert(correlation_id);
+    }
+    // remove a correlation id from the pending set
+    void Remove(uint32_t correlation_id) {
+      absl::MutexLock lock(&mutex);
+      pending_set.erase(correlation_id);
+    }
+    // clear the pending set
+    void Clear() {
+      absl::MutexLock lock(&mutex);
+      pending_set.clear();
+    }
+    // count the number of correlation ids in the pending set
+    size_t Count() {
+      absl::MutexLock lock(&mutex);
+      return pending_set.size();
+    }
+
+   private:
+    // set of co-relation ids for which the hcc activity record is pending
+    absl::flat_hash_set<uint32_t> pending_set;
+    // the callback which processes the activity records (and consequently
+    // removes items from the pending set) is called in a separate thread
+    // from the one that adds item to the list.
+    absl::Mutex mutex;
+  };
+  PendingActivityRecords pending_activity_records_;
+
+ public:
+  // Disable copy and move.
+  RocmTracer(const RocmTracer&) = delete;
+  RocmTracer& operator=(const RocmTracer&) = delete;
+};
+
+}  // namespace profiler
+}  // namespace xla
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_V1_H_

--- a/xla/stream_executor/rocm/roctracer_wrapper.h
+++ b/xla/stream_executor/rocm/roctracer_wrapper.h
@@ -1,3 +1,4 @@
+
 /* Copyright 2021 The OpenXLA Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,16 +21,26 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_ROCM_ROCTRACER_WRAPPER_H_
 #define XLA_STREAM_EXECUTOR_ROCM_ROCTRACER_WRAPPER_H_
 
+#include "rocm/rocm_config.h"
+
+// ROCm >=6.3
+#include <rocm/include/rocprofiler-sdk/registration.h>
+#include <rocm/include/rocprofiler-sdk/buffer.h>
+#include <rocm/include/rocprofiler-sdk/buffer_tracing.h>
+#include <rocm/include/rocprofiler-sdk/callback_tracing.h>
+#include <rocm/include/rocprofiler-sdk/external_correlation.h>
+#include <rocm/include/rocprofiler-sdk/fwd.h>
+#include <rocm/include/rocprofiler-sdk/internal_threading.h>
+#include <rocm/include/rocprofiler-sdk/cxx/name_info.hpp>
+#include <rocm/include/rocprofiler-sdk/rocprofiler.h>
+
+// ROCm < 6.3
+#include "rocm/include/roctracer/roctracer_roctx.h"
 #include "rocm/include/roctracer/roctracer.h"
 #include "rocm/include/roctracer/roctracer_hip.h"
-#include "rocm/rocm_config.h"
-#if TF_ROCM_VERSION >= 50300
-#include "rocm/include/roctracer/roctracer_roctx.h"
-#else
-#include "rocm/include/roctracer/roctracer_hcc.h"
-#endif
-#include "xla/tsl/platform/env.h"
+
 #include "tsl/platform/dso_loader.h"
+#include "tsl/platform/env.h"
 #include "tsl/platform/platform.h"
 
 namespace stream_executor {
@@ -63,6 +74,7 @@ namespace wrap {
   }
 
 #endif  // PLATFORM_GOOGLE
+
 
 #if TF_ROCM_VERSION >= 50300
 #define FOREACH_ROCTRACER_API(DO_FUNC)           \


### PR DESCRIPTION
This PR combines  rocprofiler-sdk (v3) and roctracer (v1) for rocm-jaxlib-v0.6.0

- Update rocprofiler-sdk integration for improved profiling with rocprofiler_force_configure() and annotations, support both time-based and step-based profiling, 
- Keep roctracer(v1) that can be built by providing `--bazel_options="--define=xla_rocm_profiler=v1" `
- still need to figure out how to add more stats related to kernel, e.g., kernel size, occupancy, DMA copy, etc. 

Previously, there was one for v3 only https://github.com/ROCm/xla/pull/251. 
