### PR TITLE
Change conv layout to NCHW for fp16 on GFX11 & GFX12

### DIFF
--- a/xla/service/gpu/transforms/layout_assignment.cc
+++ b/xla/service/gpu/transforms/layout_assignment.cc
@@ -160,7 +160,11 @@ HeuristicLayoutAssignment(const HloInstruction* instr,
 
   const auto* rocm_compute_capability =
       std::get_if<se::RocmComputeCapability>(&gpu_version);
-  if (rocm_compute_capability && input_ty == F16) return kAllNHWC;
+  if (rocm_compute_capability && input_ty == F16) {
+    return rocm_compute_capability->gfx11() || rocm_compute_capability->gfx12()
+               ? kAllNCHW
+               : kAllNHWC;
+  }
 
   // If we're not Volta or not fp16/bfloat16, or not conv2D, the decision is
   // easy: Use NCHW.


### PR DESCRIPTION
Current implementation imposes `NHWC` layout on all architectures, which is nice for MI300, but is wildly sub-optimal for GFX11 and GFX12.