### PR TITLE
Hardcode minloglevel to 0

### DIFF
--- a/xla/backends/gpu/collectives/gpu_clique.cc
+++ b/xla/backends/gpu/collectives/gpu_clique.cc
@@ -63,6 +63,8 @@ absl::Status GpuClique::HealthCheck() const {
   ForEachComm([&health_check](RankId rank, Communicator* comm) {
     if (auto s = comm->HealthCheck(); !s.ok()) {
       LOG(ERROR) << "GPU communicator error (rank " << rank << "): " << s;
+      VLOG(1) << __func__ << "#### GPU communicator error (rank " << rank
+              << "): " << s;
       if (health_check.ok()) health_check = std::move(s);  // return first error
     }
   });

--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -126,7 +126,9 @@ static absl::Status CheckComm(Communicator* comm) {
 // Runs async check on all communicators in a clique.
 static void CheckClique(const GpuCliqueKey& clique_key,
                         LockableGpuClique& lockable_clique) {
+  VLOG(1) << "##### " << __func__ << " Start";
   if (TerminateOnCollectivesError()) {
+    VLOG(1) << "##### " << __func__ << " Terminate on collectives error";
     absl::Status status = lockable_clique.HealthCheck();
     if (!status.ok()) {
       LOG(FATAL) << "Terminating process due to async GPU clique error: "
@@ -144,6 +146,7 @@ static void CheckClique(const GpuCliqueKey& clique_key,
   } else {
     VLOG(5) << "Skip checking in-use GPU clique " << clique_key.ToString();
   }
+  VLOG(1) << "##### " << __func__ << " Done";
 }
 
 // TODO(ezhulenev): We need a mechanism to destroy whole clique when one of the
@@ -160,6 +163,7 @@ static void GpuCliqueHeartBeatMonitorThread() {
       CheckClique(clique_key, lockable_clique);
     }
   }
+  VLOG(1) << "##### " << __func__ << " Done";
 }
 
 static void StartGpuCliqueHeartBeatMonitor() {
@@ -192,8 +196,13 @@ static auto DeviceRanksToString(absl::Span<const DeviceRank> ranks) {
 // side effect, enables peer access even if it was not enabled before.
 static absl::StatusOr<bool> EnablePeerAccess(
     const GpuCliqueKey& key, absl::Span<const DeviceRank> ranks) {
+  VLOG(1) << "##### " << __func__ << " Start";
   if (key.devices().size() != ranks.size()) {
     // The clique is not local, so we can't enable peer access.
+    VLOG(1) << "##### " << __func__
+            << " Device count is not equal to ranks count "
+            << " devices count " << key.devices().size() << " ranks count "
+            << ranks.size();
     return false;
   }
 
@@ -213,11 +222,15 @@ static absl::StatusOr<bool> EnablePeerAccess(
       // the result. OkStatus means that peer access is possible.
       auto status = devices[i]->EnablePeerAccessTo(devices[j]);
       if (!status.ok()) {
+        VLOG(1) << "##### " << __func__
+                << " Was not able to enable perr access from rank " << i
+                << " to rank  " << j;
         return false;
       }
     }
   }
 
+  VLOG(1) << "##### " << __func__ << " Done";
   return true;
 }
 
@@ -230,6 +243,7 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
                     const GpuCollectives::CliqueIdCallback& clique_id_callback,
                     int32_t num_local_participants, RankId rank,
                     const GpuCollectives::Config& config) {
+  VLOG(1) << "##### " << __func__ << " Start";
   VLOG(3) << "Initialize GPU clique " << clique_key.ToString() << " rank #"
           << rank << "; num_local_participants=" << num_local_participants;
 
@@ -348,10 +362,12 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
   // processes are not able to synchronize device activity.
   RendezvousArg rendezvous_arg = std::make_pair(device_rank, synchronized);
 
-  return Rendezvous<LockableGpuClique::Lock>(
+  auto result = Rendezvous<LockableGpuClique::Lock>(
       initialization_rendezvous_name, rendezvous_key, rendezvous_arg,
       num_local_participants, initialize, WarnStuckTimeout(),
       TerminateTimeout());
+  VLOG(1) << "##### " << __func__ << " Done";
+  return result;
 }
 
 // Computes a unique GPU communicator split color from a clique key. We use a
@@ -385,7 +401,7 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
   RankId parent_rank =
       *parent_clique_key.rank(clique_key.devices()[rank.value()]);
 
-  VLOG(3) << "Initialize GPU clique " << clique_key.ToString() << " rank #"
+  VLOG(1) << "Initialize GPU clique " << clique_key.ToString() << " rank #"
           << rank << " by splitting rank #" << parent_rank.value()
           << " in parent clique " << parent_clique_key.ToString()
           << "; num_local_participants=" << num_local_participants;
@@ -445,6 +461,9 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
       // The parent clique is local, we can be sure that peer access was already
       // enabled.
       peer_access_enabled = (*parent_clique)->peer_access_enabled();
+      VLOG(1) << "##### " << __func__
+              << " The parent clique is local, we can be sure that perr access "
+                 "was already enabled";
     } else {
       // The parent clique is not local, but this clique can be local. We need
       // to check if peer access is possible between all devices in this clique.
@@ -457,7 +476,7 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
                           EnablePeerAccess(clique_key, ranks));
     }
 
-    VLOG(3) << absl::StreamFormat(
+    VLOG(1) << absl::StreamFormat(
         "Create GPU communicators for clique %s; parent=%s; color=%d; "
         "peer_access_enabled=%d; rank_mapping=[%s]",
         clique_key.ToString(), parent_clique_key.ToString(), color,
@@ -492,10 +511,10 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
     // We can have a race to create a clique for a given key, the winner
     // inserts it into a map and the looser destroys all communicators.
     if (!emplaced.second) {
-      VLOG(3) << "Clique already exists: "
+      VLOG(1) << "Clique already exists: "
               << emplaced.first->second.DebugString();
     } else {
-      VLOG(3) << "Created new clique: " << emplaced.first->second.DebugString();
+      VLOG(1) << "Created new clique: " << emplaced.first->second.DebugString();
     }
 
     return emplaced.first->second.Acquire();
@@ -510,9 +529,11 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
       rank.value(), clique_key.ToString(), run_id.ToInt(),
       parent_clique_key.ToString());
 
-  return Rendezvous<LockableGpuClique::Lock>(
+  auto result = Rendezvous<LockableGpuClique::Lock>(
       initialization_rendezvous_name, rendezvous_key, rank_pair,
       num_local_participants, split, WarnStuckTimeout(), TerminateTimeout());
+  VLOG(1) << "##### " << __func__ << " Done";
+  return result;
 }
 
 //===----------------------------------------------------------------------===//
@@ -522,8 +543,9 @@ absl::StatusOr<std::shared_ptr<LockableGpuClique::Lock>> AcquireGpuClique(
     const GpuCliqueKey& clique_key,
     const GpuCollectives::CliqueIdCallback& clique_id_callback, RankId rank,
     const AcquiredCliquesMap& acquired_cliques, int64_t max_nchannels) {
+  VLOG(1) << "##### " << __func__ << " Start";
   int64_t num_local_participants = clique_key.num_local_participants();
-  VLOG(2) << "Acquire GPU clique " << clique_key.ToString() << "; run"
+  VLOG(1) << "Acquire GPU clique " << clique_key.ToString() << "; run"
           << run_id.ToString() << "; rank " << rank
           << "; num_local_participants=" << num_local_participants
           << "; acquired_cliques=" << acquired_cliques.size()
@@ -587,9 +609,11 @@ absl::StatusOr<std::shared_ptr<LockableGpuClique::Lock>> AcquireGpuClique(
   }
 
   // If we can't split any of the acquired cliques, create a new one.
-  return InitializeGpuClique(collectives, device, run_id, clique_key,
-                             clique_id_callback, num_local_participants, rank,
-                             config);
+  auto result = InitializeGpuClique(collectives, device, run_id, clique_key,
+                                    clique_id_callback, num_local_participants,
+                                    rank, config);
+  VLOG(1) << "##### " << __func__ << " Done";
+  return result;
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -127,6 +127,7 @@ NcclCollectives::CreateCommunicators(const CliqueKey& clique_key,
                                      const std::optional<CliqueIds>& clique_ids,
                                      absl::Span<const DeviceRank> ranks,
                                      const Collectives::Config& config) {
+  VLOG(1) << "##### " << __func__ << " Start";
   // With NCCL backend we rely on host to exchange unique clique ids.
   if (!clique_ids.has_value() || clique_ids->data().empty()) {
     return InvalidArgument("CliqueId is required to create NCCL communicators");
@@ -169,6 +170,7 @@ NcclCollectives::CreateCommunicators(const CliqueKey& clique_key,
     comms.emplace_back(std::make_unique<NcclCommunicator>(comm_handle));
   }
 
+  VLOG(1) << "##### " << __func__ << " Done";
   return comms;
 }
 
@@ -177,6 +179,7 @@ NcclCollectives::SplitCommunicators(absl::Span<const Communicator* const> comms,
                                     int32_t color,
                                     absl::Span<const RankId> keys,
                                     const Collectives::Config& config) {
+  VLOG(1) << "##### " << __func__ << " Start";
   auto rank_formatter = [](std::string* str, RankId rank) {
     absl::StrAppend(str, rank.value());
   };
@@ -217,8 +220,10 @@ NcclCollectives::SplitCommunicators(absl::Span<const Communicator* const> comms,
     split_comms.emplace_back(
         std::make_unique<NcclCommunicator>(split_comms_handles[i]));
   }
+  VLOG(1) << "##### " << __func__ << " Done";
   return split_comms;
 #else
+  VLOG(1) << "##### " << __func__ << " Unimplemented";
   return absl::UnimplementedError(
       absl::StrFormat("%s:%d: NCCL operation ncclCommSplit not implemented",
                       __FILE__, __LINE__));
@@ -237,6 +242,7 @@ absl::Status NcclCollectives::GroupEnd() {
 
 absl::StatusOr<void*> NcclCollectives::Allocate(uint64_t bytes) {
   void* ptr = nullptr;
+  VLOG(1) << "##### " << __func__ << " Start";
   ncclResult_t res = ncclMemAlloc(&ptr, bytes);
   if (res != ncclSuccess) {
     return absl::InternalError(absl::StrFormat(
@@ -247,10 +253,12 @@ absl::StatusOr<void*> NcclCollectives::Allocate(uint64_t bytes) {
   }
   VLOG(2) << "Allocated collective memory " << ptr << " of " << bytes
           << " bytes";
+  VLOG(1) << "##### " << __func__ << " Done";
   return ptr;
 }
 
 absl::Status NcclCollectives::Deallocate(void* location) {
+  VLOG(1) << "##### " << __func__ << " Start";
   ncclResult_t res = ncclMemFree(location);
   if (res != ncclSuccess) {
     return absl::InternalError(absl::StrFormat(
@@ -260,6 +268,7 @@ absl::Status NcclCollectives::Deallocate(void* location) {
   }
 
   VLOG(2) << "Deallocated collective memory " << location;
+  VLOG(1) << "##### " << __func__ << " Done";
   return absl::OkStatus();
 }
 

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -235,7 +235,9 @@ absl::Status NcclCommunicator::AllReduce(
     se::DeviceMemoryBase send_buffer, se::DeviceMemoryBase recv_buffer,
     PrimitiveType dtype, size_t count, ReductionKind reduction_kind,
     const Communicator::Executor& executor) {
+  VLOG(1) << "##### " << __func__ << " Start";
   if (aborted_) {
+    VLOG(1) << "##### " << __func__ << " Aborted";
     return absl::FailedPreconditionError("NcclCommunicator aborted");
   }
   TF_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
@@ -250,10 +252,12 @@ absl::Status NcclCommunicator::AllReduce(
 
   TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
 
-  return XLA_NCCL_STATUS(ncclAllReduce(
-      send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
-      nccl_dtype, ToNcclReduction(reduction_kind), comm_,
-      se::gpu::AsGpuStreamValue(stream)));
+  auto result = ncclAllReduce(send_buffer.opaque(), recv_buffer.opaque(),
+                              ToNcclCount(dtype, count), nccl_dtype,
+                              ToNcclReduction(reduction_kind), comm_,
+                              se::gpu::AsGpuStreamValue(stream));
+  VLOG(1) << "##### " << __func__ << " Done";
+  return XLA_NCCL_STATUS(result);
 }
 
 absl::Status NcclCommunicator::Broadcast(se::DeviceMemoryBase send_buffer,
@@ -261,7 +265,9 @@ absl::Status NcclCommunicator::Broadcast(se::DeviceMemoryBase send_buffer,
                                          PrimitiveType dtype, size_t count,
                                          RankId root,
                                          const Executor& executor) {
+  VLOG(1) << "##### " << __func__ << " Start";
   if (aborted_) {
+    VLOG(1) << "##### " << __func__ << " Aborted";
     return absl::FailedPreconditionError("NcclCommunicator aborted");
   }
   TF_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
@@ -276,9 +282,11 @@ absl::Status NcclCommunicator::Broadcast(se::DeviceMemoryBase send_buffer,
 
   TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
 
-  return XLA_NCCL_STATUS(ncclBroadcast(
+  auto result = ncclBroadcast(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
-      nccl_dtype, root.value(), comm_, se::gpu::AsGpuStreamValue(stream)));
+      nccl_dtype, root.value(), comm_, se::gpu::AsGpuStreamValue(stream));
+  VLOG(1) << "##### " << __func__ << " Done";
+  return XLA_NCCL_STATUS(result);
 }
 
 absl::Status NcclCommunicator::ReduceScatter(se::DeviceMemoryBase send_buffer,
@@ -286,7 +294,9 @@ absl::Status NcclCommunicator::ReduceScatter(se::DeviceMemoryBase send_buffer,
                                              PrimitiveType dtype, size_t count,
                                              ReductionKind reduction_kind,
                                              const Executor& executor) {
+  VLOG(1) << "##### " << __func__ << " Start";
   if (aborted_) {
+    VLOG(1) << "##### " << __func__ << " Aborted";
     return absl::FailedPreconditionError("NcclCommunicator aborted");
   }
   TF_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
@@ -300,18 +310,21 @@ absl::Status NcclCommunicator::ReduceScatter(se::DeviceMemoryBase send_buffer,
       count, ReductionKindToString(reduction_kind), comm_, stream);
 
   TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
-
-  return XLA_NCCL_STATUS(ncclReduceScatter(
-      send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
-      nccl_dtype, ToNcclReduction(reduction_kind), comm_,
-      se::gpu::AsGpuStreamValue(stream)));
+  auto result = ncclReduceScatter(send_buffer.opaque(), recv_buffer.opaque(),
+                                  ToNcclCount(dtype, count), nccl_dtype,
+                                  ToNcclReduction(reduction_kind), comm_,
+                                  se::gpu::AsGpuStreamValue(stream));
+  VLOG(1) << "##### " << __func__ << " Done";
+  return XLA_NCCL_STATUS(result);
 }
 
 absl::Status NcclCommunicator::AllGather(se::DeviceMemoryBase send_buffer,
                                          se::DeviceMemoryBase recv_buffer,
                                          PrimitiveType dtype, size_t count,
                                          const Executor& executor) {
+  VLOG(1) << "##### " << __func__ << " Start";
   if (aborted_) {
+    VLOG(1) << "##### " << __func__ << " Aborted";
     return absl::FailedPreconditionError("NcclCommunicator aborted");
   }
   TF_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
@@ -325,15 +338,18 @@ absl::Status NcclCommunicator::AllGather(se::DeviceMemoryBase send_buffer,
 
   TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
 
-  return XLA_NCCL_STATUS(ncclAllGather(
-      send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
-      nccl_dtype, comm_, se::gpu::AsGpuStreamValue(stream)));
+  auto result = ncclAllGather(send_buffer.opaque(), recv_buffer.opaque(),
+                              ToNcclCount(dtype, count), nccl_dtype, comm_,
+                              se::gpu::AsGpuStreamValue(stream));
+  VLOG(1) << "##### " << __func__ << " Done";
+  return XLA_NCCL_STATUS(result);
 }
 
 absl::Status NcclCommunicator::AllToAll(
     absl::Span<const se::DeviceMemoryBase> send_buffers,
     absl::Span<const se::DeviceMemoryBase> recv_buffers, PrimitiveType dtype,
     size_t count, const Executor& executor) {
+  VLOG(1) << "##### " << __func__ << " Start";
   if (aborted_) {
     return absl::FailedPreconditionError("NcclCommunicator aborted");
   }
@@ -352,6 +368,7 @@ absl::Status NcclCommunicator::AllToAll(
       primitive_util::LowercasePrimitiveTypeName(dtype), count, comm_, stream);
 
   if (send_buffers.size() != recv_buffers.size()) {
+    VLOG(-1) << "##### " << __func__ << " Error";
     return InvalidArgument(
         "Number of send buffers must match number of recv buffers: %d != %d",
         send_buffers.size(), recv_buffers.size());
@@ -361,6 +378,7 @@ absl::Status NcclCommunicator::AllToAll(
   XLA_NCCL_RETURN_IF_ERROR(ncclCommCount(comm_, &num_ranks));
 
   if (send_buffers.size() != num_ranks) {
+    VLOG(1) << "##### " << __func__ << " Error";
     return InvalidArgument(
         "Number of send buffers must match number of ranks: %d != %d",
         send_buffers.size(), num_ranks);
@@ -385,6 +403,7 @@ absl::Status NcclCommunicator::AllToAll(
 
   XLA_NCCL_RETURN_IF_ERROR(ncclGroupEnd());
 
+  VLOG(1) << "##### " << __func__ << " Done";
   return absl::OkStatus();
 }
 
@@ -392,7 +411,9 @@ absl::Status NcclCommunicator::CollectivePermute(
     se::DeviceMemoryBase send_buffer, se::DeviceMemoryBase recv_buffer,
     PrimitiveType dtype, size_t count, std::optional<RankId> source_rank,
     absl::Span<const RankId> target_ranks, const Executor& executor) {
+  VLOG(1) << "##### " << __func__ << " Start";
   if (aborted_) {
+    VLOG(1) << "##### " << __func__ << " Aborted";
     return absl::FailedPreconditionError("NcclCommunicator aborted");
   }
   TF_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
@@ -414,6 +435,7 @@ absl::Status NcclCommunicator::CollectivePermute(
 
   // Short-circuit if there is no source or target rank.
   if (!source_rank && target_ranks.empty()) {
+    VLOG(1) << "##### " << __func__ << " Done";
     return absl::OkStatus();
   }
 
@@ -433,13 +455,16 @@ absl::Status NcclCommunicator::CollectivePermute(
 
   XLA_NCCL_RETURN_IF_ERROR(ncclGroupEnd());
 
+  VLOG(-1) << "##### " << __func__ << " Done";
   return absl::OkStatus();
 }
 
 absl::Status NcclCommunicator::Send(se::DeviceMemoryBase send_buffer,
                                     PrimitiveType dtype, size_t count,
                                     RankId peer, const Executor& executor) {
+  VLOG(1) << "##### " << __func__ << " Start";
   if (aborted_) {
+    VLOG(-1) << "##### " << __func__ << " Aborted";
     return absl::FailedPreconditionError("NcclCommunicator aborted");
   }
   TF_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
@@ -453,15 +478,20 @@ absl::Status NcclCommunicator::Send(se::DeviceMemoryBase send_buffer,
 
   TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
 
-  return XLA_NCCL_STATUS(
+  auto result =
       ncclSend(send_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
-               peer.value(), comm_, se::gpu::AsGpuStreamValue(stream)));
+               peer.value(), comm_, se::gpu::AsGpuStreamValue(stream));
+
+  VLOG(1) << "##### " << __func__ << " Done";
+  return XLA_NCCL_STATUS(result);
 }
 
 absl::Status NcclCommunicator::Recv(se::DeviceMemoryBase recv_buffer,
                                     PrimitiveType dtype, size_t count,
                                     RankId peer, const Executor& executor) {
+  VLOG(1) << "##### " << __func__ << " Start";
   if (aborted_) {
+    VLOG(-1) << "##### " << __func__ << " Aborted";
     return absl::FailedPreconditionError("NcclCommunicator aborted");
   }
   TF_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
@@ -475,9 +505,12 @@ absl::Status NcclCommunicator::Recv(se::DeviceMemoryBase recv_buffer,
 
   TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
 
-  return XLA_NCCL_STATUS(
+  auto result =
       ncclRecv(recv_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
-               peer.value(), comm_, se::gpu::AsGpuStreamValue(stream)));
+               peer.value(), comm_, se::gpu::AsGpuStreamValue(stream));
+
+  VLOG(1) << "##### " << __func__ << " Done";
+  return XLA_NCCL_STATUS(result);
 }
 
 std::string NcclCommunicator::ToString() const {

--- a/xla/backends/gpu/runtime/all_gather_thunk.cc
+++ b/xla/backends/gpu/runtime/all_gather_thunk.cc
@@ -74,6 +74,8 @@ AllGatherStartThunk::AllGatherStartThunk(ThunkInfo thunk_info,
                       IsGPUSyncCollective(*inst), AsyncStreamKind::kCollective),
       config_(impl::GetAllGatherConfig(inst)),
       buffers_(std::move(buffers)) {
+  VLOG(1) << "##### " << __func__
+          << " with hlo instruction : " << inst->ToString();
   CHECK_EQ(config_.config.operand_count, buffers_.size());
 }
 
@@ -97,6 +99,7 @@ absl::Status AllGatherStartThunk::RunCollective(
       ConvertToDeviceBuffers(params, buffers_,
                              config_.config.operand_element_type));
   TF_ASSIGN_OR_RETURN(GpuCollectives * collectives, GetGpuCollectives(params));
+  VLOG(1) << "##### " << __func__ << " on stream " << stream.GetName();
   return xla::gpu::RunAllGather(collectives, device_buffers, stream,
                                 comm_handle.comm);
 }

--- a/xla/backends/gpu/runtime/all_reduce.cc
+++ b/xla/backends/gpu/runtime/all_reduce.cc
@@ -88,6 +88,7 @@ absl::Status RunAllReduceKernel(
 
   auto launch_kernel = [&](auto type) -> absl::Status {
     using T = decltype(type);
+    VLOG(1) << "##### " << __func__ << " LaunchTypedKernel ";
     return LaunchTypedKernel<T>(stream, executor, thread_dims, block_dims,
                                 input_ptrs, output_buffer, num_inputs,
                                 num_elements);
@@ -97,6 +98,9 @@ absl::Status RunAllReduceKernel(
     case F32:
       return launch_kernel(float{});
     default:
+      VLOG(1) << "##### " << __func__
+              << " Unsupported element type for AllReduce kernel: "
+              << primitive_util::LowercasePrimitiveTypeName(element_type);
       return absl::InvalidArgumentError(
           absl::StrCat("Unsupported element type: ",
                        primitive_util::LowercasePrimitiveTypeName(element_type),

--- a/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
@@ -72,6 +72,7 @@ absl::Status CollectiveBroadcastStartThunk::RunCollective(
 absl::Status RunCollectiveBroadcast(std::vector<DeviceBufferPair>& buffers,
                                     se::Stream& stream, Communicator* comm,
                                     GpuCollectives* collectives) {
+  VLOG(1) << "##### " << __func__ << " Start";
   TF_RETURN_IF_ERROR(collectives->GroupStart());
   for (auto buffer : buffers) {
     se::DeviceMemoryBase src_addr = buffer.source_buffer;
@@ -82,7 +83,9 @@ absl::Status RunCollectiveBroadcast(std::vector<DeviceBufferPair>& buffers,
         src_addr, dest_addr, buffer.element_type, buffer.element_count,
         RankId(0), GpuCollectives::On(stream)));
   }
-  return collectives->GroupEnd();
+  auto result = collectives->GroupEnd();
+  VLOG(1) << "##### " << __func__ << " Done " << result.ToString();
+  return result;
 }
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/resource_requests.cc
+++ b/xla/service/gpu/resource_requests.cc
@@ -73,7 +73,7 @@ ResourceRequests::AcquireCollectiveCliques(
     const Thunk::CollectiveExecuteParams& params, bool use_persistent_cliques) {
   if (cliques_.empty()) return Thunk::CollectiveCliques();
 
-  VLOG(2) << "Acquire " << cliques_.size()
+  VLOG(1) << "Acquire " << cliques_.size()
           << " collective cliques for global device id "
           << params.global_device_id.value()
           << "; run_id=" << params.run_id.ToInt()
@@ -85,7 +85,7 @@ ResourceRequests::AcquireCollectiveCliques(
   std::vector<CliqueRequest> ordered_cliques = GetOrderedCliqueRequests();
   for (size_t i = 0; i < ordered_cliques.size(); ++i) {
     const CliqueRequest& r = ordered_cliques[i];
-    VLOG(2) << "  clique #" << i << " (for global device id "
+    VLOG(1) << "  clique #" << i << " (for global device id "
             << params.global_device_id.value() << ")"
             << ": num_local_participants=" << r.key.num_local_participants()
             << "; id=" << r.id << "; key=" << r.key.ToString();
@@ -126,7 +126,7 @@ ResourceRequests::AcquireCollectiveCliques(
       absl::MutexLock lock(&pc.mutex);
 
       if (auto it = pc.cliques_map.find(r.key); it != pc.cliques_map.end()) {
-        VLOG(2) << "Found persistent clique for key " << r.key.ToString();
+        VLOG(1) << "Found persistent clique for key " << r.key.ToString();
         cliques_map[r.key] = it->second;
         continue;
       }
@@ -160,7 +160,7 @@ ResourceRequests::AcquireCollectiveCliques(
   }
 
   auto end_micros = tsl::Env::Default()->NowMicros();
-  VLOG(2) << "Acquired " << cliques_map.size()
+  VLOG(1) << "Acquired " << cliques_map.size()
           << " collective cliques for global device id "
           << params.global_device_id.value() << " in "
           << (end_micros - start_micros) << " μs"

--- a/xla/tsl/platform/default/logging.cc
+++ b/xla/tsl/platform/default/logging.cc
@@ -508,7 +508,7 @@ void TFDefaultLogSink::Send(const TFLogEntry& entry) {
   if (entry.log_severity() == absl::LogSeverity::kFatal) {
     abort();
   }
-#else   // PLATFORM_POSIX_ANDROID
+#else  // PLATFORM_POSIX_ANDROID
   static const internal::VlogFileMgr vlog_file;
   static bool log_thread_id = internal::EmitThreadIdFromEnv();
   uint64_t now_micros = EnvTime::NowMicros();


### PR DESCRIPTION
Add thunk logging

Additional logs in thunks based on https://github.com/ROCm/xla/commit/76771c4e422fe82482ff39675feb416c6fdd5d05 but no override `TF_CPP_MIN_LOG_LEVEL`  as 0

## Motivation

More VLOG at nccl parts

## Test Plan
```
export TF_CPP_MAX_VLOG_LEVEL=3
```

or

fine-grained
```
export TF_CPP_VMODULE="gpu_clique=3,gpu_cliques=3,nccl_collectives=3,nccl_communicator=3,all_gather_thunk=3,all_reduce=3,all_reduce_thunk=3,collective_broadcast_thunk=3,collective_group_thunk=3,collective_permute_thunk=3,resource_requests=3"
```

 