### PR TITLE
PR #30276: [ROCm] bugfix EnablePeerAccess in rocm_executor

### DIFF
--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -371,8 +371,9 @@ absl::Status EnablePeerAccess(Context* from, Context* to) {
   }
 
   ScopedActivateContext activated(from);
-  hipError_t result = wrap::hipCtxEnablePeerAccess(
-      tensorflow::down_cast<RocmContext*>(to)->context(), 0 /* = flags */);
+  hipError_t result =
+      wrap::hipDeviceEnablePeerAccess(to->device_ordinal(), 0 /* = flags */);
+
   if (result != hipSuccess && result != hipErrorPeerAccessAlreadyEnabled) {
     return absl::InternalError(
         absl::StrFormat("failed to enable peer access from %d to %d: %s",


### PR DESCRIPTION
Imported from GitHub PR https://github.com/openxla/xla/pull/30276

This would fix the failed unit test //xla/backends/gpu/runtime:all_reduce_test, previously the peer to peer access was not properly enabled.

@xla-rotation could you review my PR, please?
Copybara import of the project:

--
cc609e795220e15cf5e2c8a2509cde8eabbc245b by songlin <Songlin.Piao@amd.com>:

bugfix EnablePeerAccess in rocm_executor

Merging this change closes #30276

COPYBARA_INTEGRATE_REVIEW=https://github.com/openxla/xla/pull/30276 from ROCm:ci_bugfix_enable_peer_access cc609e795220e15cf5e2c8a2509cde8eabbc245b PiperOrigin-RevId: 796364709

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
