### PR TITLE
Restore RocmComputeCapability:: gfx11_rx7900() and gfx12_rx8900()

### DIFF
--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -138,10 +138,19 @@ class RocmComputeCapability {
                                                     "gfx1151"};
   bool gfx11_apu() const { return IsThisGfxInAnyList(kGfx11Apu); }
 
+  static constexpr absl::string_view kGfx11Rx7900[] = {"gfx1100", "gfx1101",
+                                                       "gfx1102"};
+  bool gfx11_rx7900() const {
+    // TODO(AMD/TF): instead of this, other gfx11*() methods might be better
+    return IsThisGfxInAnyList(kGfx11Rx7900);
+  }
+
   bool gfx12() const { return absl::StartsWith(gfx_version(), "gfx12"); }
 
   static constexpr absl::string_view kGfx12Discrete[] = {"gfx1200", "gfx1201"};
   bool gfx12_discrete() const { return IsThisGfxInAnyList(kGfx12Discrete); }
+
+  bool gfx12_rx8900() const { return gfx12_discrete(); }
 
   bool has_nhwc_layout_support() const { return gfx9_mi100_or_later(); }
 


### PR DESCRIPTION
At least gfx11_rx7900() is still needed for TF build https://ontrack-internal.amd.com/browse/SWDEV-553480.
Restoring it for JAX/XLA for consistency reasons.