### PR TITLE
Cherry pick xla_gpu_enable_triton_softmax_fusion flag to 0.5.0

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -223,6 +223,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
       DebugOptions::PARTITIONING_ALGORITHM_NOOP);
 
   opts.set_xla_gpu_enable_triton_gemm(true);
+  opts.set_xla_gpu_enable_triton_softmax_fusion(true);
   opts.set_xla_gpu_enable_cudnn_int8x32_convolution_reordering(true);
   opts.set_xla_gpu_triton_gemm_any(false);
   opts.set_xla_gpu_triton_fusion_level(2);
@@ -1075,6 +1076,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                 "optimizations. debug_options are written to the --xla_dump_to "
                 "dir, or, if no dir is specified, to stdout. Ignored unless "
                 "xla_dump_hlo_as_text is true."));
+  flag_list->push_back(
+      tsl::Flag("xla_gpu_enable_triton_softmax_fusion",
+                bool_setter_for(&DebugOptions::set_xla_gpu_enable_triton_softmax_fusion),
+                debug_options->xla_gpu_enable_triton_softmax_fusion(),
+                "Enable fusion of the softmax function to triton"
+                "default value is true"));
   flag_list->push_back(
       tsl::Flag("xla_dump_hlo_as_proto",
                 bool_setter_for(&DebugOptions::set_xla_dump_hlo_as_proto),

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1605,9 +1605,11 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
       pipeline.AddPass<HloCSE>(/*is_layout_sensitive=*/true);
       pipeline.AddPass<HloConstantFolding>();
       pipeline.AddPass<HloDCE>();
-      pipeline.AddPass<SoftmaxRewriterTriton>(
-          gpu_target_config.device_description, ShapeSizeBytesFunction(),
-          /*only_fuse_if_profitable=*/true);
+      if (debug_options.xla_gpu_enable_triton_softmax_fusion()) {
+        pipeline.AddPass<SoftmaxRewriterTriton>(
+            gpu_target_config.device_description, ShapeSizeBytesFunction(),
+            /*only_fuse_if_profitable=*/true);
+      }
     }
 
     pipeline.AddPass<ReductionDimensionGrouper>();

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -742,6 +742,7 @@ message DebugOptions {
   PartitioningAlgorithm xla_partitioning_algorithm = 187;
 
   bool xla_gpu_enable_triton_gemm = 188;
+  bool xla_gpu_enable_triton_softmax_fusion = 363;
 
   bool xla_gpu_enable_cudnn_int8x32_convolution_reordering = 189;
 
@@ -1119,7 +1120,7 @@ message DebugOptions {
   // For sub-byte dot operands, layout them along contracting dimensions.
   bool xla_gpu_experimental_pack_dot_operands_along_k_dimension = 362;
 
-  // Next id: 363
+  // Next id: 364
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
Commits: 51a7f4b4a7858fcfb4cef10509e01b62f59a337b, 1851bcc52e3133850565d7a2bcc39813ad563a0a

Related issue: [@rocm/framework #13568](https://github.com/ROCm/frameworks-internal/issues/13568)