### PR TITLE
use VLOG(2) to replace LOG(INFO)

### DIFF
--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -178,7 +178,7 @@ class RocmTraceCollectorImpl : public RocmTraceCollector {
 
   void OnEventsDropped(const std::string& reason,
                        uint32_t correlation_id) override {
-    LOG(INFO) << "RocmTracerEvent dropped (correlation_id=" << correlation_id
+    VLOG(2) << "RocmTracerEvent dropped (correlation_id=" << correlation_id
               << ",) : " << reason << ".";
   }
 


### PR DESCRIPTION
📝 Summary of Changes

- use VLOG(2) to replace LOG(INFO), so there is no verbose info when using PGLE 

<img width="3371" height="1350" alt="image" src="https://github.com/user-attachments/assets/c208ede2-565c-479f-8d22-f420fce860f2" />
