### PR TITLE
Select sanitizer ignore list based on the config

### DIFF
--- a/build_tools/rocm/BUILD
+++ b/build_tools/rocm/BUILD
@@ -1,10 +1,35 @@
-filegroup(
-    name="sanitizer_ignore_lists",
-    srcs = [
-        "asan_ignore_list.txt",
-        "lsan_ignore_list.txt",
-        "tsan_ignore_list.txt",
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+string_flag(
+    name = "sanitizer",
+    build_setting_default = "none",
+    values = [
+        "none",
+        "asan",
+        "tsan",
     ],
+)
+
+config_setting(
+    name = "asan",
+    flag_values = {"//build_tools/rocm:sanitizer": "asan"},
+)
+
+config_setting(
+    name = "tsan",
+    flag_values = {"//build_tools/rocm:sanitizer": "tsan"},
+)
+
+filegroup(
+    name = "sanitizer_ignore_lists",
+    srcs = select({
+        ":asan": [
+            "asan_ignore_list.txt",
+            "lsan_ignore_list.txt",
+        ],
+        ":tsan": ["tsan_ignore_list.txt"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -224,6 +224,7 @@ build:asan --copt -g
 build:tsan --linkopt -g
 build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
+build:asan --//build_tools/rocm:sanitizer=asan
 
 build:tsan --strip=never
 build:tsan --copt -fsanitize=thread
@@ -231,6 +232,7 @@ build:tsan --copt -g
 build:tsan --copt -fno-omit-frame-pointer
 build:tsan --linkopt -fsanitize=thread
 build:tsan --linkopt -g
+build:tsan --//build_tools/rocm:sanitizer=tsan
 
 build:rocm_base --copt=-Wno-gnu-offsetof-extensions
 build:rocm_base --crosstool_top=@local_config_rocm//crosstool:toolchain


### PR DESCRIPTION
## Motivation
This pr will select the ignore files for the sanitizer wrapper to ensure better CI utilization.
If asan ignore list has changed we shall not rerun all the tsan tests and vise versa.