### PR TITLE
update to remove previously hard-coded rocprofiler-sdk path

### DIFF
--- a/build_tools/lint/tags.py
+++ b/build_tools/lint/tags.py
@@ -94,6 +94,7 @@ _TAGS_TO_DOCUMENTATION_MAP = {
     "multi_gpu_h100": (
         "Used by `xla_test` to signal that multiple H100s are needed."
     ),
+    "skip_rocprofiler_sdk": "used to skip rocmtracer test as it calls rocprofiler-sdk via rocprofiler_force_configure",
 }
 
 

--- a/build_tools/rocm/run_xla.sh
+++ b/build_tools/rocm/run_xla.sh
@@ -62,11 +62,10 @@ TritonTest.NonstandardLayoutWithManyNonContractingDims
 TritonTest.NonstandardLayoutWithManyNonContractingDimsReversedLayout
 # //xla/hlo/builder/lib:self_adjoint_eig_test_gpu_amd_any marked as flaky but randomly red after 3 attempts
 RandomEighTestInstantiation/RandomEighTest.Random/*
-# //xla/backends/profiler/gpu:rocm_tracer_test_gpu_amd_any, filtered out due to rocprofiler-sdk
-RocmTracerTest.SingletonInstance
-RocmTracerTest.InitialStateIsAvailable
-RocmTracerTest.EnableAndDisableLifecycle
-RocmTracerTest.AnnotationMapWorks
+)
+
+EXCLUDED_TARGETS=(
+  //xla/backends/profiler/gpu:rocm_tracer_test_gpu_amd_any
 )
 
 BAZEL_DISK_CACHE_SIZE=100G
@@ -113,6 +112,7 @@ bazel --bazelrc=build_tools/rocm/rocm_xla.bazelrc test \
     --test_env=MIOPEN_FIND_ENFORCE=5 \
     --test_env=MIOPEN_FIND_MODE=1 \
     --test_filter=-$(IFS=: ; echo "${EXCLUDED_TESTS[*]}") \
+    "${EXCLUDED_TARGETS[@]/#/-}" \
     "${SANITIZER_ARGS[@]}" \
     "$@"
 

--- a/build_tools/rocm/run_xla.sh
+++ b/build_tools/rocm/run_xla.sh
@@ -64,16 +64,12 @@ TritonTest.NonstandardLayoutWithManyNonContractingDimsReversedLayout
 RandomEighTestInstantiation/RandomEighTest.Random/*
 )
 
-EXCLUDED_TARGETS=(
-  //xla/backends/profiler/gpu:rocm_tracer_test_gpu_amd_any
-)
-
 BAZEL_DISK_CACHE_SIZE=100G
 BAZEL_DISK_CACHE_DIR="/tf/disk_cache/rocm-jaxlib-v0.6.0"
 mkdir -p ${BAZEL_DISK_CACHE_DIR}
 
 SCRIPT_DIR=$(realpath $(dirname $0))
-TAG_FILTERS=$($SCRIPT_DIR/rocm_tag_filters.sh),gpu,-multigpu,-multi_gpu_h100,requires-gpu-amd
+TAG_FILTERS=$($SCRIPT_DIR/rocm_tag_filters.sh),gpu,-multigpu,-multi_gpu_h100,requires-gpu-amd,-skip_rocprofiler_sdk
 
 SANITIZER_ARGS=()
 if [[ $1 == "asan" ]]; then
@@ -112,7 +108,6 @@ bazel --bazelrc=build_tools/rocm/rocm_xla.bazelrc test \
     --test_env=MIOPEN_FIND_ENFORCE=5 \
     --test_env=MIOPEN_FIND_MODE=1 \
     --test_filter=-$(IFS=: ; echo "${EXCLUDED_TESTS[*]}") \
-    "${EXCLUDED_TARGETS[@]/#/-}" \
     "${SANITIZER_ARGS[@]}" \
     "$@"
 

--- a/build_tools/rocm/run_xla.sh
+++ b/build_tools/rocm/run_xla.sh
@@ -62,6 +62,11 @@ TritonTest.NonstandardLayoutWithManyNonContractingDims
 TritonTest.NonstandardLayoutWithManyNonContractingDimsReversedLayout
 # //xla/hlo/builder/lib:self_adjoint_eig_test_gpu_amd_any marked as flaky but randomly red after 3 attempts
 RandomEighTestInstantiation/RandomEighTest.Random/*
+# //xla/backends/profiler/gpu:rocm_tracer_test_gpu_amd_any, filtered out due to rocprofiler-sdk
+RocmTracerTest.SingletonInstance
+RocmTracerTest.InitialStateIsAvailable
+RocmTracerTest.EnableAndDisableLifecycle
+RocmTracerTest.AnnotationMapWorks
 )
 
 BAZEL_DISK_CACHE_SIZE=100G

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -348,6 +348,19 @@ cc_library(
 )
 
 cc_library(
+    name = "rocprofiler-sdk",
+    srcs = glob(["%{rocm_root}/lib/librocprofiler-sdk*.so*"]),
+    hdrs = glob(["%{rocm_root}/include/rocprofiler-sdk/**"]),
+    include_prefix = "rocm",
+    includes = [
+        "%{rocm_root}/include/",
+    ],
+    strip_include_prefix = "%{rocm_root}",
+    visibility = ["//visibility:public"],
+    deps = [":rocm_config"],
+)
+
+cc_library(
     name = "rocsolver",
     srcs = glob(["%{rocm_root}/lib/librocsolver*.so*"]),
     hdrs = glob(["%{rocm_root}/include/rocsolver/**"]),

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -341,6 +341,7 @@ def _find_libs(repository_ctx, rocm_config, miopen_path, rccl_path, bash_bin):
             ("rocsolver", rocm_config.rocm_toolkit_path),
             ("hipfft", rocm_config.rocm_toolkit_path),
             ("rocrand", rocm_config.rocm_toolkit_path),
+            ("rocprofiler-sdk", rocm_config.rocm_toolkit_path),
         ]
     ]
     if int(rocm_config.rocm_version_number) >= 40500:

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -390,6 +390,7 @@ xla_test(
     tags = [
         "gpu",
         "rocm-only",
+        "skip_rocprofiler_sdk",   # due to rocprofiler-sdk's rocprofiler_force_configure
     ] + if_google([
         # Optional: only run internally if ROCm config is enabled
         "manual",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -246,12 +246,6 @@ cc_library(
         "manual",
         "rocm-only",
     ],
-  linkopts = [
-    "-Wl,--no-as-needed",
-    "-L/opt/rocm/lib",
-    "-Wl,-rpath,/opt/rocm/lib",
-    "-lhsa-runtime64",
-  ],
   deps = [
     "//xla/tsl/profiler/backends/cpu:annotation_stack",
     "//xla/tsl/profiler/utils:time_utils",
@@ -266,6 +260,7 @@ cc_library(
     "@tsl//tsl/platform:errors",
     "@tsl//tsl/platform:logging",
     "@tsl//tsl/platform:macros",
+    "@local_config_rocm//rocm:rocprofiler-sdk",
   ],
   visibility = ["//visibility:public"],
 )
@@ -274,13 +269,6 @@ cc_library(
     name = "rocm_collector",
     srcs = ["rocm_collector.cc"],
     hdrs = ["rocm_collector.h"],
-    # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
-    linkopts = select({
-        "//conditions:default": [
-            "-L/opt/rocm/lib",      # search path for all ROCm shared objects
-            "-lrocprofiler-sdk",    # the library that owns the missing symbols
-        ],
-    }),
     tags = [
         "gpu",
         "rocm-only",
@@ -315,6 +303,7 @@ cc_library(
         "@tsl//tsl/platform:types",
         "@tsl//tsl/profiler/lib:profiler_factory",
         "@tsl//tsl/profiler/lib:profiler_interface",
+        "@local_config_rocm//rocm:rocprofiler-sdk",
     ],
 )
 


### PR DESCRIPTION
## Motivation

remove previously hard-coded rocprofiler-sdk path, as the 'ROCM_PATH' might be changed on clients' envs. 

this PR fixed the following issue related to linking `rocprofiler-sdk' 

```
bazel-out/k8-opt/bin/external/xla/xla/backends/profiler/gpu/_objs/rocm_tracer_impl/rocm_profiler_sdk.pic.o:rocm_profiler_sdk.cc:function xla::profiler::RocmTracer::GetTimestamp(): error: undefined reference to 'rocprofiler_get_timestamp'
bazel-out/k8-opt/bin/external/xla/xla/backends/profiler/gpu/_objs/rocm_tracer_impl/rocm_profiler_sdk.pic.o:rocm_profiler_sdk.cc:function xla::profiler::RocmTracer::Enable(xla::profiler::RocmTracerOptions const&, xla::profiler::RocmTraceCollector*): error: undefined reference to 'rocprofiler_start_context'
``` 



