### PR TITLE
Use workers to run the tests

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -259,13 +259,19 @@ build:rocm_dev --remote_cache="https://wardite.cluster.engflow.com"
 
 build:rocm_rbe --bes_backend="grpcs://wardite.cluster.engflow.com"
 build:rocm_rbe --bes_results_url="https://wardite.cluster.engflow.com/invocation/"
-build:rocm_rbe --remote_executor="grpcs://wardite.cluster.engflow.com"
 build:rocm_rbe --host_platform="//platform/linux_x64"
 build:rocm_rbe --extra_execution_platforms="//platform/linux_x64"
 build:rocm_rbe --platforms="//platform/linux_x64"
 build:rocm_rbe --bes_timeout=600s
 build:rocm_rbe --tls_client_certificate="/tf/certificates/ci-cert.crt"
 build:rocm_rbe --tls_client_key="/tf/certificates/ci-cert.key"
+build:rocm_rbe --spawn_strategy=local
+
+test:rocm_rbe --jobs=200
+test:rocm_rbe --remote_executor=grpcs://wardite.cluster.engflow.com
+test:rocm_rbe --remote_timeout=3600
+test:rocm_rbe --strategy=TestRunner=remote,local
+test:rocm_rbe --worker_sandboxing=true
 
 build:rocm_ci --config=rocm_clang_official
 


### PR DESCRIPTION
Use rbe workers to execute tests remotely. Building is still done on the worker node.