### PR TITLE
Add toolchain files as depenency to toolchain

### DIFF
--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -81,3 +81,21 @@ test:xla_mgpu -- \
 //xla/pjrt/distributed:topology_util_test \
 //xla/pjrt/distributed:client_server_test \
 //xla/backends/gpu/runtime:all_reduce_test
+
+
+build:rocm_dev --remote_upload_local_results=false
+build:rocm_dev --remote_cache="https://wardite.cluster.engflow.com"
+
+build:rocm_rbe --bes_backend="grpcs://wardite.cluster.engflow.com"
+build:rocm_rbe --bes_results_url="https://wardite.cluster.engflow.com/invocation/"
+build:rocm_rbe --host_platform="//platform/linux_x64"
+build:rocm_rbe --extra_execution_platforms="//platform/linux_x64"
+build:rocm_rbe --platforms="//platform/linux_x64"
+build:rocm_rbe --bes_timeout=600s
+build:rocm_rbe --tls_client_certificate="/tf/certificates/ci-cert.crt"
+build:rocm_rbe --tls_client_key="/tf/certificates/ci-cert.key"
+build:rocm_rbe --remote_executor=grpcs://wardite.cluster.engflow.com
+build:rocm_rbe --spawn_strategy=remote,worker,standalone,local
+build:rocm_rbe --jobs=200
+build:rocm_rbe --remote_timeout=3600
+test:rocm_rbe --strategy=TestRunner=remote,local

--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -81,21 +81,3 @@ test:xla_mgpu -- \
 //xla/pjrt/distributed:topology_util_test \
 //xla/pjrt/distributed:client_server_test \
 //xla/backends/gpu/runtime:all_reduce_test
-
-
-build:rocm_dev --remote_upload_local_results=false
-build:rocm_dev --remote_cache="https://wardite.cluster.engflow.com"
-
-build:rocm_rbe --bes_backend="grpcs://wardite.cluster.engflow.com"
-build:rocm_rbe --bes_results_url="https://wardite.cluster.engflow.com/invocation/"
-build:rocm_rbe --host_platform="//platform/linux_x64"
-build:rocm_rbe --extra_execution_platforms="//platform/linux_x64"
-build:rocm_rbe --platforms="//platform/linux_x64"
-build:rocm_rbe --bes_timeout=600s
-build:rocm_rbe --tls_client_certificate="/tf/certificates/ci-cert.crt"
-build:rocm_rbe --tls_client_key="/tf/certificates/ci-cert.key"
-build:rocm_rbe --remote_executor=grpcs://wardite.cluster.engflow.com
-build:rocm_rbe --spawn_strategy=remote,worker,standalone,local
-build:rocm_rbe --jobs=200
-build:rocm_rbe --remote_timeout=3600
-test:rocm_rbe --strategy=TestRunner=remote,local

--- a/third_party/gpus/crosstool/BUILD.rocm.tpl
+++ b/third_party/gpus/crosstool/BUILD.rocm.tpl
@@ -35,7 +35,7 @@ cc_toolchain_suite(
 
 cc_toolchain(
     name = "cc-compiler-local",
-    all_files = ":crosstool_wrapper_driver_is_not_gcc",
+    all_files = "@local_config_rocm//rocm:all_files",
     compiler_files = ":crosstool_wrapper_driver_is_not_gcc",
     ar_files = ":crosstool_wrapper_driver_is_not_gcc",
     as_files = ":crosstool_wrapper_driver_is_not_gcc",
@@ -112,6 +112,8 @@ filegroup(
 
 filegroup(
   name = "crosstool_wrapper_driver_is_not_gcc",
-  srcs = [":clang/bin/crosstool_wrapper_driver_is_not_gcc"],
-  data = ["@local_config_rocm//rocm:all_files"],
+  srcs = [
+      ":clang/bin/crosstool_wrapper_driver_is_not_gcc", 
+      "@local_config_rocm//rocm:toolchain_data",
+  ],
 )

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -25,10 +25,8 @@ import shlex
 # Template values set by rocm_configure.bzl.
 CPU_COMPILER = ('%{cpu_compiler}')
 USE_CLANG = ('%{compiler_is_clang}' == 'True')
-HOST_COMPILER_PATH = ('%{host_compiler_path}')
 
 HIPCC_PATH = '%{rocm_root}/bin/hipcc'
-PREFIX_DIR = os.path.dirname(HOST_COMPILER_PATH)
 HIPCC_ENV = '%{hipcc_env}'
 HIP_RUNTIME_PATH = '%{rocm_root}/lib'
 HIP_RUNTIME_LIBRARY = '%{rocm_root}/lib'

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -30,9 +30,9 @@ HOST_COMPILER_PATH = ('%{host_compiler_path}')
 HIPCC_PATH = '%{rocm_root}/bin/hipcc'
 PREFIX_DIR = os.path.dirname(HOST_COMPILER_PATH)
 HIPCC_ENV = '%{hipcc_env}'
-HIP_RUNTIME_PATH = '%{hip_runtime_path}'
-HIP_RUNTIME_LIBRARY = '%{hip_runtime_library}'
-ROCR_RUNTIME_PATH = '%{rocr_runtime_path}'
+HIP_RUNTIME_PATH = '%{rocm_root}/lib'
+HIP_RUNTIME_LIBRARY = '%{rocm_root}/lib'
+ROCR_RUNTIME_PATH = '%{rocm_root}/lib'
 ROCR_RUNTIME_LIBRARY = '%{rocr_runtime_library}'
 VERBOSE = '%{crosstool_verbose}'=='1'
 
@@ -208,7 +208,7 @@ def InvokeHipcc(argv, log=False):
   hipccopts += defines
   hipccopts += std_options
   hipccopts += m_options
-  hipccopts += ' --rocm-path="%{rocm_path}" '
+  hipccopts += ' --rocm-path="%{rocm_root}" '
 
   if depfiles:
     # Generate the dependency file

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -27,7 +27,7 @@ CPU_COMPILER = ('%{cpu_compiler}')
 USE_CLANG = ('%{compiler_is_clang}' == 'True')
 HOST_COMPILER_PATH = ('%{host_compiler_path}')
 
-HIPCC_PATH = '%{hipcc_path}'
+HIPCC_PATH = '%{rocm_root}/bin/hipcc'
 PREFIX_DIR = os.path.dirname(HOST_COMPILER_PATH)
 HIPCC_ENV = '%{hipcc_env}'
 HIP_RUNTIME_PATH = '%{hip_runtime_path}'

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -170,12 +170,12 @@ cc_library(
         "%{rocm_root}/include",
     ],
     strip_include_prefix = "%{rocm_root}",
+    visibility = ["//visibility:public"],
     deps = [
         ":rocm_config",
         ":rocprofiler_register",
         ":system_libs",
     ],
-    visibility = ["//visibility:public"],
 )
 
 # Used by jax_rocm_plugin to minimally link to hip runtime.
@@ -256,8 +256,8 @@ cc_library(
 
 cc_library(
     name = "miopen",
-    hdrs = glob(["%{rocm_root}/include/miopen/**"]),
     srcs = glob(["%{rocm_root}/lib/libMIOpen*.so*"]),
+    hdrs = glob(["%{rocm_root}/include/miopen/**"]),
     data = glob([
         "%{rocm_root}/share/miopen/**",
     ]),
@@ -523,6 +523,15 @@ filegroup(
     srcs = [
         "%{rocm_root}/bin/clang-offload-bundler",
     ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "toolchain_data",
+    srcs = glob([
+        "%{rocm_root}/bin/hipcc",
+        "%{rocm_root}/lib/llvm/bin/clang*",
+    ]),
     visibility = ["//visibility:public"],
 )
 

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -530,7 +530,9 @@ filegroup(
     name = "toolchain_data",
     srcs = glob([
         "%{rocm_root}/bin/hipcc",
-        "%{rocm_root}/lib/llvm/bin/clang*",
+        "%{rocm_root}/lib/llvm/**",
+        "%{rocm_root}/share/hip/**",
+        "%{rocm_root}/amdgcn/**",
     ]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Fixing rbe build.

This pr introduces files dependency which are used by our compiler driver. 
These files will be put to rbe worker when building the xla targets.