### PR TITLE
Execute rbe tests locally

### DIFF
--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -1,5 +1,24 @@
 # Test-related settings.
 
+build:rocm_dev --remote_upload_local_results=false
+build:rocm_dev --remote_cache="https://wardite.cluster.engflow.com"
+
+build:rocm_rbe --bes_backend="grpcs://wardite.cluster.engflow.com"
+build:rocm_rbe --bes_results_url="https://wardite.cluster.engflow.com/invocation/"
+build:rocm_rbe --host_platform="//platform/linux_x64"
+build:rocm_rbe --extra_execution_platforms="//platform/linux_x64"
+build:rocm_rbe --platforms="//platform/linux_x64"
+build:rocm_rbe --bes_timeout=600s
+build:rocm_rbe --tls_client_certificate="/tf/certificates/ci-cert.crt"
+build:rocm_rbe --tls_client_key="/tf/certificates/ci-cert.key"
+build:rocm_rbe --spawn_strategy=local
+
+test:rocm_rbe --jobs=200
+test:rocm_rbe --remote_executor=grpcs://wardite.cluster.engflow.com
+test:rocm_rbe --remote_timeout=3600
+test:rocm_rbe --strategy=TestRunner=local
+test:rocm_rbe --worker_sandboxing=true
+
 build:asan --strip=never
 build:asan --copt -fsanitize=address
 build:asan --copt -DADDRESS_SANITIZER

--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -236,25 +236,6 @@ build:rocm_clang_official --action_env=TF_ROCM_CLANG="1"
 build:rocm_clang_official --linkopt="-fuse-ld=lld"
 build:rocm_clang_official --host_linkopt="-fuse-ld=lld"
 
-build:rocm_dev --remote_upload_local_results=false
-build:rocm_dev --remote_cache="https://wardite.cluster.engflow.com"
-
-build:rocm_rbe --bes_backend="grpcs://wardite.cluster.engflow.com"
-build:rocm_rbe --bes_results_url="https://wardite.cluster.engflow.com/invocation/"
-build:rocm_rbe --host_platform="//platform/linux_x64"
-build:rocm_rbe --extra_execution_platforms="//platform/linux_x64"
-build:rocm_rbe --platforms="//platform/linux_x64"
-build:rocm_rbe --bes_timeout=600s
-build:rocm_rbe --tls_client_certificate="/tf/certificates/ci-cert.crt"
-build:rocm_rbe --tls_client_key="/tf/certificates/ci-cert.key"
-build:rocm_rbe --spawn_strategy=local
-
-test:rocm_rbe --jobs=200
-test:rocm_rbe --remote_executor=grpcs://wardite.cluster.engflow.com
-test:rocm_rbe --remote_timeout=3600
-test:rocm_rbe --strategy=TestRunner=remote,local
-test:rocm_rbe --worker_sandboxing=true
-
 build:rocm_ci --config=rocm_clang_official
 
 build:rocm_ci_hermetic --config=rocm_clang_official


### PR DESCRIPTION
Rbe is not yet ready to run tests remotely. We switch back to local execution