### PR TITLE
[ROCm] Restore CudnnFusedConvRewriter  (#372)

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2135,6 +2135,7 @@ cc_library(
         "//xla/service/gpu/transforms:conv_padding_legalization",
         "//xla/service/gpu/transforms:conv_rewriter",
         "//xla/service/gpu/transforms:cublas_pad_for_gemms",
+        "//xla/service/gpu/transforms:cudnn_fused_conv_decomposer",
         "//xla/service/gpu/transforms:cudnn_fused_conv_rewriter",
         "//xla/service/gpu/transforms:gpusolver_rewriter",
         "//xla/service/gpu/transforms:triangular_solve_rewriter",

--- a/xla/service/gpu/amdgpu_compiler.cc
+++ b/xla/service/gpu/amdgpu_compiler.cc
@@ -58,6 +58,7 @@ limitations under the License.
 #include "xla/service/gpu/transforms/conv_rewriter.h"
 #include "xla/service/gpu/transforms/cublas_pad_for_gemms.h"
 #include "xla/service/gpu/transforms/cudnn_fused_conv_rewriter.h"
+#include "xla/service/gpu/transforms/cudnn_fused_conv_decomposer.h"
 #include "xla/service/gpu/transforms/gpusolver_rewriter.h"
 #include "xla/service/gpu/transforms/triangular_solve_rewriter.h"
 #include "xla/service/hlo_module_config.h"
@@ -216,7 +217,7 @@ absl::Status AMDGPUCompiler::OptimizeHloPostLayoutAssignment(
 // enabled.
 bool AMDGPUCompiler::RequiresCollectiveScheduleLinearizer(
     const HloModule* module, se::StreamExecutor* stream_exec) {
-  if (stream_exec == nullptr || !GpuConvAlgorithmPicker::IsEnabled(module)) {
+  if (stream_exec == nullptr) {
     return false;
   }
   for (const HloComputation* comp : module->MakeNonfusionComputations()) {
@@ -235,34 +236,11 @@ absl::Status AMDGPUCompiler::AddConvAndGemmAutotuningPasses(
     const CompileOptions& options, HloModule* hlo_module,
     AutotuneConfig& autotune_config, tsl::thread::ThreadPool* thread_pool,
     se::StreamExecutor* stream_exec) {
-  const DebugOptions& debug_options = hlo_module->config().debug_options();
-  if (hlo_module->config()
-          .debug_options()
-          .xla_gpu_experimental_disable_binary_libraries() ||
-      debug_options.xla_gpu_autotune_level() == 0 ||
-      debug_options.xla_gpu_exclude_nondeterministic_ops()) {
-    return absl::OkStatus();
-  }
-
-  // TODO(b/407495801): Cached Gemm as well as Conv autotuning results are
-  // loaded in the GpuConvAlgorithmPicker but should be loaded in the autotuner.
+  //We do autotuning irrespective of --xla_gpu_autotune_level.
   pipeline->AddPass<GpuConvAlgorithmPicker>(autotune_config);
-
-  std::vector<std::unique_ptr<CodegenBackend>> backends;
-  // TODO: b/407494793 - Add proper support for ROCM. Currently the Cublas
-  // backend uses the same API as rocBLAS.
-  if (debug_options.xla_gpu_experimental_use_autotuner_pass()) {
-    backends.push_back(
-        std::make_unique<CublasBackend>(stream_exec, &debug_options, this));
-    TF_ASSIGN_OR_RETURN(
-        std::unique_ptr<AutotunerPass> autotuner_pass,
-        AutotunerPass::Create(std::move(backends), debug_options, stream_exec,
-                              thread_pool));
-    pipeline->AddPass(std::move(autotuner_pass));
-  } else {
-    pipeline->AddPass<GemmAlgorithmPicker>(autotune_config);
-  }
-
+  // Undo CudnnFusedConvRewriter work if no algorithm was found.
+  pipeline->AddPass<CudnnFusedConvDecomposer>();
+  pipeline->AddPass<GemmAlgorithmPicker>(autotune_config);
   return absl::OkStatus();
 }
 

--- a/xla/service/gpu/autotuning/conv_algorithm_picker.cc
+++ b/xla/service/gpu/autotuning/conv_algorithm_picker.cc
@@ -423,7 +423,7 @@ absl::StatusOr<AutotuneResult> GpuConvAlgorithmPicker::PickBestAlgorithmNoCache(
   // utilities are not used in ROCm routine
   se::Platform::Id platform_id = stream_exec->GetPlatform()->id();
   if (platform_id == se::rocm::kROCmPlatformId) {
-    result_or = PickBestAlgorithmNoCacheRocm(instr);
+    result_or = PickBestAlgorithmNoCacheRocm(instr, instr->GetModule()->config());
   } else if (platform_id == se::cuda::kCudaPlatformId) {
     result_or = PickBestAlgorithmNoCacheCuda(instr);
   }
@@ -911,16 +911,86 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheCuda(
 }
 
 absl::StatusOr<AutotuneResult>
+GpuConvAlgorithmPicker::PickBestAlgorithmForFusionNoCacheRocm(
+    const HloCustomCallInstruction* instr, const HloModuleConfig& hlo_config) {
+  TF_ASSIGN_OR_RETURN(GpuConvConfig config, GetGpuConvConfig(instr));
+
+  CHECK(config.kind == CudnnConvKind::kForwardActivation);
+
+  TF_ASSIGN_OR_RETURN(se::dnn::DataType dtype,
+                      GetDNNDataTypeFromPrimitiveType(config.output_type));
+
+  TF_ASSIGN_OR_RETURN(se::Stream* const stream, config_.GetStream());
+  se::StreamExecutor* stream_exec = config_.GetExecutor();
+  auto dnn = stream_exec->AsDnn();
+  if (dnn == nullptr) {
+    return absl::InvalidArgumentError("No DNN in stream executor.");
+  }
+
+  std::vector<std::unique_ptr<const se::dnn::FusedConvRunner>> runners;
+  TF_RETURN_IF_ERROR(dnn->GetFusedConvolveRunners(
+      se::dnn::ConvolutionKind::FORWARD, dtype,
+      dtype, dtype, config.conv_result_scale, config.fusion->side_input_scale,
+      config.fusion->leakyrelu_alpha, stream, config.input_descriptor,
+      config.filter_descriptor, config.bias_descriptor,
+      config.output_descriptor, config.conv_desc,
+      /* use_fallback */ false, config.fusion->mode, /* numeric_options */ {},
+      &runners));
+
+  CHECK(runners.size() < 2);
+
+  if (runners.size() == 1) {
+    AutotuneResult result;
+    TF_ASSIGN_OR_RETURN(auto alg, runners[0]->ToAlgorithmDesc());
+    auto algorithm_proto = alg.ToProto();
+    *result.mutable_algorithm() = algorithm_proto;
+    result.set_scratch_bytes(runners[0]->GetWorkspaceSize());
+    *result.mutable_run_time() =
+        tsl::proto_utils::ToDurationProto(absl::Milliseconds(-1));
+    return result;
+  }
+
+  // No algorithm found. Try finding algorithm for unfused conv.
+
+  CHECK(config.conv_result_scale == 1.0 &&
+        config.fusion->side_input_scale == 0.0 &&
+        instr->operands().size() == 3);
+
+  absl::InlinedVector<HloInstruction*, 3> new_operands(
+      instr->operands().begin(), instr->operands().end());
+  new_operands.pop_back();
+
+  auto new_conv =
+      instr->CloneWithNewOperands(instr->shape(), new_operands);
+  new_conv->set_custom_call_target(kCudnnConvForwardCallTarget);
+
+  TF_ASSIGN_OR_RETURN(auto gpu_config,
+                      new_conv->backend_config<GpuBackendConfig>());
+  CudnnConvBackendConfig& backend_config =
+      *gpu_config.mutable_cudnn_conv_backend_config();
+  backend_config.set_activation_mode(se::dnn::ActivationMode::kNone);
+
+  return PickBestAlgorithmNoCacheRocm(
+      static_cast<HloCustomCallInstruction*>(new_conv.get()), hlo_config);
+}
+
+absl::StatusOr<AutotuneResult>
 GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
-    const HloCustomCallInstruction* instr) {
+    const HloCustomCallInstruction* instr, const HloModuleConfig& hlo_config) {
   XLA_SCOPED_LOGGING_TIMER(absl::StrCat(
       "GpuConvAlgorithmPicker::PickBestAlgorithmImpl for ", instr->ToString()));
+
+  if (instr->custom_call_target() == kCudnnConvBiasActivationForwardCallTarget) {
+    return PickBestAlgorithmForFusionNoCacheRocm(instr, hlo_config);
+  }
 
   const bool allow_tf32 = absl::c_all_of(
       instr->precision_config().operand_precision(),
       [](int precision) { return precision <= PrecisionConfig::HIGH; });
+
   const se::NumericOptions numeric_options{
-      RequireDeterminism(instr->GetModule()->config()), allow_tf32};
+      RequireDeterminism(hlo_config),
+      allow_tf32};
 
   se::StreamExecutor* stream_exec = config_.GetExecutor();
   const auto device_ordinal = stream_exec->device_ordinal();
@@ -977,8 +1047,9 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
                           &scratch_allocator, stream, numeric_options));
 
   std::vector<AutotuneResult> profile_results;
-
-  if (runners.size() == 1) {
+  // If using TF_ROCM_USE_IMMEDIATE_MODE but user doesn't want autotuning, choose the first
+  // algo.
+  if (runners.size() == 1 || !IsEnabled(instr->GetModule())) {
     TF_ASSIGN_OR_RETURN(auto alg, runners[0]->ToAlgorithmDesc());
     auto algorithm_proto = alg.ToProto();
     profile_results.emplace_back();
@@ -1044,7 +1115,7 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
 
   TF_ASSIGN_OR_RETURN(AutotuneResult selected_algorithm,
                       PickBestResult(profile_results, instr->ToString(),
-                                     instr->GetModule()->config()));
+                                     hlo_config));
   return selected_algorithm;
 }
 
@@ -1163,7 +1234,8 @@ absl::StatusOr<bool> GpuConvAlgorithmPicker::Run(
   XLA_SCOPED_LOGGING_TIMER(
       absl::StrCat("GpuConvAlgorithmPicker for ", module->name()));
 
-  if (!IsEnabled(module)) {
+  if (!IsEnabled(module) && !std::holds_alternative<se::RocmComputeCapability>(
+                                config_.GetGpuComputeCapability())) {
     VLOG(3) << "Convolution auto-tuning disabled, GpuConvAlgorithmPicker "
                "returning early.";
     return false;

--- a/xla/service/gpu/autotuning/conv_algorithm_picker.h
+++ b/xla/service/gpu/autotuning/conv_algorithm_picker.h
@@ -140,7 +140,9 @@ class GpuConvAlgorithmPicker : public HloModulePass {
       const HloCustomCallInstruction* instr);
 
   absl::StatusOr<AutotuneResult> PickBestAlgorithmNoCacheRocm(
-      const HloCustomCallInstruction* instr);
+      const HloCustomCallInstruction* instr, const HloModuleConfig& hlo_config);
+  absl::StatusOr<AutotuneResult> PickBestAlgorithmForFusionNoCacheRocm(
+      const HloCustomCallInstruction* instr, const HloModuleConfig& hlo_config);
 
  private:
   AutotuneConfig config_;

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -724,6 +724,42 @@ xla_test(
     ],
 )
 
+# Tested via :cudnn_fused_conv_rewriter_test
+cc_library(
+    name = "cudnn_fused_conv_decomposer",
+    srcs = ["cudnn_fused_conv_decomposer.cc"],
+    hdrs = ["cudnn_fused_conv_decomposer.h"],
+    deps = [
+        "//xla:comparison_util",
+        "//xla:debug_options_flags",
+        "//xla:literal",
+        "//xla:shape_util",
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla:xla_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/ir:hlo_instruction_utils",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/service:hlo_creation_utils",
+        "//xla/service:pattern_matcher",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/service/gpu:cublas_cudnn",
+        "//xla/stream_executor:dnn",
+        "//xla/tsl/protobuf:dnn_proto_cc",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:ml_dtypes",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
 # Tested via //third_party/tensorflow/compiler/xla/backends/gpu/codegen:cudnn_test
 cc_library(
     name = "cudnn_fusion_compiler",

--- a/xla/service/gpu/transforms/cudnn_fused_conv_decomposer.cc
+++ b/xla/service/gpu/transforms/cudnn_fused_conv_decomposer.cc
@@ -1,0 +1,180 @@
+/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/cudnn_fused_conv_decomposer.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+
+#include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_clone_context.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/primitive_util.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/hlo_creation_utils.h"
+#include "xla/shape_util.h"
+#include "xla/stream_executor/dnn.h"
+#include "xla/service/gpu/cublas_cudnn.h"
+#include "xla/util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/statusor.h"
+
+namespace xla {
+namespace gpu {
+
+namespace {
+
+class CustomCallVisitor : public DfsHloRewriteVisitor {
+ public:
+  absl::Status HandleCustomCall(HloInstruction* instr) override {
+    if (instr->custom_call_target() !=
+        kCudnnConvBiasActivationForwardCallTarget) {
+      return absl::OkStatus();
+    }
+    TF_ASSIGN_OR_RETURN(auto gpu_config,
+                        instr->backend_config<GpuBackendConfig>());
+    CudnnConvBackendConfig& backend_config =
+        *gpu_config.mutable_cudnn_conv_backend_config();
+    if (backend_config.algorithm().is_cudnn_frontend()) {
+      return absl::OkStatus();
+    }
+
+    CHECK(backend_config.conv_result_scale() == 1.0 &&
+          backend_config.side_input_scale() == 0.0 &&
+          instr->operands().size() == 3);
+
+    HloInstruction* bias = instr->operands().back();
+    const std::vector<HloInstruction*> users(instr->users().begin(),
+                                             instr->users().end());
+    HloInstruction* conv_result =
+        instr->AddInstruction(HloInstruction::CreateGetTupleElement(instr, 0));
+    HloInstruction* bcast_bias = instr->AddInstruction(
+        HloInstruction::CreateBroadcast(conv_result->shape(), bias,
+                                        {instr->convolution_dimension_numbers()
+                                             .output_feature_dimension()}));
+    HloInstruction* conv_bias =
+        instr->AddInstruction(HloInstruction::CreateBinary(
+            conv_result->shape(), HloOpcode::kAdd, conv_result, bcast_bias));
+
+    HloInstruction* conv_bias_act = nullptr;
+
+    switch (backend_config.activation_mode()) {
+      case se::dnn::ActivationMode::kNone:
+        conv_bias_act = conv_bias;
+        break;
+      case se::dnn::ActivationMode::kRelu:
+        conv_bias_act = instr->AddInstruction(HloInstruction::CreateBinary(
+            conv_bias->shape(), HloOpcode::kMaximum,
+            BroadcastZeros(instr->parent(), conv_bias->shape()), conv_bias));
+        break;
+      case se::dnn::ActivationMode::kElu:
+        conv_bias_act = instr->AddInstruction(HloInstruction::CreateTernary(
+            conv_bias->shape(), HloOpcode::kSelect,
+            instr->AddInstruction(HloInstruction::CreateCompare(
+                ShapeUtil::ChangeElementType(conv_bias->shape(), PRED),
+                conv_bias, BroadcastZeros(instr->parent(), conv_bias->shape()),
+                ComparisonDirection::kGt)),
+            conv_bias,
+            instr->AddInstruction(HloInstruction::CreateUnary(
+                conv_bias->shape(), HloOpcode::kExpm1, conv_bias))));
+        break;
+      case se::dnn::ActivationMode::kRelu6:
+        conv_bias_act = instr->AddInstruction(HloInstruction::CreateTernary(
+            conv_bias->shape(), HloOpcode::kClamp,
+            BroadcastZeros(instr->parent(), conv_bias->shape()), conv_bias,
+            instr->AddInstruction(HloInstruction::CreateBroadcast(
+                conv_bias->shape(),
+                instr->AddInstruction(
+                    HloInstruction::CreateConstant(LiteralUtil::CreateR0(
+                        conv_bias->shape().element_type(), 6))),
+                {}))));
+        break;
+      case se::dnn::ActivationMode::kLeakyRelu:
+        conv_bias_act = instr->AddInstruction(HloInstruction::CreateTernary(
+            conv_bias->shape(), HloOpcode::kSelect,
+            instr->AddInstruction(HloInstruction::CreateCompare(
+                ShapeUtil::ChangeElementType(conv_bias->shape(), PRED),
+                conv_bias, BroadcastZeros(instr->parent(), conv_bias->shape()),
+                ComparisonDirection::kGt)),
+            conv_bias,
+            instr->AddInstruction(HloInstruction::CreateBinary(
+                conv_bias->shape(), HloOpcode::kMultiply,
+                instr->AddInstruction(HloInstruction::CreateBroadcast(
+                    conv_bias->shape(),
+                    instr->AddInstruction(
+                        HloInstruction::CreateConstant(LiteralUtil::CreateR0(
+                            conv_bias->shape().element_type(),
+                            backend_config.leakyrelu_alpha()))),
+                    {})),
+                conv_bias))));
+        break;
+    }
+
+    CHECK_NE(conv_bias_act, nullptr);
+
+    HloInstruction* new_result =
+        instr->AddInstruction(HloInstruction::CreateTuple(
+            {conv_bias_act,
+             instr->AddInstruction(
+                 HloInstruction::CreateGetTupleElement(instr, 1))}));
+
+    for (auto user : users) {
+      TF_RETURN_IF_ERROR(instr->ReplaceUseWith(user, new_result));
+    }
+
+    backend_config.set_activation_mode(se::dnn::ActivationMode::kNone);
+    absl::InlinedVector<HloInstruction*, 3> new_operands(
+        instr->operands().begin(), instr->operands().end());
+    new_operands.pop_back();
+
+    HloInstruction* new_conv = instr->AddInstruction(
+        instr->CloneWithNewOperands(instr->shape(), new_operands));
+    new_conv->set_custom_call_target(kCudnnConvForwardCallTarget);
+    // Preserve old name to make it obvious that we decomposed fused conv
+    new_conv->SetAndSanitizeName(instr->name());
+    TF_RETURN_IF_ERROR(ReplaceInstruction(instr, new_conv));
+    ;
+    return absl::OkStatus();
+  }
+};
+
+}  // namespace
+
+absl::StatusOr<bool> CudnnFusedConvDecomposer::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  XLA_SCOPED_LOGGING_TIMER("cuDNN fused conv decomposer");
+  return CustomCallVisitor().RunOnModule(module, execution_threads);
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/transforms/cudnn_fused_conv_decomposer.h
+++ b/xla/service/gpu/transforms/cudnn_fused_conv_decomposer.h
@@ -1,0 +1,44 @@
+/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_TRANSFORMS_CUDNN_FUSED_CONV_DECOMPOSER_H_
+#define XLA_SERVICE_GPU_TRANSFORMS_CUDNN_FUSED_CONV_DECOMPOSER_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+#include "xla/stream_executor/dnn.h"
+
+namespace xla {
+namespace gpu {
+
+// Reverts fused conv-bias-activation custom calls (when no matching algorithm is found)
+// back to their unfused representation.
+class CudnnFusedConvDecomposer : public HloModulePass {
+ public:
+  absl::string_view name() const override { return "cudnn-fused-conv-decomposer"; }
+
+  using HloPassInterface::Run;
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_TRANSFORMS_CUDNN_FUSED_CONV_DECOMPOSER_H_

--- a/xla/service/gpu/transforms/cudnn_fused_conv_rewriter.cc
+++ b/xla/service/gpu/transforms/cudnn_fused_conv_rewriter.cc
@@ -97,7 +97,7 @@ bool IsNonDepthwiseConvCustomCall(const HloInstruction* instr) {
   return IsConvCustomCall(instr) && !IsConvDepthwise(instr);
 }
 
-bool IsROCm(se::GpuComputeCapability cc) {
+bool IsROCm(const se::GpuComputeCapability& cc) {
   return std::holds_alternative<se::RocmComputeCapability>(cc);
 }
 
@@ -111,7 +111,7 @@ bool IsROCm(se::GpuComputeCapability cc) {
 // Note that as of writing, xla_gpu_use_runtime_fusion is disabled by default
 // due to apparent bugs in cudnn 8.9.0.  See debug_options_flags.cc for details.
 bool ShouldUseCudnnRuntimeFusion(const DebugOptions& debug_opts,
-                                 se::GpuComputeCapability cc) {
+                                 const se::GpuComputeCapability& cc) {
   const auto* cuda_cc = std::get_if<se::CudaComputeCapability>(&cc);
   if (cuda_cc != nullptr)
     return debug_opts.xla_gpu_use_runtime_fusion() && cuda_cc->IsAtLeast(7, 5);
@@ -312,7 +312,9 @@ absl::StatusOr<bool> FuseRemoveConvertInConv(HloComputation* comp) {
 
 // alpha * gte(custom-call(...)) ->
 // gte(custom-call(..., backend_config={alpha})).
-absl::StatusOr<bool> FuseConvAlpha(HloComputation* comp) {
+absl::StatusOr<bool> FuseConvAlpha(HloComputation* comp,
+                                   const se::GpuComputeCapability& cc) {
+  if (IsROCm(cc)) return false;
   bool changed = false;
   for (auto instr : comp->MakeInstructionPostOrder()) {
     HloInstruction* conv = nullptr;
@@ -960,7 +962,8 @@ absl::StatusOr<bool> F8GraphConv(HloComputation* comp,
   return changed;
 }
 
-absl::StatusOr<bool> FuseBiasOrSideInput(HloComputation* comp) {
+absl::StatusOr<bool> FuseBiasOrSideInput(HloComputation* comp,
+                                         const se::GpuComputeCapability& cc) {
   bool changed = false;
   for (auto instr : comp->MakeInstructionPostOrder()) {
     HloInstruction* conv = nullptr;
@@ -985,15 +988,6 @@ absl::StatusOr<bool> FuseBiasOrSideInput(HloComputation* comp) {
       continue;
     }
 
-    // If it's a vanilla forward conv, upgrade it to a bias-activation conv.  We
-    // only want to do this if the fusion will succeed, but we're guaranteed
-    // that it will, because the only reason we'll bail at this point is if
-    // !can_accept_bias && !can_accept_side_input, and our shiny new
-    // bias-activation conv will be able to accept both.
-    if (conv->custom_call_target() == kCudnnConvForwardCallTarget) {
-      TF_ASSIGN_OR_RETURN(conv, EnsureIsConvBiasActivation(conv));
-    }
-
     // Can't fuse bias or side-input if the conv already has a relu (or other
     // activation), because bias and side-input are added before the activation
     // is applied.
@@ -1008,8 +1002,9 @@ absl::StatusOr<bool> FuseBiasOrSideInput(HloComputation* comp) {
     // Does `conv` already have a (nonzero) bias?  Does it already have a
     // side_input?
     bool can_accept_bias =
+        conv->operand_count() < 3 ||
         Match(conv->operand(2), m::Broadcast(m::ConstantEffectiveScalar(0)));
-    bool can_accept_side_input = conv->operand_count() < 4;
+    bool can_accept_side_input = conv->operand_count() < 4 && !IsROCm(cc);
 
     // The addend can be fused as a bias if
     //  - it is 1D broadcasted in the output feature dimension, and
@@ -1029,6 +1024,13 @@ absl::StatusOr<bool> FuseBiasOrSideInput(HloComputation* comp) {
         HloPredicateIsOp<HloOpcode::kBroadcast>(addend) &&
         addend->dimensions().empty() &&
         IsLosslesslyConvertibleTo(addend, bias_ty);
+
+    // ROCM can only support bias form for now
+    if (!addend_may_be_rank1_bias && !addend_may_be_rank0_bias && IsROCm(cc)) {
+      continue;
+    }
+
+    TF_ASSIGN_OR_RETURN(conv, EnsureIsConvBiasActivation(conv));
 
     absl::InlinedVector<HloInstruction*, 4> new_operands(
         conv->operands().begin(), conv->operands().end());
@@ -1074,7 +1076,9 @@ absl::StatusOr<bool> FuseBiasOrSideInput(HloComputation* comp) {
 //
 // where `reshape` can be an arbitrary chain of reshapes+transposes.  This idiom
 // is created by the ReshapeMover pass.
-absl::StatusOr<bool> FuseSideInputAlpha(HloComputation* comp) {
+absl::StatusOr<bool> FuseSideInputAlpha(HloComputation* comp,
+                                        const se::GpuComputeCapability& cc) {
+  if (IsROCm(cc)) return false;
   bool changed = false;
   for (HloInstruction* instr : comp->MakeInstructionPostOrder()) {
     HloInstruction* conv;
@@ -1182,7 +1186,7 @@ absl::StatusOr<bool> FuseSideInputAlpha(HloComputation* comp) {
 }
 
 absl::StatusOr<bool> FuseElu(HloComputation* comp,
-                             se::GpuComputeCapability cc) {
+                             const se::GpuComputeCapability& cc) {
   if (!ShouldUseCudnnRuntimeFusion(comp->parent()->config().debug_options(),
                                    cc)) {
     return false;
@@ -1283,7 +1287,7 @@ absl::StatusOr<bool> FuseRelu(HloComputation* comp) {
 }
 
 absl::StatusOr<bool> FuseRelu6(HloComputation* comp,
-                               se::GpuComputeCapability cc) {
+                               const se::GpuComputeCapability& cc) {
   if (!ShouldUseCudnnRuntimeFusion(comp->parent()->config().debug_options(),
                                    cc)) {
     return false;
@@ -1332,7 +1336,7 @@ absl::StatusOr<bool> FuseRelu6(HloComputation* comp,
 }
 
 absl::StatusOr<bool> FuseLeakyRelu(HloComputation* comp,
-                                   se::GpuComputeCapability cc) {
+                                   const se::GpuComputeCapability& cc) {
   if (!ShouldUseCudnnRuntimeFusion(comp->parent()->config().debug_options(),
                                    cc)) {
     return false;
@@ -1453,7 +1457,7 @@ absl::StatusOr<bool> FuseConvertToF16(HloComputation* comp) {
 }
 
 absl::StatusOr<bool> FuseConvertToS8(HloComputation* comp,
-                                     se::GpuComputeCapability cc) {
+                                     const se::GpuComputeCapability& cc) {
   if (IsROCm(cc)) return false;
   bool changed = false;
   for (HloInstruction* instr : comp->MakeInstructionPostOrder()) {
@@ -1708,18 +1712,18 @@ absl::StatusOr<bool> CudnnFusedConvRewriter::Run(
     TF_ASSIGN_OR_RETURN(changed, FuseRemoveConvertInConv(comp));
     any_changed |= changed;
 
-    TF_ASSIGN_OR_RETURN(changed, FuseConvAlpha(comp));
+    TF_ASSIGN_OR_RETURN(changed, FuseConvAlpha(comp, compute_capability_));
     any_changed |= changed;
 
     // s8 convs' bias and side-input appear before conversion to s8.
     //
     // Run FuseBiasOrSideInput twice, so we get both the bias and the side
     // input, if both are present.
-    TF_ASSIGN_OR_RETURN(changed, FuseBiasOrSideInput(comp));
+    TF_ASSIGN_OR_RETURN(changed, FuseBiasOrSideInput(comp, compute_capability_));
     any_changed |= changed;
-    TF_ASSIGN_OR_RETURN(changed, FuseBiasOrSideInput(comp));
+    TF_ASSIGN_OR_RETURN(changed, FuseBiasOrSideInput(comp, compute_capability_));
     any_changed |= changed;
-    TF_ASSIGN_OR_RETURN(changed, FuseSideInputAlpha(comp));
+    TF_ASSIGN_OR_RETURN(changed, FuseSideInputAlpha(comp, compute_capability_));
     any_changed |= changed;
 
     // Relu might appear before or after convert-to-f16/s8, so we check in both
@@ -1740,11 +1744,11 @@ absl::StatusOr<bool> CudnnFusedConvRewriter::Run(
     any_changed |= changed;
 
     // f16 convs' bias+side-input can appear before or after conversion to f16.
-    TF_ASSIGN_OR_RETURN(changed, FuseBiasOrSideInput(comp));
+    TF_ASSIGN_OR_RETURN(changed, FuseBiasOrSideInput(comp, compute_capability_));
     any_changed |= changed;
-    TF_ASSIGN_OR_RETURN(changed, FuseBiasOrSideInput(comp));
+    TF_ASSIGN_OR_RETURN(changed, FuseBiasOrSideInput(comp, compute_capability_));
     any_changed |= changed;
-    TF_ASSIGN_OR_RETURN(changed, FuseSideInputAlpha(comp));
+    TF_ASSIGN_OR_RETURN(changed, FuseSideInputAlpha(comp, compute_capability_));
     any_changed |= changed;
 
     TF_ASSIGN_OR_RETURN(changed, FuseRelu(comp));

--- a/xla/service/gpu/transforms/cudnn_fused_conv_rewriter_test.cc
+++ b/xla/service/gpu/transforms/cudnn_fused_conv_rewriter_test.cc
@@ -173,11 +173,13 @@ class CudnnFusedConvRewriterTest : public GpuCodegenTest {
       const std::string hlo_with_new_type =
           absl::StrReplaceAll(hlo_string, {{"TYPE", type}});
       std::string optimized_hlo_string = GetOptimizedHlo(hlo_with_new_type);
+      // Match instruction names to allow for CudnnFusedConvDecomposer reverting back
+      // some of the fusions on ROCm.
       EXPECT_THAT(optimized_hlo_string,
-                  Not(HasSubstr(kCudnnConvForwardCallTarget)))
+                  Not(HasSubstr("cudnn-conv.")))
           << optimized_hlo_string;
       EXPECT_THAT(optimized_hlo_string,
-                  HasSubstr(kCudnnConvBiasActivationForwardCallTarget));
+                  HasSubstr("cudnn-conv-bias-activation."));
 
       TF_ASSERT_OK_AND_ASSIGN(auto module,
                               ParseAndReturnVerifiedModule(hlo_with_new_type));
@@ -587,6 +589,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestLeakyRelu) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestSideInputOnly) {
+  MAYBE_SKIP_TEST("SideInput");
   // max(0, conv(x, w) + side_input);
   TestMatchWithAllTypes(R"(
     HloModule Test
@@ -625,6 +628,7 @@ TEST_F(CudnnFusedConvRewriterTest, DontFuseSideInputWithDepthwiseConv) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestBiasAndSideInput) {
+  MAYBE_SKIP_TEST("SideInput");
   // max(0, conv(x, w) + side_input + bias);
   TestMatchWithAllTypes(R"(
     HloModule Test
@@ -647,6 +651,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestBiasAndSideInput) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestScaledConv) {
+  MAYBE_SKIP_TEST("Scale");
   // max(0, 0.999994934 * conv(x, w));
   TestMatchWithAllTypes(R"(
     HloModule Test
@@ -707,6 +712,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestNoCrashOnInf) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestConvAndScaledSideInput) {
+  MAYBE_SKIP_TEST("SideInput");
   // max(0, conv(x, w) + 0.899994934 * side_input);
   TestMatchWithAllTypes(R"(
     HloModule Test
@@ -751,6 +757,7 @@ TEST_F(CudnnFusedConvRewriterTest, DontFuseDepthwiseConvWithScaledSideInput) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestScaledConvAndScaledSideInput) {
+  MAYBE_SKIP_TEST("SideInput");
   // max(0, 0.999994934 * conv(x, w) + 0.899994934 * side_input);
   TestMatchWithAllTypes(R"(
     HloModule Test
@@ -776,6 +783,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestScaledConvAndScaledSideInput) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestScaledConvAndScaledSideInputWithBias) {
+  MAYBE_SKIP_TEST("SideInput");
   // max(0, 0.999994934 * conv(x, w) + 0.899994934 * side_input + bias);
   TestMatchWithAllTypes(R"(
     HloModule Test

--- a/xla/stream_executor/rocm/rocm_dnn.cc
+++ b/xla/stream_executor/rocm/rocm_dnn.cc
@@ -714,7 +714,6 @@ dnn::ProfileResult GetProfileResultFromConvAlgoPerf(
   int64_t algo_id;
   switch (kind) {
     case dnn::ConvolutionKind::FORWARD:
-    case dnn::ConvolutionKind::FORWARD_BIAS_ACTIVATION:
       algo_id = algorithm.fwd_algo;
       break;
     case dnn::ConvolutionKind::BACKWARD_DATA:
@@ -1506,7 +1505,7 @@ class ScopedFusionPlanConvolutionBiasActivation : public ScopedFusionPlanBase {
                                                   input_descriptor);
 
     VLOG(2) << "Fusion Plan compile begin";
-
+    // TODO(rocm): Check if the caching is actualy needed
     uint64_t hash =
         GetFusionOpHashValue(miopen_handle, input_descriptor, filter_descriptor,
                              conv_descriptor, bias_descriptor, act_descriptor);
@@ -3616,8 +3615,7 @@ absl::Status MIOpenSupport::GetMIOpenConvolveAlgorithmsImmediateMode(
   size_t maxSolutionCount = 0;
 
   switch (kind) {
-    case dnn::ConvolutionKind::FORWARD:
-    case dnn::ConvolutionKind::FORWARD_BIAS_ACTIVATION: {
+    case dnn::ConvolutionKind::FORWARD: {
       auto status = wrap::miopenConvolutionForwardGetSolutionCount(
           miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
           output_nd.handle(), &maxSolutionCount);
@@ -3829,8 +3827,7 @@ absl::Status MIOpenSupport::GetMIOpenConvolveAlgorithmsFindMode(
   // Determine the workspace memory size that will need by the call to Find
   size_t scratch_memory_size = 0;
   switch (kind) {
-    case dnn::ConvolutionKind::FORWARD:
-    case dnn::ConvolutionKind::FORWARD_BIAS_ACTIVATION: {
+    case dnn::ConvolutionKind::FORWARD: {
       auto status = wrap::miopenConvolutionForwardGetWorkSpaceSize(
           miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
           output_nd.handle(), &scratch_memory_size);
@@ -3906,8 +3903,7 @@ absl::Status MIOpenSupport::GetMIOpenConvolveAlgorithmsFindMode(
   bool exhaustiveSearch = false;
 
   switch (kind) {
-    case dnn::ConvolutionKind::FORWARD:
-    case dnn::ConvolutionKind::FORWARD_BIAS_ACTIVATION: {
+    case dnn::ConvolutionKind::FORWARD: {
       auto status = wrap::miopenFindConvolutionForwardAlgorithm(
           miopen.handle(), input_nd.handle(), input_data.opaque(),
           filter.handle(), filter_data.opaque(), conv.handle(),
@@ -4863,43 +4859,32 @@ class RocmFusedConvRunner : public dnn::FusedConvRunner {
     return MakeAlgorithmDesc().ToString();
   }
 
-  uint64_t GetWorkspaceSize() const override { return workspace_size_; }
+  uint64_t GetWorkspaceSize() const override { return 0; }
 
   absl::StatusOr<dnn::AlgorithmDesc> ToAlgorithmDesc() const override {
     return MakeAlgorithmDesc();
   }
 
-  absl::Status operator()(Stream* stream, dnn::ProfileResult* profile_result,
-                          DeviceMemoryBase scratch_memory,
-                          DeviceMemoryBase input_data,
-                          DeviceMemoryBase filter_data,
-                          DeviceMemoryBase side_input_data,
-                          DeviceMemoryBase bias_data,
-                          DeviceMemoryBase output_data) const override {
+  absl::Status operator()(
+      Stream* stream, dnn::ProfileResult* output_profile_result,
+      DeviceMemoryBase scratch_memory, DeviceMemoryBase input_data,
+      DeviceMemoryBase filter_data, DeviceMemoryBase side_input_data,
+      DeviceMemoryBase bias_data, DeviceMemoryBase output_data) const override {
     VLOG(2) << "RocmFusedConvRunner()";
     if (parent_ != stream->parent()) {
       return absl::InternalError(
           "RocmFusedConvRunner cached across multiple StreamExecutors.");
     }
 
-    // We can't reliably detect whether this sequence can be fused until
-    // we come here and actually try to fuse it. So, we need a fallback.
-    bool do_unfused =
-        (side_input_scale_ != 0.0) || !fusion_plan_.CompilationSucceeded();
-
-    if (do_unfused)
-      return execute_unfused(stream, profile_result, scratch_memory, input_data,
-                             filter_data, side_input_data, bias_data,
-                             output_data);
-    auto algo = MakeAlgorithmDesc();
     auto miopen = miopen_->GetHandle(parent_, stream);
     fusion_plan_.SetConvolutionArgs(filter_data.opaque());
     fusion_plan_.SetBiasArgs(bias_data.opaque());
     if (activation_desc_.miopen_activation_mode_ != miopenActivationPASTHRU)
       fusion_plan_.SetActivationForwardArgs(activation_desc_);
 
+    const bool is_profiling = output_profile_result != nullptr;
     std::unique_ptr<EventBasedTimer> timer;
-    if (profile_result) {
+    if (is_profiling) {
       TF_ASSIGN_OR_RETURN(timer, stream->CreateEventBasedTimer(
                                      /* use_delay_kernel=*/false));
     }
@@ -4918,28 +4903,19 @@ class RocmFusedConvRunner : public dnn::FusedConvRunner {
           stream_executor::gpu::ToString(status));
     }
 
-    if (profile_result) {
-      absl::StatusOr<absl::Duration> elapsed = timer->GetElapsedDuration();
-      if (!elapsed.ok()) {
-        LOG(ERROR) << "Failed to get elapsed duration";
-        return absl::InternalError("Timer failure");
-      }
-      profile_result->set_elapsed_time_in_ms(
-          absl::ToDoubleMilliseconds(*elapsed));
-      profile_result->set_algorithm(algo);
-      profile_result->set_scratch_size(scratch_memory.size());
+    if (is_profiling) {
+      TF_RETURN_IF_ERROR(PopulateProfileFromTimer(
+          timer.get(), MakeAlgorithmDesc(), output_profile_result));
     }
 
     return absl::OkStatus();
   }
 
  public:
-  // Queries the workspace size and constructs a 'RocmFusedConvRunner'.
   static absl::StatusOr<std::unique_ptr<const dnn::FusedConvRunner>> Create(
       StreamExecutor* parent, Stream* stream, MIOpenAccess* miopen,
       const dnn::AlgorithmDesc& algo, dnn::DataType input_type,
-      dnn::DataType bias_type, double conv_scale, double side_input_scale,
-      double leakyrelu_alpha, BatchDescriptor input_nd,
+      dnn::DataType bias_type, double leakyrelu_alpha, BatchDescriptor input_nd,
       BatchDescriptor output_nd, FilterDescriptor filter,
       BatchDescriptor bias_nd, ConvolutionDescriptor conv,
       dnn::ActivationMode activation) {
@@ -4966,78 +4942,28 @@ class RocmFusedConvRunner : public dnn::FusedConvRunner {
             filter_.handle(), conv_.handle(), bias_nd_.handle(),
             activation_desc));
 
-    VLOG(2) << "RocmFusedConvRunner";
-    auto mi = miopen->GetHandle(parent, stream);
+    if (!fusion_plan.CompilationSucceeded()) {
+      return absl::InternalError("No algorithms found");
+    }
 
-    size_t maxSolutionCount = 0;
-    auto status = wrap::miopenConvolutionForwardGetSolutionCount(
-        mi.handle(), filter_.handle(), input_nd_.handle(), conv_.handle(),
-        output_nd_.handle(), &maxSolutionCount);
-
-    size_t solutionCount = 0;
-    std::unique_ptr<miopenConvSolution_t[]> solutions(
-        new miopenConvSolution_t[maxSolutionCount]);
-
-    status = wrap::miopenConvolutionForwardGetSolution(
-        mi.handle(), filter_.handle(), input_nd_.handle(), conv_.handle(),
-        output_nd_.handle(), maxSolutionCount, &solutionCount, solutions.get());
-
-    VLOG(2) << solutionCount << " solutions";
-
-    if (solutionCount == 0) return absl::InternalError("No algorithms found");
-
-    size_t workspace_size_1 = solutions[0].workspace_size;
-    size_t true_workspace_size = 0;
-    status = wrap::miopenConvolutionForwardGetWorkSpaceSize(
-        mi.handle(), filter_.handle(), input_nd_.handle(), conv_.handle(),
-        output_nd_.handle(), &true_workspace_size);
-
-    VLOG(2) << "True workspace size " << workspace_size_1 << " "
-            << true_workspace_size;
-
-    auto obj = new RocmFusedConvRunner(
-        parent, stream, miopen, static_cast<int64_t>(solutions[0].solution_id),
-        true_workspace_size, input_type, bias_type, conv_scale,
-        side_input_scale, leakyrelu_alpha, input_nd, output_nd, filter, bias_nd,
-        conv, activation, input_nd_, output_nd_, filter_, bias_nd_, conv_,
-        activation_desc, fusion_plan);
+    auto obj = new RocmFusedConvRunner(parent, stream, miopen, input_nd_,
+                                       output_nd_, filter_, bias_nd_, conv_,
+                                       activation_desc, fusion_plan);
 
     return std::unique_ptr<const dnn::FusedConvRunner>(obj);
   }
 
  private:
-  // Private to prevent passing in the wrong workspace_size.
-  RocmFusedConvRunner(
-      StreamExecutor* parent, Stream* stream, MIOpenAccess* miopen,
-      int64_t algo_id, size_t workspace_size, dnn::DataType input_type,
-      dnn::DataType bias_type, double conv_scale, double side_input_scale,
-      double leakyrelu_alpha, BatchDescriptor dnn_input_nd,
-      BatchDescriptor dnn_output_nd, FilterDescriptor dnn_filter,
-      BatchDescriptor dnn_bias_nd, ConvolutionDescriptor dnn_conv,
-      dnn::ActivationMode activation, ScopedTensorDescriptor& input_nd,
-      ScopedTensorDescriptor& output_nd, ScopedFilterDescriptor& filter,
-      ScopedTensorDescriptor& bias_nd, ScopedConvolutionDescriptor& conv,
-      ScopedActivationDescriptor& activation_desc,
-      ScopedFusionPlanConvolutionBiasActivation& fusion_plan)
+  RocmFusedConvRunner(StreamExecutor* parent, Stream* stream,
+                      MIOpenAccess* miopen, ScopedTensorDescriptor& input_nd,
+                      ScopedTensorDescriptor& output_nd,
+                      ScopedFilterDescriptor& filter,
+                      ScopedTensorDescriptor& bias_nd,
+                      ScopedConvolutionDescriptor& conv,
+                      ScopedActivationDescriptor& activation_desc,
+                      ScopedFusionPlanConvolutionBiasActivation& fusion_plan)
       : parent_(parent),
         miopen_(miopen),
-        algo_id_(algo_id),
-        workspace_size_(workspace_size),
-        input_type_(input_type),
-        bias_type_(bias_type),
-
-        conv_scale_(conv_scale),
-        side_input_scale_(side_input_scale),
-        leakyrelu_alpha_(leakyrelu_alpha),
-        side_input_scale_f32_(static_cast<float>(side_input_scale)),
-
-        activation_mode_(activation),
-        dnn_input_nd_(dnn_input_nd),
-        dnn_output_nd_(dnn_output_nd),
-        dnn_filter_(dnn_filter),
-        dnn_bias_nd_(dnn_bias_nd),
-        dnn_conv_(dnn_conv),
-
         input_nd_(std::move(input_nd)),
         output_nd_(std::move(output_nd)),
         filter_(std::move(filter)),
@@ -5046,98 +4972,18 @@ class RocmFusedConvRunner : public dnn::FusedConvRunner {
         activation_desc_(std::move(activation_desc)),
         fusion_plan_(std::move(fusion_plan)) {}
 
-  absl::Status execute_unfused(
-      Stream* stream, dnn::ProfileResult* profile_result,
-      DeviceMemoryBase scratch_memory, DeviceMemoryBase input_data,
-      DeviceMemoryBase filter_data, DeviceMemoryBase side_input_data,
-      DeviceMemoryBase bias_data, DeviceMemoryBase output_data) const {
-    auto miopen = miopen_->GetHandle(parent_, stream);
-    auto status = wrap::miopenConvolutionForwardImmediate(
-        miopen.handle(), filter_.handle(), filter_data.opaque(),
-        input_nd_.handle(), input_data.opaque(), conv_.handle(),
-        output_nd_.handle(), output_data.opaque(), scratch_memory.opaque(),
-        scratch_memory.size(), static_cast<uint64_t>(algo_id_));
-    if (status != miopenStatusSuccess) {
-      VLOG(0) << "Failed to enqueue convolution: "
-              << stream_executor::gpu::ToString(status);
-      return absl::InternalError("Failed to enqueue convolution: " +
-                                 stream_executor::gpu::ToString(status));
-    }
-
-    int batch;
-    std::vector<int64_t> dims_output =
-        dnn_output_nd_.full_dims(dnn_output_nd_.layout());
-    int rank = dims_output.size();
-    if (rank != 4 && rank != 5)
-      return absl::InternalError(
-          "RocmFusedConvRunner expects 4d or 5d descriptors");
-    int d1 = 1, d2 = 1;
-    bool bNCHW = (dnn_output_nd_.layout() != dnn::DataLayout::kBatchYXDepth);
-    batch = dims_output[0];
-    if (bNCHW) {
-      d1 = dims_output[1];
-      for (int i = 2; i < rank; i++) d2 *= dims_output[i];
-    } else {
-      d2 = dims_output[rank - 1];
-      for (int i = 1; i < rank - 1; i++) d1 *= dims_output[i];
-    }
-
-    float param = activation_desc_.alpha_;
-
-    auto inplace_call = [&](auto out, auto bias) {
-      return InplaceBiasActivation(stream, out, bias, side_input_data,
-                                   side_input_scale_f32_, activation_mode_,
-                                   batch, d1, d2, d2, param, bNCHW);
-    };
-
-    absl::Status biasActStatus;
-    if (input_type_ == dnn::DataType::kFloat &&
-        bias_type_ == dnn::DataType::kFloat)
-      biasActStatus = inplace_call(DeviceMemory<float>(output_data),
-                                   DeviceMemory<float>(bias_data));
-    else if (input_type_ == dnn::DataType::kHalf &&
-             bias_type_ == dnn::DataType::kFloat)
-      biasActStatus = inplace_call(DeviceMemory<Eigen::half>(output_data),
-                                   DeviceMemory<float>(bias_data));
-    else if (input_type_ == dnn::DataType::kHalf &&
-             bias_type_ == dnn::DataType::kHalf)
-      biasActStatus = inplace_call(DeviceMemory<Eigen::half>(output_data),
-                                   DeviceMemory<Eigen::half>(bias_data));
-    else if (input_type_ == dnn::DataType::kBF16 &&
-             bias_type_ == dnn::DataType::kFloat)
-      biasActStatus = inplace_call(DeviceMemory<Eigen::bfloat16>(output_data),
-                                   DeviceMemory<float>(bias_data));
-    else if (input_type_ == dnn::DataType::kBF16 &&
-             bias_type_ == dnn::DataType::kBF16)
-      biasActStatus = inplace_call(DeviceMemory<Eigen::bfloat16>(output_data),
-                                   DeviceMemory<Eigen::bfloat16>(bias_data));
-    else
-      return absl::InternalError("Unsupported data type");
-
-    return absl::OkStatus();
-  }
-
   // Internal form of ToAlgorithmDesc without the StatusOr.
   dnn::AlgorithmDesc MakeAlgorithmDesc() const {
-    return {algo_id_, /*tensor_ops_enabled_*/ true, workspace_size_};
+    dnn::AlgorithmProto algorithm;
+    algorithm.set_algo_id(0);
+    algorithm.set_math_type(dnn::AlgorithmProto::TENSOR_OP_MATH);
+    algorithm.set_is_cudnn_frontend(true);
+    algorithm.mutable_workspace_size()->set_value(0);
+    return dnn::AlgorithmDesc{algorithm};
   }
-
-  std::string desc_;
 
   StreamExecutor* parent_;
   MIOpenAccess* miopen_;
-  int64_t algo_id_;
-  size_t workspace_size_;
-  dnn::DataType input_type_, bias_type_;
-  double conv_scale_, side_input_scale_, leakyrelu_alpha_;
-  float side_input_scale_f32_;
-  dnn::ActivationMode activation_mode_;
-
-  BatchDescriptor dnn_input_nd_;
-  BatchDescriptor dnn_output_nd_;
-  FilterDescriptor dnn_filter_;
-  BatchDescriptor dnn_bias_nd_;
-  ConvolutionDescriptor dnn_conv_;
 
   ScopedTensorDescriptor input_nd_;
   ScopedTensorDescriptor output_nd_;
@@ -5165,14 +5011,15 @@ MIOpenSupport::FusedConvolveRunnerFromDesc(
           << convolution_descriptor.ToString() << getTypeName(input_type) << " "
           << getTypeName(bias_type) << " " << getTypeName(output_type);
 
-  // note: these checks need to be duplicated in XLA logic, because XLA calls
-  // this function directly and it terminates the process on error
+  if (conv_scale != 1.0 || side_input_scale != 0.0) {
+    return absl::InvalidArgumentError(
+        "MIOpen fusions don't support conv_scale or side_input_scale");
+  }
 
   return RocmFusedConvRunner::Create(
       parent_, stream, miopen_.get(), algorithm_desc, input_type, bias_type,
-      conv_scale, side_input_scale, leakyrelu_alpha, input_descriptor,
-      output_descriptor, filter_descriptor, bias_descriptor,
-      convolution_descriptor, activation_mode);
+      leakyrelu_alpha, input_descriptor, output_descriptor, filter_descriptor,
+      bias_descriptor, convolution_descriptor, activation_mode);
 }
 
 absl::Status MIOpenSupport::GetFusedConvolveRunners(
@@ -5187,24 +5034,13 @@ absl::Status MIOpenSupport::GetFusedConvolveRunners(
     dnn::ActivationMode activation_mode, const NumericOptions& numeric_options,
     std::vector<std::unique_ptr<const dnn::FusedConvRunner>>* out_exec_plans) {
   VLOG(2) << "MIOpenSupport::GetFusedConvolveRunners";
-  VLOG(2) << "filter_descriptor " << filter_descriptor.ndims();
 
-  std::vector<dnn::AlgorithmDesc> algorithms{
-      // clang-format off
-      dnn::AlgorithmDesc(miopenConvolutionFwdAlgoGEMM, false, 0),
-      dnn::AlgorithmDesc(miopenConvolutionFwdAlgoDirect, false, 0),
-      dnn::AlgorithmDesc(miopenConvolutionFwdAlgoFFT, false, 0),
-      dnn::AlgorithmDesc(miopenConvolutionFwdAlgoWinograd, false, 0),
-      // clang-format on
-  };
-
-  for (const auto& algo : algorithms) {
-    auto runner_or = FusedConvolveRunnerFromDesc(
-        stream, algo, kind, input_type, bias_type, output_type, conv_scale,
-        side_input_scale, leakyrelu_alpha, input_descriptor, filter_descriptor,
-        bias_descriptor, output_descriptor, convolution_descriptor,
-        activation_mode);
-    if (!runner_or.ok()) continue;
+  auto runner_or = FusedConvolveRunnerFromDesc(
+      stream, {}, kind, input_type, bias_type, output_type, conv_scale,
+      side_input_scale, leakyrelu_alpha, input_descriptor, filter_descriptor,
+      bias_descriptor, output_descriptor, convolution_descriptor,
+      activation_mode);
+  if (runner_or.ok()) {
     out_exec_plans->push_back(std::move(runner_or).value());
   }
 


### PR DESCRIPTION
* [ROCm] Allways run GpuConvAlgorithmPicker

* [ROCm] Restore CudnnFusedConvRewriter

Introduce CudnnFusedConvDecomposer to revert back fused convs if no fused algorithm could be found with ConvAlgorithmPicker. Remove unfused fallback paths from RocmFusedConvRunner.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
