### PR TITLE
Add flag to control swish activation fusion.

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -376,6 +376,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_nccl_collective_max_nchannels(0);
   opts.set_xla_gpu_nccl_p2p_max_nchannels(0);
   opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
+  opts.set_xla_gpu_experimental_enable_cublaslt_swish_fusion(false);
 
   opts.set_xla_gpu_experimental_stream_annotation(true);
   // Minimum combined size of matrices in matrix multiplication to
@@ -2184,6 +2185,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "(minimum combined number of elements of both matrices "
       "in non-batch dimensions to be considered for a rewrite)."));
   flag_list->push_back(tsl::Flag(
+      "xla_gpu_experimental_enable_cublaslt_swish_fusion",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_experimental_enable_cublaslt_swish_fusion),
+      debug_options->xla_gpu_experimental_enable_cublaslt_swish_fusion(),
+      "Enable fusion of the swish activiation with cublaslt gemm."));
+  flag_list->push_back(tsl::Flag(
       "xla_gpu_use_embeded_device_lib",
       bool_setter_for(&DebugOptions::set_xla_gpu_use_embeded_device_lib),
       debug_options->xla_gpu_use_embeded_device_lib(),
@@ -2697,8 +2704,7 @@ FlagStatus GetFlagStatus(absl::string_view flag_name) {
           "xla_gpu_all_reduce_combine_threshold_bytes",
           "xla_gpu_autotune_level",
           "xla_gpu_collective_permute_decomposer_threshold",
-          "xla_gpu_cublas_fallback",
-          "xla_gpu_dot_merger_threshold_mb",
+          "xla_gpu_cublas_fallback", "xla_gpu_dot_merger_threshold_mb",
           "xla_gpu_enable_dynamic_slice_fusion",
           "xla_gpu_enable_latency_hiding_scheduler",
           "xla_gpu_enable_pipelined_all_gather",

--- a/xla/service/gpu/transforms/gemm_rewriter.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter.cc
@@ -808,7 +808,12 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
 
     const auto is_rocm =
         std::holds_alternative<se::RocmComputeCapability>(gpu_version_);
-    if (is_rocm &&
+    const bool swishFusionEnabled =
+        instr->GetModule()
+            ->config()
+            .debug_options()
+            .xla_gpu_experimental_enable_cublaslt_swish_fusion();
+    if (swishFusionEnabled && is_rocm &&
         toolkit_version_ >= stream_executor::SemanticVersion{7, 0, 0}) {
       // Attempt to match approximate Swish activation
       // (https://flax.readthedocs.io/en/v0.5.3/_autosummary/flax.linen.swish.html),

--- a/xla/service/gpu/transforms/gemm_rewriter_test.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter_test.cc
@@ -1587,6 +1587,123 @@ TEST_F(SmallDotGemmRewriteTest, RewriteForALG_BF16_BF16_F32) {
 )");
 }
 
+TEST_F(GemmRewriteTest, SwishActivationFusion) {
+  if (SkipGpuBlasLtTest()) {
+    GTEST_SKIP() << "BlasLt is not supported on this GPU architecture";
+  }
+
+  // Swish fusion is only supported on ROCm with toolkit version >= 7.0.0
+  if (!IsRocm()) {
+    GTEST_SKIP() << "Swish fusion is only supported on ROCm";
+  }
+
+  const char* hlo_text = R"(
+    HloModule swish_fusion
+
+    ENTRY main {
+      x = f32[128,256] parameter(0)
+      y = f32[256,512] parameter(1)
+      dot = f32[128,512] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+      
+      // Swish activation: x * sigmoid(x)
+      // where: sigmoid(x) = 1/(1 + exp(-x))
+      one = f32[] constant(1)
+      one_bcast = f32[128,512] broadcast(one), dimensions={}
+      neg_dot = f32[128,512] negate(dot)
+      exp_neg_dot = f32[128,512] exponential(neg_dot)
+      denom = f32[128,512] add(one_bcast, exp_neg_dot)
+      sigmoid = f32[128,512] divide(one_bcast, denom)
+      ROOT swish = f32[128,512] multiply(dot, sigmoid)
+    }
+    )";
+
+  DebugOptions debug_options = GetDebugOptionsForTest();
+  debug_options.set_xla_gpu_enable_cublaslt(true);
+  debug_options.set_xla_gpu_experimental_enable_cublaslt_swish_fusion(true);
+
+  HloModuleConfig config;
+  config.set_debug_options(debug_options);
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_text, config));
+
+  EXPECT_TRUE(RunAndCompare(std::move(module), ErrorSpec{1e-3, 1e-3}));
+
+  // Check that the swish activation is fused into the cuBLASLt call
+  TF_ASSERT_OK_AND_ASSIGN(module,
+                          ParseAndReturnVerifiedModule(hlo_text, config));
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> optimized_module,
+                          GetOptimizedModule(std::move(module)));
+
+  absl::StatusOr<bool> filecheck_result =
+      RunFileCheck(optimized_module->ToString(),
+                   R"(
+      ; CHECK: custom_call_target="__cublas$lt$matmul"
+      ; CHECK-SAME: "epilogue":"SILU"
+      )");
+  TF_ASSERT_OK(filecheck_result.status());
+  EXPECT_TRUE(filecheck_result.value());
+}
+
+TEST_F(GemmRewriteTest, SwishActivationFusionDisabled) {
+  if (SkipGpuBlasLtTest()) {
+    GTEST_SKIP() << "BlasLt is not supported on this GPU architecture";
+  }
+
+  // Swish fusion is only supported on ROCm with toolkit version >= 7.0.0
+  if (!IsRocm()) {
+    GTEST_SKIP() << "Swish fusion is only supported on ROCm";
+  }
+
+  const char* hlo_text = R"(
+    HloModule swish_fusion
+
+    ENTRY main {
+      x = f32[128,256] parameter(0)
+      y = f32[256,512] parameter(1)
+      dot = f32[128,512] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+      
+      // Swish activation: x * sigmoid(x)
+      // where: sigmoid(x) = 1/(1 + exp(-x))
+      one = f32[] constant(1)
+      one_bcast = f32[128,512] broadcast(one), dimensions={}
+      neg_dot = f32[128,512] negate(dot)
+      exp_neg_dot = f32[128,512] exponential(neg_dot)
+      denom = f32[128,512] add(one_bcast, exp_neg_dot)
+      sigmoid = f32[128,512] divide(one_bcast, denom)
+      ROOT swish = f32[128,512] multiply(dot, sigmoid)
+    }
+    )";
+
+  DebugOptions debug_options = GetDebugOptionsForTest();
+  debug_options.set_xla_gpu_enable_cublaslt(true);
+  debug_options.set_xla_gpu_experimental_enable_cublaslt_swish_fusion(false);
+
+  HloModuleConfig config;
+  config.set_debug_options(debug_options);
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_text, config));
+
+  EXPECT_TRUE(RunAndCompare(std::move(module), ErrorSpec{1e-3, 1e-3}));
+
+  // Check that the swish activation is fused into the cuBLASLt call
+  TF_ASSERT_OK_AND_ASSIGN(module,
+                          ParseAndReturnVerifiedModule(hlo_text, config));
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> optimized_module,
+                          GetOptimizedModule(std::move(module)));
+
+  absl::StatusOr<bool> filecheck_result =
+      RunFileCheck(optimized_module->ToString(),
+                   R"(
+      ; CHECK: custom_call_target="__cublas$lt$matmul"
+      ; CHECK-SAME: "epilogue":"DEFAULT"
+      ; CHECK-NOT: "epilogue":"SILU"
+      )");
+  TF_ASSERT_OK(filecheck_result.status());
+  EXPECT_TRUE(filecheck_result.value());
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -727,6 +727,8 @@ message DebugOptions {
   // rewrite).
   optional int64 xla_gpu_gemm_rewrite_size_threshold = 283;
 
+  optional bool xla_gpu_experimental_enable_cublaslt_swish_fusion = 502;
+
   // If true, we generate debug info when compiling PTX. This is useful for
   // profiling and debugging.
   optional bool xla_gpu_generate_debug_info = 348;


### PR DESCRIPTION
Performance of several LLM models (include MaxText) appears to drop due to the swish activation fusion.
This PR adds a flag to allow user to disable this fusion if they wish. 

## Test Plan

2 tests have been added to test the flag behavior.

## Test Result

Tests pass.
