### PR TITLE
Add rocm version check in the fusion swish activation test.

### DIFF
--- a/xla/service/gpu/transforms/gemm_rewriter_test.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter_test.cc
@@ -1597,6 +1597,12 @@ TEST_F(GemmRewriteTest, SwishActivationFusion) {
     GTEST_SKIP() << "Swish fusion is only supported on ROCm";
   }
 
+  // Check ROCm version - SILU epilogue requires ROCm 7.0+
+  if (GetToolkitVersion() < stream_executor::SemanticVersion{7, 0, 0}) {
+    GTEST_SKIP() << "Swish fusion requires ROCm 7.0 or later, current version: "
+                 << GetToolkitVersion().ToString();
+  }
+
   const char* hlo_text = R"(
     HloModule swish_fusion
 


### PR DESCRIPTION
Add rocm version check in the fusion swish activation test to ensure the test does not fail with older versions.