### PR TITLE
Skip swish fusion if pre-activation output used

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -379,7 +379,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_nccl_collective_max_nchannels(0);
   opts.set_xla_gpu_nccl_p2p_max_nchannels(0);
   opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
-  opts.set_xla_gpu_experimental_enable_cublaslt_swish_fusion(false);
+  opts.set_xla_gpu_experimental_enable_cublaslt_swish_fusion(true);
 
   opts.set_xla_gpu_experimental_stream_annotation(true);
   // Minimum combined size of matrices in matrix multiplication to

--- a/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
+++ b/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
@@ -2213,6 +2213,62 @@ ENTRY test {
       )");
 }
 
+// Test Swish/SILU activation with bitcast - expects no-fusion when there are
+// additional users beyond the Swish pattern
+TEST_F(CublasLtGemmRewriteTest, SwishActivationWithBitcastAndAuxiliaryOutput) {
+  auto runtime_version = GetRuntimeVersion();
+  bool rocm_swish_available =
+      IsRocm() &&
+      (runtime_version >= stream_executor::SemanticVersion(7, 0, 0));
+  if (!rocm_swish_available) {
+    GTEST_SKIP() << "Swish/SILU activation fusion only available on ROCm 7.0+";
+  }
+
+  const char* hlo_text = R"(
+HloModule test
+
+ENTRY test (x: bf16[49152,11008], y: bf16[11008,11008]) -> (bf16[12,4096,11008], bf16[49152,11008]) {
+  x = bf16[49152,11008]{1,0} parameter(0)
+  y = bf16[11008,11008]{1,0} parameter(1)
+  dot = bf16[49152,11008]{1,0} dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  bitcast = bf16[12,4096,11008]{2,1,0} bitcast(dot)
+  
+  one = bf16[] constant(1)
+  one_bcast = bf16[12,4096,11008]{2,1,0} broadcast(one), dimensions={}
+  neg = bf16[12,4096,11008]{2,1,0} negate(bitcast)
+  exp = bf16[12,4096,11008]{2,1,0} exponential(neg)
+  add = bf16[12,4096,11008]{2,1,0} add(exp, one_bcast)
+  sigmoid = bf16[12,4096,11008]{2,1,0} divide(one_bcast, add)
+  swish = bf16[12,4096,11008]{2,1,0} multiply(bitcast, sigmoid)
+  
+  extra_user = bf16[49152,11008]{1,0} negate(dot)
+  
+  ROOT out = (bf16[12,4096,11008]{2,1,0}, bf16[49152,11008]{1,0}) tuple(swish, extra_user)
+}
+)";
+
+  HloModuleConfig config;
+  DebugOptions debug_options = GetDebugOptionsForTest();
+  config.set_debug_options(debug_options);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_text, config));
+
+  GemmRewriterOptions options;
+  options.enable_cublaslt = true;
+  GemmRewriter pass(Capability(), GetToolkitVersion(), options);
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunHloPass(&pass, module.get()));
+  EXPECT_TRUE(changed);
+
+  TF_ASSERT_OK_AND_ASSIGN(bool filecheck_result,
+                          RunFileCheck(module->ToString(), R"(
+; CHECK:           [[GEMM_TUPLE:%[^ ]+]] = {{.*}} custom-call
+; CHECK:           custom_call_target="__cublas$lt$matmul",
+; CHECK-DAG:         "epilogue":"DEFAULT"
+      )"));
+  EXPECT_TRUE(filecheck_result);
+}
+
 TEST_F(CublasLtGemmRewriteTest, SwishActivationFusionDisabled) {
   if (SkipGpuBlasLtTest()) {
     GTEST_SKIP() << "BlasLt is not supported on this GPU architecture";

--- a/xla/service/gpu/transforms/gemm_rewriter.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter.cc
@@ -542,6 +542,24 @@ auto OptionalBitcast(HloInstruction** optional_bitcast, Pattern pattern) {
                                   std::move(pattern));
 }
 
+// Counts the number of final users of an instruction, recursively traversing
+// through slice and bitcast operations. If a user is a slice or bitcast, we
+// recursively count its users. Otherwise, we count it as a final user.
+static inline uint32_t CountFinalUsers(const HloInstruction* instr) {
+  uint32_t final_user_count = 0;
+  for (const HloInstruction* user : instr->users()) {
+    if (user->opcode() == HloOpcode::kSlice ||
+        user->opcode() == HloOpcode::kBitcast) {
+      // Recursively count users of slice/bitcast operations
+      final_user_count += CountFinalUsers(user);
+    } else {
+      // This is a final user (not a slice or bitcast)
+      final_user_count += 1;
+    }
+  }
+  return final_user_count;
+}
+
 // The rewriting proceeds in a bottom-up way:
 //
 // (kDot A B) is rewritten into a (kCustomCall:gemm A B)
@@ -2004,8 +2022,13 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       return absl::OkStatus();
     }
 
-    // There are four users of the gemm output within the GELU calculation.
-    bool has_aux = gemm->user_count() > 4;
+    // There are 2 final users of the gemm output within the Swish calculation.
+    bool has_aux = CountFinalUsers(gemm) > 2;
+    if (has_aux) {
+      // SILU_AUX epilogue is not supported yet.
+      // https://rocm.docs.amd.com/projects/hipBLASLt/en/latest/reference/datatypes.html
+      return absl::OkStatus();
+    }
 
     TF_ASSIGN_OR_RETURN(auto gpu_config,
                         gemm->backend_config<GpuBackendConfig>());
@@ -2019,9 +2042,8 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       return absl::OkStatus();
     }
 
-    std::unique_ptr<HloInstruction> output = gemm->CloneWithNewShape(
-        has_aux ? ShapeUtil::MakeTupleShape({gemm->shape(), gemm->shape()})
-                : gemm->shape());
+    std::unique_ptr<HloInstruction> output =
+        gemm->CloneWithNewShape(gemm->shape());
     TF_RETURN_IF_ERROR(output->set_backend_config(gpu_config));
     TF_RETURN_IF_ERROR(SetName(multiply->GetModule(), output.get()));
 
@@ -2029,14 +2051,6 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       output = slice_or_bitcast->CloneWithNewOperands(
           slice_or_bitcast->shape(),
           {gemm->parent()->AddInstruction(std::move(output))});
-    }
-
-    if (has_aux) {
-      HloInstruction* tuple_output =
-          gemm->parent()->AddInstruction(std::move(output));
-      TF_RETURN_IF_ERROR(ReplaceWithNewInstruction(
-          gemm, HloInstruction::CreateGetTupleElement(tuple_output, 1)));
-      output = HloInstruction::CreateGetTupleElement(tuple_output, 0);
     }
 
     return ReplaceWithNewInstruction(multiply, std::move(output));


### PR DESCRIPTION
Hipblaslt does not support SILU_AUX yet. So, we do not fuse the activation if the pre-activation output is used.
This avoid duplicating the gemm operation (1 with activation + 1 without activation).

### Motivation

The swish activation makes "only" 2 references to the gemm ouput (Swish(x)=x∗sigmoid(βx)).
Consequently, the `aux` condition should be:
```
bool has_aux = gemm->user_count() > 2;
```
But that is not sufficient. Because in the Llama training workload for example, the gemm output does not have more that 2 references, because the output is first "bitcasted" before being used to calculate the swish function.
So, without gradient, we have something like:
```
dot.67 (gemm output)
  ↓
bitcast.85 (reshape to higher rank)
  ↓ (used in 2 places)
  ├─ neg.16 → exp.10 → add.326 → div.147 (sigmoid computation)
  └─ mul.617 (multiply with sigmoid result)
dot.67.user_count() = 1  (only bitcast.85)
bitcast.85.user_count() = 2  (neg.16 and mul.617)
```
Consequently, we must search for final users and not direct users. That is why the `CountFinalUsers` function has been introduced.

## Test Plan

UT added in this PR

## Test Result

Test pass.


Same as https://github.com/ROCm/xla/pull/605