### PR TITLE
Fix issue with missing upcast/downcast for bf16 libdevice calls.

### DIFF
--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_math_to_libdevice.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_math_to_libdevice.cc
@@ -194,8 +194,9 @@ class ConvertToLibdevice : public mlir::OpRewritePattern<OpTy> {
 
     llvm::SmallVector<Value, 2> casted_inputs;
     if (output_type_is_16bit_float &&
-        (output_type.isF16() &&
-         !HasF16Implementation(OpInfo<OpTy>::kFunctionID, triple_))) {
+        (output_type.isBF16() ||
+         (output_type.isF16() &&
+         !HasF16Implementation(OpInfo<OpTy>::kFunctionID, triple_)))) {
       // Upcast the inputs to F32.
       for (auto operand : op->getOperands()) {
         casted_inputs.push_back(
@@ -213,8 +214,9 @@ class ConvertToLibdevice : public mlir::OpRewritePattern<OpTy> {
         /*pure=*/true);
 
     if (res.getType() != output_type ||
-        (output_type.isF16() &&
-         !HasF16Implementation(OpInfo<OpTy>::kFunctionID, triple_))) {
+        (output_type.isBF16() ||
+         (output_type.isF16() &&
+         !HasF16Implementation(OpInfo<OpTy>::kFunctionID, triple_)))) {
       // Downcast back to the original output type.
       res = ::xla::xtile::Cast(builder, res, output_type);
     }


### PR DESCRIPTION
📝 Summary of Changes
Introduced missing upcast/downcast for bf16 type

🎯 Justification
upcast/downcast are necessary because there is no native bf16 implementation in libdevice 

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
triton_xla_math_to_libdevice.mlir

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
