### PR TITLE
Compute theoretical occupancy for ROCm profiler kernels

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -554,8 +554,8 @@ xla_cc_test(
         "manual",
     ]),
     deps = [
-        # ":rocm_tracer",
         ":rocm_collector",
+        ":rocm_tracer",
         ":rocm_tracer_utils",
         "@com_google_googletest//:gtest_main",
         "//xla/tsl/profiler/utils:xplane_utils",

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -96,6 +96,17 @@ RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
   options.max_callback_api_events = max_events;
   options.max_activity_api_events = max_events;
   options.max_annotation_strings = max_events;
+
+  // Get SIMD properties for theoretical occupancy calculation.
+  uint32_t simd_per_cu = 0, max_waves = 0, gfx_ver = 0;
+  if (rocm_tracer_->GetGpuSimdInfo(0, &simd_per_cu, &max_waves, &gfx_ver)) {
+    options.simd_per_cu = simd_per_cu;
+    options.max_waves_per_simd = max_waves;
+    options.gfx_target_version = gfx_ver;
+  } else {
+    LOG(WARNING) << "Failed to query GPU SIMD properties; "
+                    "theoretical occupancy will not be reported.";
+  }
   return options;
 }
 

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -148,32 +149,109 @@ uint64_t get_timestamp() {
 }
 }  // namespace
 
-OccupancyStats PerDeviceCollector::GetOccupancy(
-    const RocmDeviceOccupancyParams& params) const {
-  // TODO(rocm-profiler): hipOccupancyMaxActiveBlocksPerMultiprocessor only
-  // return hipSuccess for HIP_API_ID_hipLaunchKernel
-  OccupancyStats stats;
-  int number_of_active_blocks;
-  hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
-      &number_of_active_blocks, params.func_ptr, params.block_size,
-      params.dynamic_smem_size);
+// SGPR allocation granularity is 16 across all architectures.
+// (see HIP CLR: hipamd/src/hip_platform.cpp)
+constexpr uint32_t kSgprAllocGranularity = 16;
 
-  if (err != hipError_t::hipSuccess) {
-    return {};
+double PerDeviceCollector::ComputeTheoreticalOccupancy(
+    const KernelDetails& ki) {
+  int block_size = ki.workgroup_x * ki.workgroup_y * ki.workgroup_z;
+  OccupancyKey key{ki.arch_vgpr_count, ki.sgpr_count, ki.group_segment_size,
+                   static_cast<uint32_t>(block_size)};
+  auto it = theoretical_occupancy_cache_.find(key);
+  if (it != theoretical_occupancy_cache_.end()) {
+    return it->second;
+  }
+  if (block_size <= 0 || device_properties_.warpSize <= 0 ||
+      simd_per_cu_ == 0 || max_waves_per_simd_ == 0) {
+    return 0.0;
   }
 
-  stats.occupancy_pct = number_of_active_blocks * params.block_size * 100;
-  stats.occupancy_pct /= device_properties_.maxThreadsPerMultiProcessor;
+  int wave_size = device_properties_.warpSize;
+  uint32_t gfx_major = gfx_target_version_ / 10000;
 
-  err = hipOccupancyMaxPotentialBlockSize(
-      &stats.min_grid_size, &stats.suggested_block_size,
-      static_cast<const void*>(params.func_ptr), params.dynamic_smem_size, 0);
+  // Derive VGPRs per SIMD from device properties.
+  // (see HIP CLR: rocclr/device/rocm/rocdevice.cpp)
+  uint32_t vgprs_per_simd =
+      device_properties_.regsPerMultiprocessor / wave_size / simd_per_cu_;
 
-  if (err != hipError_t::hipSuccess) {
-    return {};
+  // VGPR allocation granularity per thread.
+  // gfx10+ adjusts for wave64 mode by halving the granularity.
+  // (see HIP CLR: hipamd/src/hip_platform.cpp)
+  uint32_t vgpr_alloc_granularity;
+  if (gfx_major <= 9) {
+    vgpr_alloc_granularity = 8;
+  } else if (gfx_major <= 10) {
+    vgpr_alloc_granularity = wave_size == 64 ? 4 : 8;
+  } else {
+    vgpr_alloc_granularity = wave_size == 64 ? 6 : 12;
   }
 
-  return stats;
+  // VGPR limit: how many waves fit per SIMD given VGPR usage.
+  uint32_t used_vgprs = ki.arch_vgpr_count;
+  uint32_t vgpr_waves = max_waves_per_simd_;
+  if (used_vgprs > 0) {
+    uint32_t alloc_vgprs =
+        ((used_vgprs + vgpr_alloc_granularity - 1) / vgpr_alloc_granularity) *
+        vgpr_alloc_granularity;
+    vgpr_waves = vgprs_per_simd / alloc_vgprs;
+  }
+  if (vgpr_waves == 0) {
+    return 0.0;
+  }
+
+  // SGPRs per SIMD: shared between waves on gfx8/gfx9, unlimited on gfx10+.
+  // (see HIP CLR: rocclr/device/rocm/rocdevice.cpp)
+  uint32_t sgprs_per_simd;
+  if (gfx_major < 8) {
+    sgprs_per_simd = 512;
+  } else if (gfx_major < 10) {
+    sgprs_per_simd = 800;
+  } else {
+    sgprs_per_simd = std::numeric_limits<uint32_t>::max();
+  }
+
+  // SGPR limit
+  uint32_t gpr_waves = vgpr_waves;
+  if (ki.sgpr_count > 0 &&
+      sgprs_per_simd != std::numeric_limits<uint32_t>::max()) {
+    uint32_t alloc_sgprs =
+        ((ki.sgpr_count + kSgprAllocGranularity - 1) / kSgprAllocGranularity) *
+        kSgprAllocGranularity;
+    uint32_t sgpr_waves = sgprs_per_simd / alloc_sgprs;
+    gpr_waves = std::min(gpr_waves, sgpr_waves);
+  }
+
+  // ALU occupancy: total threads per CU limited by registers
+  int alu_waves = simd_per_cu_ * std::min(max_waves_per_simd_, gpr_waves);
+  int alu_limited_threads = alu_waves * wave_size;
+
+  // LDS limit: how many workgroups fit given LDS usage
+  int lds_limited_wgs = std::numeric_limits<int>::max();
+  if (ki.group_segment_size > 0 &&
+      device_properties_.maxSharedMemoryPerMultiProcessor > 0) {
+    lds_limited_wgs =
+        static_cast<int>(device_properties_.maxSharedMemoryPerMultiProcessor /
+                         ki.group_segment_size);
+  }
+
+  // Block size aligned to wavefront
+  int aligned_block = ((block_size + wave_size - 1) / wave_size) * wave_size;
+  int max_blocks = alu_limited_threads / aligned_block;
+  max_blocks = std::min(max_blocks, lds_limited_wgs);
+  max_blocks =
+      std::min(max_blocks, device_properties_.maxBlocksPerMultiProcessor);
+  max_blocks = std::max(max_blocks, 0);
+
+  int max_threads = device_properties_.maxThreadsPerMultiProcessor;
+  if (max_threads <= 0) {
+    return 0.0;
+  }
+
+  double result =
+      std::min(100.0, 100.0 * max_blocks * block_size / max_threads);
+  theoretical_occupancy_cache_[key] = result;
+  return result;
 }
 
 void PerDeviceCollector::CreateXEvent(const RocmTracerEvent& event,
@@ -218,11 +296,15 @@ void PerDeviceCollector::CreateXEvent(const RocmTracerEvent& event,
 
   if (event.type == RocmTracerEventType::Kernel &&
       event.source == RocmTracerEventSource::Activity) {
-    xevent.AddStatValue(
-        *plane->GetOrCreateStatMetadata(
-            GetStatTypeStr(StatType::kKernelDetails)),
-        *plane->GetOrCreateStatMetadata(ToXStat(event.kernel_info,
-                                                /*occupancy_pct*/ 0)));
+    double theoretical_occupancy_pct =
+        ComputeTheoreticalOccupancy(event.kernel_info);
+    xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
+                            GetStatTypeStr(StatType::kTheoreticalOccupancyPct)),
+                        theoretical_occupancy_pct);
+    xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
+                            GetStatTypeStr(StatType::kKernelDetails)),
+                        *plane->GetOrCreateStatMetadata(ToXStat(
+                            event.kernel_info, theoretical_occupancy_pct)));
   } else if (event.type == RocmTracerEventType::MemcpyH2D ||
              event.type == RocmTracerEventType::MemcpyD2H ||
              event.type == RocmTracerEventType::MemcpyD2D ||
@@ -400,7 +482,13 @@ void PerDeviceCollector::AddEvent(RocmTracerEvent&& event) {
 }
 
 void PerDeviceCollector::GetDeviceCapabilities(int32_t device_ordinal,
-                                               XPlaneBuilder* device_plane) {
+                                               XPlaneBuilder* device_plane,
+                                               uint32_t simd_per_cu,
+                                               uint32_t max_waves_per_simd,
+                                               uint32_t gfx_target_version) {
+  simd_per_cu_ = simd_per_cu;
+  max_waves_per_simd_ = max_waves_per_simd;
+  gfx_target_version_ = gfx_target_version;
   device_plane->AddStatValue(*device_plane->GetOrCreateStatMetadata(
                                  GetStatTypeStr(StatType::kDevVendor)),
                              kDeviceVendorAMD);
@@ -559,7 +647,9 @@ void RocmTraceCollectorImpl::Export(XSpace* space) {
     device_plane.SetId(id);
     // Calculate device capabilities before flushing, so that device
     // properties are available to the occupancy calculator in export().
-    per_device_collector_[id].GetDeviceCapabilities(id, &device_plane);
+    per_device_collector_[id].GetDeviceCapabilities(
+        id, &device_plane, options_.simd_per_cu, options_.max_waves_per_simd,
+        options_.gfx_target_version);
     per_device_collector_[id].Export(start_walltime_ns_, start_gputime_ns_,
                                      end_gputime_ns, &device_plane,
                                      &host_plane);

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -58,64 +58,6 @@ inline std::string ToXStat(const KernelDetails& kernel_info,
                       " occ_pct:", occupancy_pct);
 }
 
-struct RocmDeviceOccupancyParams {
-  hipFuncAttributes attributes = {};
-  int block_size = 0;
-  size_t dynamic_smem_size = 0;
-  void* func_ptr;
-
-  friend bool operator==(const RocmDeviceOccupancyParams& a,
-                         const RocmDeviceOccupancyParams& b) noexcept {
-    // Compare only the fields that affect occupancy decisions.
-    return std::tuple{a.attributes.binaryVersion,
-                      a.attributes.cacheModeCA,
-                      a.attributes.constSizeBytes,
-                      a.attributes.localSizeBytes,
-                      a.attributes.maxDynamicSharedSizeBytes,
-                      a.attributes.maxThreadsPerBlock,
-                      a.attributes.numRegs,
-                      a.attributes.preferredShmemCarveout,
-                      a.attributes.ptxVersion,
-                      a.block_size,
-                      a.dynamic_smem_size,
-                      a.func_ptr} ==
-           std::tuple{b.attributes.binaryVersion,
-                      b.attributes.cacheModeCA,
-                      b.attributes.constSizeBytes,
-                      b.attributes.localSizeBytes,
-                      b.attributes.maxDynamicSharedSizeBytes,
-                      b.attributes.maxThreadsPerBlock,
-                      b.attributes.numRegs,
-                      b.attributes.preferredShmemCarveout,
-                      b.attributes.ptxVersion,
-                      b.block_size,
-                      b.dynamic_smem_size,
-                      b.func_ptr};
-  }
-
-  friend bool operator!=(const RocmDeviceOccupancyParams& a,
-                         const RocmDeviceOccupancyParams& b) noexcept {
-    return !(a == b);
-  }
-
-  template <typename H>
-  friend H AbslHashValue(H hash_state,
-                         const RocmDeviceOccupancyParams& params) {
-    return H::combine(
-        std::move(hash_state), params.attributes.maxThreadsPerBlock,
-        params.attributes.numRegs, params.attributes.sharedSizeBytes,
-        params.attributes.maxDynamicSharedSizeBytes, params.block_size,
-        params.dynamic_smem_size, params.func_ptr);
-  }
-};
-
-// FIXME: rocprofiler-sdk does not have this one yet
-struct OccupancyStats {
-  double occupancy_pct = 0.0;
-  int min_grid_size = 0;
-  int suggested_block_size = 0;
-};
-
 class RocmTraceCollector {
  public:
   explicit RocmTraceCollector(const RocmTraceCollectorOptions& options)
@@ -148,10 +90,12 @@ class PerDeviceCollector {
 
   void AddEvent(RocmTracerEvent&& event);
   void GetDeviceCapabilities(int32_t device_ordinal,
-                             tsl::profiler::XPlaneBuilder* device_plane);
+                             tsl::profiler::XPlaneBuilder* device_plane,
+                             uint32_t simd_per_cu, uint32_t max_waves_per_simd,
+                             uint32_t gfx_target_version);
 
  private:
-  OccupancyStats GetOccupancy(const RocmDeviceOccupancyParams& params) const;
+  double ComputeTheoreticalOccupancy(const KernelDetails& ki);
   void CreateXEvent(const RocmTracerEvent& event,
                     tsl::profiler::XPlaneBuilder* plane, uint64_t start_gpu_ns,
                     uint64_t end_gpu_ns, tsl::profiler::XLineBuilder* line);
@@ -161,9 +105,30 @@ class PerDeviceCollector {
  private:
   absl::Mutex events_mutex_;
   std::vector<RocmTracerEvent> events_ ABSL_GUARDED_BY(events_mutex_);
-  absl::flat_hash_map<RocmDeviceOccupancyParams, OccupancyStats>
-      occupancy_cache_;
   hipDeviceProp_t device_properties_;
+  struct OccupancyKey {
+    uint32_t arch_vgpr_count;
+    uint32_t sgpr_count;
+    uint32_t group_segment_size;
+    uint32_t block_size;
+
+    template <typename H>
+    friend H AbslHashValue(H h, const OccupancyKey& k) {
+      return H::combine(std::move(h), k.arch_vgpr_count, k.sgpr_count,
+                        k.group_segment_size, k.block_size);
+    }
+    friend bool operator==(const OccupancyKey& a, const OccupancyKey& b) {
+      return a.arch_vgpr_count == b.arch_vgpr_count &&
+             a.sgpr_count == b.sgpr_count &&
+             a.group_segment_size == b.group_segment_size &&
+             a.block_size == b.block_size;
+    }
+  };
+
+  absl::flat_hash_map<OccupancyKey, double> theoretical_occupancy_cache_;
+  uint32_t simd_per_cu_ = 0;
+  uint32_t max_waves_per_simd_ = 0;
+  uint32_t gfx_target_version_ = 0;
 };  // PerDeviceCollector
 
 class RocmTraceCollectorImpl : public RocmTraceCollector {

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -19,8 +19,6 @@ limitations under the License.
 
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 
-#include <unistd.h>
-
 #include <atomic>
 #include <cassert>
 #include <cstdint>
@@ -43,6 +41,7 @@ limitations under the License.
 #include "rocm/include/rocprofiler-sdk/internal_threading.h"
 #include "rocm/include/rocprofiler-sdk/registration.h"
 #include "rocm/include/rocprofiler-sdk/rocprofiler.h"
+#include <unistd.h>
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/backends/cpu/annotation_stack.h"
@@ -139,6 +138,24 @@ void RocmTracer::Enable(const RocmTracerOptions& options,
   activity_tracing_enabled_ = true;
   rocprofiler_start_context(context_);
   VLOG(1) << "GpuTracer started with number of GPUs = " << NumGpus();
+}
+
+bool RocmTracer::GetGpuSimdInfo(uint32_t device_ordinal, uint32_t* simd_per_cu,
+                                uint32_t* max_waves_per_simd,
+                                uint32_t* gfx_target_version) const {
+  uint32_t gpu_index = 0;
+  for (const auto& [handle, agent] : agents_) {
+    if (agent.type == ROCPROFILER_AGENT_TYPE_GPU) {
+      if (gpu_index == device_ordinal) {
+        *simd_per_cu = agent.simd_per_cu;
+        *max_waves_per_simd = agent.max_waves_per_simd;
+        *gfx_target_version = agent.gfx_target_version;
+        return true;
+      }
+      gpu_index++;
+    }
+  }
+  return false;
 }
 
 void RocmTracer::HipApiEvent(const rocprofiler_record_header_t* hdr,
@@ -295,11 +312,17 @@ void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
       .grid_x = kinfo.grid_size.x,
       .grid_y = kinfo.grid_size.y,
       .grid_z = kinfo.grid_size.z,
-      .func_ptr = nullptr,
+      .sgpr_count = 0,
+      .arch_vgpr_count = 0,
   };
 
   auto it = kernel_info_.find(kinfo.kernel_id);
-  if (it != kernel_info_.end()) trace_event->name = it->second.name;
+  if (it != kernel_info_.end()) {
+    trace_event->name = it->second.name;
+    const auto& sym = it->second.data;
+    trace_event->kernel_info.sgpr_count = sym.sgpr_count;
+    trace_event->kernel_info.arch_vgpr_count = sym.arch_vgpr_count;
+  }
 }
 
 void RocmTracer::TracingCallback(rocprofiler_context_id_t context,

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -53,6 +53,11 @@ class RocmTracer {
   void Disable();
 
   static uint64_t GetTimestamp();
+
+  // Get GPU agent properties needed for theoretical occupancy calculation.
+  bool GetGpuSimdInfo(uint32_t device_ordinal, uint32_t* simd_per_cu,
+                      uint32_t* max_waves_per_simd,
+                      uint32_t* gfx_target_version) const;
   uint32_t NumGpus() const { return num_gpus_; };
   RocmTraceCollector* collector() { return collector_; }
 

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -69,9 +69,9 @@ struct KernelDetails {
   uint32_t grid_y;
   // Z-dimension of a grid.
   uint32_t grid_z;
-
-  // kernel address. Used for calculating core occupancy
-  void* func_ptr;
+  // Register counts (in DWORDs) from kernel code object metadata.
+  uint32_t sgpr_count;
+  uint32_t arch_vgpr_count;
 };
 
 enum class RocmTracerEventType {
@@ -148,6 +148,9 @@ struct RocmTracerEvent {
 };
 
 struct RocmTraceCollectorOptions {
+  uint32_t simd_per_cu = 0;
+  uint32_t max_waves_per_simd = 0;
+  uint32_t gfx_target_version = 0;
   // Maximum number of events to collect from callback API; if -1, no limit.
   // if 0, the callback API is enabled to build a correlation map, but no
   // events are collected.


### PR DESCRIPTION
- Replace broken hipOccupancy API path (func_ptr was always null) with direct computation from kernel code object metadata (VGPR/SGPR counts) and rocprofiler-sdk agent properties (SIMD/CU configuration)
- Add kTheoreticalOccupancyPct as separate XEvent stat for Kernel Stats table
- Use arch-based lookup for VGPR/SGPR allocation limits matching HIP CLR


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
