### PR TITLE
[ROCm] Enable Triton MLIR verifier by default on ROCm

### DIFF
--- a/xla/backends/gpu/codegen/triton/xtile_compiler.cc
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.cc
@@ -429,8 +429,13 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
 
   const HloModuleConfig& hlo_config = hlo_module.config();
 
+  const auto& debug_opts = hlo_config.debug_options();
+  // On ROCm the verifier is enabled by default as an extra safety net:
+  // it turns invalid IR into a graceful compilation error that the autotuner
+  // can skip. Disable via --xla_gpu_rocm_triton_verifier=false.
   bool should_verify =
-      (hlo_config.debug_options().xla_gpu_llvm_verification_level() >= 1);
+      (debug_opts.xla_gpu_llvm_verification_level() >= 1) ||
+      (gpu_cc.IsRocm() && debug_opts.xla_gpu_rocm_triton_verifier());
 #ifndef NDEBUG
   should_verify = true;
 #endif

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -499,6 +499,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 
   // maximum number of events to be traced, default to 4M
   opts.set_xla_gpu_rocm_max_trace_events(4 * 1024 * 1024);
+  opts.set_xla_gpu_rocm_triton_verifier(true);
 
   opts.set_xla_gpu_print_compilation_stats(false);
 
@@ -2942,6 +2943,14 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_rocm_max_trace_events(),
       "Maximum number of ROCm trace events (applies to callback/activity/"
       "annotation). Set as high as memory allows; up to 1e9."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_rocm_triton_verifier",
+      bool_setter_for(&DebugOptions::set_xla_gpu_rocm_triton_verifier),
+      debug_options->xla_gpu_rocm_triton_verifier(),
+      "If true, enables MLIR pass verification in the Triton compilation "
+      "pipeline on ROCm. Catches invalid IR early so the autotuner can skip "
+      "bad configs instead of crashing. Only consulted when "
+      "xla_gpu_llvm_verification_level is 0 and the target is ROCm."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_enable_tiling_propagation",
       bool_setter_for(

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1002,6 +1002,12 @@ message DebugOptions {
   // usage during profiling on AMD GPUs.
   optional int64 xla_gpu_rocm_max_trace_events = 449;
 
+  // If true, enables MLIR pass verification in the Triton compilation pipeline
+  // on ROCm. This catches invalid IR early, allowing the autotuner to skip bad
+  // configs instead of crashing. Only consulted when
+  // xla_gpu_llvm_verification_level is 0 and the target is ROCm.
+  optional bool xla_gpu_rocm_triton_verifier = 502;
+
   optional ShapeChecks xla_gpu_shape_checks = 170;
 
   // If true, shards the autotuning work between participating compiler


### PR DESCRIPTION
Add a new flag xla_gpu_rocm_triton_verifier (default true) that enables the MLIR pass verifier in the Triton compilation pipeline on ROCm. This turns invalid IR from miscompiling passes into graceful compilation errors that the autotuner can skip, instead of crashing the process.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
