### PR TITLE
Update skipped list for upstream CI

### DIFF
--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -5,7 +5,6 @@ set -ex
 SCRIPT_DIR=$(realpath "$(dirname "$0")")
 
 EXCLUDED_TESTS=(
-    "*ParametersUsedByCollectiveMosaicShouldBeCopiedToCollectiveMemory"
     "SortingTest*"
     "*IotaR1Test*"
     "HostMemoryAllocateTest.Numa"
@@ -13,20 +12,16 @@ EXCLUDED_TESTS=(
 )
 
 EXCLUDED_TARGETS_SGPU=(
-    "//xla/service/gpu:dot_algorithm_support_test_amdgpu_any"
     "//xla/service/gpu:float_support_test_amdgpu_any"
-    "//xla/backends/gpu/transforms:scatter_determinism_expander_test_amdgpu_any"
+    "//xla/tests:iota_test_amdgpu_any"   # Taking too many CI nodes
     "//xla/backends/gpu/transforms:triton_fusion_numerics_verifier_test_amdgpu_any"
-    "//xla/backends/gpu/codegen/triton:dot_algorithms_test_amdgpu_any"
 )
 
 TEST_TARGETS_SGPU=(
     "//xla/..."
-    "-//xla/service/gpu:dot_algorithm_support_test_amdgpu_any"
+    "-//xla/tests:iota_test_amdgpu_any"   # Taking too many CI nodes
     "-//xla/service/gpu:float_support_test_amdgpu_any"
-    "-//xla/backends/gpu/transforms:scatter_determinism_expander_test_amdgpu_any"
     "-//xla/backends/gpu/transforms:triton_fusion_numerics_verifier_test_amdgpu_any"
-    "-//xla/backends/gpu/codegen/triton:dot_algorithms_test_amdgpu_any"
 )
 
 TEST_TARGETS_MGPU=(

--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -12,7 +12,6 @@ EXCLUDED_TESTS=(
 )
 
 EXCLUDED_TARGETS_SGPU=(
-    "//xla/service/gpu:float_support_test_amdgpu_any"
     "//xla/tests:iota_test_amdgpu_any"   # Taking too many CI nodes
     "//xla/backends/gpu/transforms:triton_fusion_numerics_verifier_test_amdgpu_any"
 )
@@ -20,7 +19,6 @@ EXCLUDED_TARGETS_SGPU=(
 TEST_TARGETS_SGPU=(
     "//xla/..."
     "-//xla/tests:iota_test_amdgpu_any"   # Taking too many CI nodes
-    "-//xla/service/gpu:float_support_test_amdgpu_any"
     "-//xla/backends/gpu/transforms:triton_fusion_numerics_verifier_test_amdgpu_any"
 )
 

--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -13,13 +13,11 @@ EXCLUDED_TESTS=(
 
 EXCLUDED_TARGETS_SGPU=(
     "//xla/tests:iota_test_amdgpu_any"   # Taking too many CI nodes
-    "//xla/backends/gpu/transforms:triton_fusion_numerics_verifier_test_amdgpu_any"
 )
 
 TEST_TARGETS_SGPU=(
     "//xla/..."
     "-//xla/tests:iota_test_amdgpu_any"   # Taking too many CI nodes
-    "-//xla/backends/gpu/transforms:triton_fusion_numerics_verifier_test_amdgpu_any"
 )
 
 TEST_TARGETS_MGPU=(

--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -4,73 +4,19 @@ set -ex
 
 SCRIPT_DIR=$(realpath "$(dirname "$0")")
 
-EXCLUDED_TESTS=("HostMemoryAllocateTest.Numa")
-
-EXCLUDED_TARGETS_SGPU=(
-    "//xla/tests:iota_test_amdgpu_any"   # Taking too many CI nodes
-    "//xla/backends/gpu/codegen/triton:dot_algorithms_test_amdgpu_any"
+EXCLUDED_TESTS=(
+    "HostMemoryAllocateTest.Numa" # Failing on RBE
+    "*IotaR1Test*" # Taking too many CI nodes
 )
-
-TEST_TARGETS_SGPU=(
-    "//xla/..."
-)
-
-TEST_TARGETS_MGPU=(
-    "//xla/tests:collective_ops_test"
-    "//xla/backends/gpu/collectives:gpu_clique_key_test"
-    "//xla/backends/gpu/runtime:all_reduce_test"
-    "//xla/backends/gpu/runtime:collective_kernel_thunk_test"
-    "//xla/backends/gpu/runtime:buffers_checksum_thunk_test"
-    "//xla/backends/gpu/tests:collective_ops_command_buffer_test"
-    "//xla/backends/gpu/tests:collective_pipeline_parallelism_test"
-    "//xla/backends/gpu/tests:nccl_group_execution_test"
-    "//xla/backends/gpu/tests:collective_ops_e2e_test"
-    "//xla/backends/gpu/tests:collective_ops_ffi_test"
-    "//xla/backends/gpu/tests:collective_ops_sharded_unsharded_e2e_test"
-    "//xla/backends/gpu/tests:ragged_all_to_all_e2e_test"
-    "//xla/backends/gpu/tests:replicated_io_feed_test"
-    "//xla/backends/gpu/tests:all_reduce_e2e_test"
-    "//xla/service:collective_ops_utils_test"
-    "//xla/service:collective_pipeliner_test"
-    "//xla/service:collective_permute_cycle_test"
-    "//xla/service:batched_gather_scatter_normalizer_test"
-    "//xla/service:all_reduce_simplifier_test"
-    "//xla/service:all_gather_simplifier_test"
-    "//xla/service:reduce_scatter_decomposer_test"
-    "//xla/service:reduce_scatter_reassociate_test"
-    "//xla/service:reduce_scatter_combiner_test"
-    "//xla/service:scatter_simplifier_test"
-    "//xla/service:sharding_propagation_test"
-    "//xla/service:sharding_remover_test"
-    "//xla/service:p2p_schedule_preparation_test"
-    "//xla/tools/multihost_hlo_runner:functional_hlo_runner_test"
-    "//xla/pjrt/distributed:topology_util_test"
-    "//xla/pjrt/distributed:client_server_test"
-    "//xla/pjrt/extensions/cross_host_transfers:pjrt_c_api_cross_host_transfers_extension_gpu_test"
-    "//xla/pjrt/gpu/tfrt:tfrt_gpu_client_test"
-    "//xla/pjrt/gpu:se_gpu_pjrt_client_test"
-)
-
-EXCLUDED_TARGETS_MGPU=()
 
 TAG_FILTERS=$("${SCRIPT_DIR}/rocm_tag_filters.sh")
-TEST_TARGETS=("${TEST_TARGETS_SGPU[@]}")
-SGPU_AMDGPU_TARGETS="${TF_ROCM_SGPU_AMDGPU_TARGETS:-gfx90a,gfx942}"
-MGPU_AMDGPU_TARGETS="${TF_ROCM_MGPU_AMDGPU_TARGETS:-gfx950}"
-AMDGPU_TARGETS="${SGPU_AMDGPU_TARGETS}"
 
 for arg in "$@"; do
     if [[ "$arg" == "--config=ci_multi_gpu" ]]; then
-        TAG_FILTERS=""
-        TEST_TARGETS=("${TEST_TARGETS_MGPU[@]}")
-        EXCLUDED_TARGETS=("${EXCLUDED_TARGETS_MGPU[@]}")
-        AMDGPU_TARGETS="${MGPU_AMDGPU_TARGETS}"
+        TAG_FILTERS="${TAG_FILTERS},multi_gpu,-no_oss"
     fi
     if [[ "$arg" == "--config=ci_single_gpu" ]]; then
         TAG_FILTERS="${TAG_FILTERS},gpu,-multi_gpu,-no_oss"
-        TEST_TARGETS=("${TEST_TARGETS_SGPU[@]}")
-        EXCLUDED_TARGETS=("${EXCLUDED_TARGETS_SGPU[@]}")
-        AMDGPU_TARGETS="${SGPU_AMDGPU_TARGETS}"
     fi
 done
 
@@ -81,7 +27,7 @@ done
     --execution_log_compact_file=execution_log.binpb.zst \
     --spawn_strategy=local \
     --repo_env=REMOTE_GPU_TESTING=1 \
-    --repo_env=TF_ROCM_AMDGPU_TARGETS=${AMDGPU_TARGETS} \
+    --repo_env=TF_ROCM_AMDGPU_TARGETS=gfx90a,gfx942,gfx950 \
     --remote_download_outputs=minimal \
     --grpc_keepalive_time=30s \
     --test_sharding_strategy=disabled \
@@ -92,9 +38,5 @@ done
         IFS=:
         echo "${EXCLUDED_TESTS[*]}"
     ) \
-    -- "${TEST_TARGETS[@]}" \
-    -$(
-        IFS=:
-        echo "${EXCLUDED_TARGETS[*]}"
-    )
+    -- //xla/...
 

--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -4,25 +4,35 @@ set -ex
 
 SCRIPT_DIR=$(realpath "$(dirname "$0")")
 
-EXCLUDED_TESTS=(
-    "SortingTest*"
-    "*IotaR1Test*"
-    "HostMemoryAllocateTest.Numa"
-    "CubSort*"
-)
+
+EXCLUDED_TESTS=()
 
 EXCLUDED_TARGETS_SGPU=(
     "//xla/tests:iota_test_amdgpu_any"   # Taking too many CI nodes
+    "//xla/backends/gpu/codegen/triton:dot_algorithms_test_amdgpu_any"
 )
 
 TEST_TARGETS_SGPU=(
     "//xla/..."
     "-//xla/tests:iota_test_amdgpu_any"   # Taking too many CI nodes
+    "-//xla/backends/gpu/codegen/triton:dot_algorithms_test_amdgpu_any"
 )
 
 TEST_TARGETS_MGPU=(
-    "//xla/backends/gpu/tests:collective_pipeline_parallelism_test"
+    "//xla/tests:collective_ops_test"
     "//xla/backends/gpu/collectives:gpu_clique_key_test"
+    "//xla/backends/gpu/runtime:all_reduce_test"
+    "//xla/backends/gpu/runtime:collective_kernel_thunk_test"
+    "//xla/backends/gpu/runtime:buffers_checksum_thunk_test"
+    "//xla/backends/gpu/tests:collective_ops_command_buffer_test"
+    "//xla/backends/gpu/tests:collective_pipeline_parallelism_test"
+    "//xla/backends/gpu/tests:nccl_group_execution_test"
+    "//xla/backends/gpu/tests:collective_ops_e2e_test"
+    "//xla/backends/gpu/tests:collective_ops_ffi_test"
+    "//xla/backends/gpu/tests:collective_ops_sharded_unsharded_e2e_test"
+    "//xla/backends/gpu/tests:ragged_all_to_all_e2e_test"
+    "//xla/backends/gpu/tests:replicated_io_feed_test"
+    "//xla/backends/gpu/tests:all_reduce_e2e_test"
     "//xla/service:collective_ops_utils_test"
     "//xla/service:collective_pipeliner_test"
     "//xla/service:collective_permute_cycle_test"
@@ -36,9 +46,12 @@ TEST_TARGETS_MGPU=(
     "//xla/service:sharding_propagation_test"
     "//xla/service:sharding_remover_test"
     "//xla/service:p2p_schedule_preparation_test"
+    "//xla/tools/multihost_hlo_runner:functional_hlo_runner_test"
     "//xla/pjrt/distributed:topology_util_test"
     "//xla/pjrt/distributed:client_server_test"
-)
+    "//xla/pjrt/extensions/cross_host_transfers:pjrt_c_api_cross_host_transfers_extension_gpu_test"
+    "//xla/pjrt/gpu/tfrt:tfrt_gpu_client_test"
+    "//xla/pjrt/gpu:se_gpu_pjrt_client_test")
 
 TAG_FILTERS=$("${SCRIPT_DIR}/rocm_tag_filters.sh")
 TEST_TARGETS=("${TEST_TARGETS_SGPU[@]}")

--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -7,6 +7,12 @@ SCRIPT_DIR=$(realpath "$(dirname "$0")")
 EXCLUDED_TESTS=(
     "HostMemoryAllocateTest.Numa" # Failing on RBE
     "*IotaR1Test*" # Taking too many CI nodes
+    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e4m3fn_f8e5m2"
+    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e5m2_f8e5m2"
+    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e5m2_f8e4m3fn"
+    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e4m3fn_f8e4m3fn"
+    "TritonAndBlasSupportForDifferentTensorSizes/TritonAndBlasSupportForDifferentTensorSizes.IsDotAlgorithmSupportedByTriton/dot_bf16_bf16_f32_x6"
+    "TritonAndBlasSupportForDifferentTensorSizes/TritonAndBlasSupportForDifferentTensorSizes.IsDotAlgorithmSupportedByTriton/dot_bf16_bf16_f32_x9"
 )
 
 TAG_FILTERS=$("${SCRIPT_DIR}/rocm_tag_filters.sh")

--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -7,12 +7,13 @@ SCRIPT_DIR=$(realpath "$(dirname "$0")")
 EXCLUDED_TESTS=(
     "HostMemoryAllocateTest.Numa" # Failing on RBE
     "*IotaR1Test*" # Taking too many CI nodes
-    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e4m3fn_f8e5m2"
-    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e5m2_f8e5m2"
-    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e5m2_f8e4m3fn"
-    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e4m3fn_f8e4m3fn"
-    "TritonAndBlasSupportForDifferentTensorSizes/TritonAndBlasSupportForDifferentTensorSizes.IsDotAlgorithmSupportedByTriton/dot_bf16_bf16_f32_x6"
-    "TritonAndBlasSupportForDifferentTensorSizes/TritonAndBlasSupportForDifferentTensorSizes.IsDotAlgorithmSupportedByTriton/dot_bf16_bf16_f32_x9"
+    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e4m3fn_f8e5m2" # TODO: fix
+    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e5m2_f8e5m2" # TODO: fix
+    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e5m2_f8e4m3fn" # TODO: fix
+    "Fp8s/FloatNormalizationTest.Fp8Normalization/f8e4m3fn_f8e4m3fn" # TODO: fix
+    "TritonAndBlasSupportForDifferentTensorSizes/TritonAndBlasSupportForDifferentTensorSizes.IsDotAlgorithmSupportedByTriton/dot_bf16_bf16_f32_x6" # TODO: fix
+    "TritonAndBlasSupportForDifferentTensorSizes/TritonAndBlasSupportForDifferentTensorSizes.IsDotAlgorithmSupportedByTriton/dot_bf16_bf16_f32_x9" # TODO: fix
+    "RocmExecutorTest.CreateUnifiedMemoryAllocatorWorks" # TODO: fix
 )
 
 TAG_FILTERS=$("${SCRIPT_DIR}/rocm_tag_filters.sh")
@@ -44,5 +45,7 @@ done
         IFS=:
         echo "${EXCLUDED_TESTS[*]}"
     ) \
-    -- //xla/...
+    -- \
+    //xla/... \
+    -//xla/backends/gpu/tests:sorting.hlo.test_mi200 # lit test can't filter with gtest filters
 

--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -63,13 +63,13 @@ for arg in "$@"; do
     if [[ "$arg" == "--config=ci_multi_gpu" ]]; then
         TAG_FILTERS=""
         TEST_TARGETS=("${TEST_TARGETS_MGPU[@]}")
-        EXCLUDED_TARGETS=("${EXCLUDED_TARGETS_SGPU}")
+        EXCLUDED_TARGETS=("${EXCLUDED_TARGETS_MGPU[@]}")
         AMDGPU_TARGETS="${MGPU_AMDGPU_TARGETS}"
     fi
     if [[ "$arg" == "--config=ci_single_gpu" ]]; then
         TAG_FILTERS="${TAG_FILTERS},gpu,-multi_gpu,-no_oss"
         TEST_TARGETS=("${TEST_TARGETS_SGPU[@]}")
-        EXCLUDED_TARGETS=("${EXCLUDED_TARGETS_MGPU}")
+        EXCLUDED_TARGETS=("${EXCLUDED_TARGETS_SGPU[@]}")
         AMDGPU_TARGETS="${SGPU_AMDGPU_TARGETS}"
     fi
 done

--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -20,10 +20,10 @@ TAG_FILTERS=$("${SCRIPT_DIR}/rocm_tag_filters.sh")
 
 for arg in "$@"; do
     if [[ "$arg" == "--config=ci_multi_gpu" ]]; then
-        TAG_FILTERS="${TAG_FILTERS},multi_gpu,-no_oss"
+        TAG_FILTERS="${TAG_FILTERS},multi_gpu"
     fi
     if [[ "$arg" == "--config=ci_single_gpu" ]]; then
-        TAG_FILTERS="${TAG_FILTERS},gpu,-multi_gpu,-no_oss"
+        TAG_FILTERS="${TAG_FILTERS},gpu,-multi_gpu"
     fi
 done
 

--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -4,7 +4,7 @@ set -ex
 
 SCRIPT_DIR=$(realpath "$(dirname "$0")")
 
-EXCLUDED_TESTS=()
+EXCLUDED_TESTS=("HostMemoryAllocateTest.Numa")
 
 EXCLUDED_TARGETS_SGPU=(
     "//xla/tests:iota_test_amdgpu_any"   # Taking too many CI nodes
@@ -13,8 +13,6 @@ EXCLUDED_TARGETS_SGPU=(
 
 TEST_TARGETS_SGPU=(
     "//xla/..."
-    "-//xla/tests:iota_test_amdgpu_any"   # Taking too many CI nodes
-    "-//xla/backends/gpu/codegen/triton:dot_algorithms_test_amdgpu_any"
 )
 
 TEST_TARGETS_MGPU=(
@@ -53,6 +51,8 @@ TEST_TARGETS_MGPU=(
     "//xla/pjrt/gpu:se_gpu_pjrt_client_test"
 )
 
+EXCLUDED_TARGETS_MGPU=()
+
 TAG_FILTERS=$("${SCRIPT_DIR}/rocm_tag_filters.sh")
 TEST_TARGETS=("${TEST_TARGETS_SGPU[@]}")
 SGPU_AMDGPU_TARGETS="${TF_ROCM_SGPU_AMDGPU_TARGETS:-gfx90a,gfx942}"
@@ -63,11 +63,13 @@ for arg in "$@"; do
     if [[ "$arg" == "--config=ci_multi_gpu" ]]; then
         TAG_FILTERS=""
         TEST_TARGETS=("${TEST_TARGETS_MGPU[@]}")
+        EXCLUDED_TARGETS=("${EXCLUDED_TARGETS_SGPU}")
         AMDGPU_TARGETS="${MGPU_AMDGPU_TARGETS}"
     fi
     if [[ "$arg" == "--config=ci_single_gpu" ]]; then
         TAG_FILTERS="${TAG_FILTERS},gpu,-multi_gpu,-no_oss"
         TEST_TARGETS=("${TEST_TARGETS_SGPU[@]}")
+        EXCLUDED_TARGETS=("${EXCLUDED_TARGETS_MGPU}")
         AMDGPU_TARGETS="${SGPU_AMDGPU_TARGETS}"
     fi
 done
@@ -90,4 +92,9 @@ done
         IFS=:
         echo "${EXCLUDED_TESTS[*]}"
     ) \
-    -- "${TEST_TARGETS[@]}"
+    -- "${TEST_TARGETS[@]}" \
+    -$(
+        IFS=:
+        echo "${EXCLUDED_TARGETS[*]}"
+    )
+


### PR DESCRIPTION
## Motivation

after this PR is merged https://github.com/openxla/xla/pull/36893 we are fully using `rocm-dev-infra` for upstream CI and we can better control the skipped list.
 