### PR TITLE
Cherry-pick-adaptation:PR #40199: [ROCm] Fix profiler leaking stale hipErrorInvalidDevice on ROCm

### DIFF
--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -187,6 +187,7 @@ absl::Status GpuTracer::DoStart() {
       GetRocmTraceCollectorOptions(rocm_tracer_->NumGpus());
   rocm_trace_collector_ = CreateRocmCollector(
       trace_collector_options, start_walltime_ns, start_gputime_ns);
+  rocm_trace_collector_->SetGpuAgents(rocm_tracer_->GpuAgents());
 
   rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get());
 

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -163,7 +163,13 @@ OccupancyStats PerDeviceCollector::GetOccupancy(
   }
 
   stats.occupancy_pct = number_of_active_blocks * params.block_size * 100;
-  stats.occupancy_pct /= device_properties_.maxThreadsPerMultiProcessor;
+  // TODO(ROCm): GetOccupancy is currently dead code -- no callers populate
+  // max_waves_per_cu / wave_front_size, so occupancy_pct stays zero.
+  // Wire up agent data when occupancy reporting is enabled.
+  auto max_threads = params.max_waves_per_cu * params.wave_front_size;
+  if (max_threads > 0) {
+    stats.occupancy_pct /= max_threads;
+  }
 
   err = hipOccupancyMaxPotentialBlockSize(
       &stats.min_grid_size, &stats.suggested_block_size,
@@ -399,18 +405,15 @@ void PerDeviceCollector::AddEvent(RocmTracerEvent&& event) {
   events_.emplace_back(std::move(event));
 }
 
-void PerDeviceCollector::GetDeviceCapabilities(int32_t device_ordinal,
-                                               XPlaneBuilder* device_plane) {
+void PerDeviceCollector::GetDeviceCapabilities(
+    const rocprofiler_agent_v0_t& agent, XPlaneBuilder* device_plane) {
   device_plane->AddStatValue(*device_plane->GetOrCreateStatMetadata(
                                  GetStatTypeStr(StatType::kDevVendor)),
                              kDeviceVendorAMD);
 
-  if (hipGetDeviceProperties(&device_properties_, device_ordinal) !=
-      hipSuccess) {
-    return;
-  }
-
-  auto clock_rate_in_khz = device_properties_.clockRate;  // this is also in Khz
+  // Agent clock rates are in MHz; profiler stats expect KHz.
+  auto clock_rate_in_khz =
+      static_cast<int64_t>(agent.max_engine_clk_fcompute) * 1000;
   if (clock_rate_in_khz) {
     device_plane->AddStatValue(
         *device_plane->GetOrCreateStatMetadata(
@@ -418,47 +421,71 @@ void PerDeviceCollector::GetDeviceCapabilities(int32_t device_ordinal,
         clock_rate_in_khz);
   }
 
-  auto core_count = device_properties_.multiProcessorCount;
+  auto core_count = agent.cu_count;
   if (core_count) {
     device_plane->AddStatValue(*device_plane->GetOrCreateStatMetadata(
                                    GetStatTypeStr(StatType::kDevCapCoreCount)),
                                core_count);
   }
 
-  auto mem_clock_khz = device_properties_.memoryClockRate;
-  auto mem_bus_width_bits = device_properties_.memoryBusWidth;
+  // Extract memory info from VRAM (frame buffer) banks only, skipping
+  // system memory, LDS, GDS, scratch, etc.
+  // TODO(ROCm): APUs share system memory and may not have frame buffer
+  // banks; verify behavior on APU targets.
+  if (agent.mem_banks_count > 0 && agent.mem_banks != nullptr) {
+    uint64_t total_memory = 0;
+    uint32_t vram_clock_mhz = 0;
+    uint32_t vram_bus_width_bits = 0;
+    for (uint32_t i = 0; i < agent.mem_banks_count; ++i) {
+      if (agent.mem_banks[i].heap_type == HSA_HEAPTYPE_FRAME_BUFFER_PUBLIC ||
+          agent.mem_banks[i].heap_type == HSA_HEAPTYPE_FRAME_BUFFER_PRIVATE) {
+        total_memory += agent.mem_banks[i].size_in_bytes;
+        if (vram_clock_mhz == 0) {
+          vram_clock_mhz = agent.mem_banks[i].mem_clk_max;
+          vram_bus_width_bits = agent.mem_banks[i].width;
+        }
+      }
+    }
 
-  if (mem_clock_khz && mem_bus_width_bits) {
-    // Times 2 because HBM is DDR memory; it gets two data bits per each
-    // data lane.
-    auto memory_bandwidth =
-        uint64_t{2} * (mem_clock_khz) * 1000 * (mem_bus_width_bits) / 8;
-    device_plane->AddStatValue(
-        *device_plane->GetOrCreateStatMetadata(
-            GetStatTypeStr(StatType::kDevCapMemoryBandwidth)),
-        memory_bandwidth);
+    if (vram_clock_mhz && vram_bus_width_bits) {
+      // Agent mem_clk_max is in MHz; multiply by 10^6 to get Hz.
+      // Times 2 because HBM is DDR memory; it gets two data bits per each
+      // data lane.
+      auto memory_bandwidth = uint64_t{2} *
+                              static_cast<uint64_t>(vram_clock_mhz) * 1000 *
+                              1000 * vram_bus_width_bits / 8;
+      device_plane->AddStatValue(
+          *device_plane->GetOrCreateStatMetadata(
+              GetStatTypeStr(StatType::kDevCapMemoryBandwidth)),
+          memory_bandwidth);
+    }
+
+    if (total_memory) {
+      device_plane->AddStatValue(
+          *device_plane->GetOrCreateStatMetadata(
+              GetStatTypeStr(StatType::kDevCapMemorySize)),
+          total_memory);
+    }
   }
 
-  size_t total_memory = device_properties_.totalGlobalMem;
-  if (total_memory) {
-    device_plane->AddStatValue(*device_plane->GetOrCreateStatMetadata(
-                                   GetStatTypeStr(StatType::kDevCapMemorySize)),
-                               static_cast<uint64_t>(total_memory));
-  }
-
-  auto compute_capability_major = device_properties_.major;
-  if (compute_capability_major) {
-    device_plane->AddStatValue(
-        *device_plane->GetOrCreateStatMetadata(
-            GetStatTypeStr(StatType::kDevCapComputeCapMajor)),
-        compute_capability_major);
-  }
-  auto compute_capability_minor = device_properties_.minor;
-  if (compute_capability_minor) {
-    device_plane->AddStatValue(
-        *device_plane->GetOrCreateStatMetadata(
-            GetStatTypeStr(StatType::kDevCapComputeCapMinor)),
-        compute_capability_minor);
+  // gfx_target_version encodes: major=((value/10000)%100),
+  // minor=((value/100)%100), patch=(value%100)
+  auto gfx_ver = agent.gfx_target_version;
+  if (gfx_ver) {
+    auto compute_capability_major = (gfx_ver / 10000) % 100;
+    if (compute_capability_major) {
+      device_plane->AddStatValue(
+          *device_plane->GetOrCreateStatMetadata(
+              GetStatTypeStr(StatType::kDevCapComputeCapMajor)),
+          compute_capability_major);
+    }
+    auto compute_capability_minor = (gfx_ver / 100) % 100;
+    if (compute_capability_minor) {
+      device_plane->AddStatValue(
+          *device_plane->GetOrCreateStatMetadata(
+              GetStatTypeStr(StatType::kDevCapComputeCapMinor)),
+          compute_capability_minor);
+    }
   }
 }
 
@@ -549,9 +576,10 @@ void RocmTraceCollectorImpl::Export(XSpace* space) {
     std::string name = GpuPlaneName(id);
     XPlaneBuilder device_plane(FindOrAddMutablePlaneWithName(space, name));
     device_plane.SetId(id);
-    // Calculate device capabilities before flushing, so that device
-    // properties are available to the occupancy calculator in export().
-    per_device_collector_[id].GetDeviceCapabilities(id, &device_plane);
+    if (id < static_cast<int>(gpu_agents_.size())) {
+      per_device_collector_[id].GetDeviceCapabilities(gpu_agents_[id],
+                                                      &device_plane);
+    }
     per_device_collector_[id].Export(start_walltime_ns_, start_gputime_ns_,
                                      end_gputime_ns, &device_plane,
                                      &host_plane);

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -30,10 +30,11 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
-#include "rocm/include/hip/hip_runtime.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/utils/xplane_builder.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "rocprofiler-sdk/agent.h"
 
 namespace xla {
 namespace profiler {
@@ -63,6 +64,8 @@ struct RocmDeviceOccupancyParams {
   int block_size = 0;
   size_t dynamic_smem_size = 0;
   void* func_ptr;
+  uint32_t max_waves_per_cu = 0;
+  uint32_t wave_front_size = 0;
 
   friend bool operator==(const RocmDeviceOccupancyParams& a,
                          const RocmDeviceOccupancyParams& b) noexcept {
@@ -78,7 +81,9 @@ struct RocmDeviceOccupancyParams {
                       a.attributes.ptxVersion,
                       a.block_size,
                       a.dynamic_smem_size,
-                      a.func_ptr} ==
+                      a.func_ptr,
+                      a.max_waves_per_cu,
+                      a.wave_front_size} ==
            std::tuple{b.attributes.binaryVersion,
                       b.attributes.cacheModeCA,
                       b.attributes.constSizeBytes,
@@ -90,7 +95,9 @@ struct RocmDeviceOccupancyParams {
                       b.attributes.ptxVersion,
                       b.block_size,
                       b.dynamic_smem_size,
-                      b.func_ptr};
+                      b.func_ptr,
+                      b.max_waves_per_cu,
+                      b.wave_front_size};
   }
 
   friend bool operator!=(const RocmDeviceOccupancyParams& a,
@@ -105,7 +112,8 @@ struct RocmDeviceOccupancyParams {
         std::move(hash_state), params.attributes.maxThreadsPerBlock,
         params.attributes.numRegs, params.attributes.sharedSizeBytes,
         params.attributes.maxDynamicSharedSizeBytes, params.block_size,
-        params.dynamic_smem_size, params.func_ptr);
+        params.dynamic_smem_size, params.func_ptr, params.max_waves_per_cu,
+        params.wave_front_size);
   }
 };
 
@@ -122,6 +130,9 @@ class RocmTraceCollector {
       : options_(options) {}
   virtual ~RocmTraceCollector() {}
 
+  // Agent data used by GetDeviceCapabilities instead of hipGetDeviceProperties
+  // (which can set sticky hipGetLastError for non-visible devices on ROCm 7+).
+  virtual void SetGpuAgents(std::vector<rocprofiler_agent_v0_t> /*agents*/) {}
   virtual void AddEvent(RocmTracerEvent&& event, bool is_auxiliary) = 0;
   virtual void OnEventsDropped(const std::string& reason,
                                uint32_t num_events) = 0;
@@ -147,7 +158,7 @@ class PerDeviceCollector {
   PerDeviceCollector() = default;
 
   void AddEvent(RocmTracerEvent&& event);
-  void GetDeviceCapabilities(int32_t device_ordinal,
+  void GetDeviceCapabilities(const rocprofiler_agent_v0_t& agent,
                              tsl::profiler::XPlaneBuilder* device_plane);
 
  private:
@@ -163,7 +174,6 @@ class PerDeviceCollector {
   std::vector<RocmTracerEvent> events_ ABSL_GUARDED_BY(events_mutex_);
   absl::flat_hash_map<RocmDeviceOccupancyParams, OccupancyStats>
       occupancy_cache_;
-  hipDeviceProp_t device_properties_;
 };  // PerDeviceCollector
 
 class RocmTraceCollectorImpl : public RocmTraceCollector {
@@ -176,6 +186,10 @@ class RocmTraceCollectorImpl : public RocmTraceCollector {
         start_walltime_ns_(start_walltime_ns),
         start_gputime_ns_(start_gputime_ns),
         num_gpus_(options.num_gpus) {}
+
+  void SetGpuAgents(std::vector<rocprofiler_agent_v0_t> agents) override {
+    gpu_agents_ = std::move(agents);
+  }
 
   void AddEvent(RocmTracerEvent&& event, bool is_auxiliary) override;
   void Flush() override;
@@ -193,6 +207,7 @@ class RocmTraceCollectorImpl : public RocmTraceCollector {
   uint64_t start_walltime_ns_;
   uint64_t start_gputime_ns_;
   int num_gpus_;
+  std::vector<rocprofiler_agent_v0_t> gpu_agents_;
 
   absl::Mutex event_maps_mutex_;
   absl::flat_hash_map<uint32_t, RocmTracerEvent> api_events_map_

--- a/xla/backends/profiler/gpu/rocm_profiler_sdk.cc
+++ b/xla/backends/profiler/gpu/rocm_profiler_sdk.cc
@@ -439,13 +439,16 @@ int RocmTracer::toolInit(rocprofiler_client_finalize_t fini_func,
   // Gather API names with rocprofiler-sdk api call
   name_info_ = GetBufferTracingNames();
 
-  // Gather agent info
+  // Gather agent info.  Build an ordered list of GPU agents for use by the
+  // profiler collector (e.g. GetDeviceCapabilities).
   num_gpus_ = 0;
+  gpu_agents_.clear();
   for (const auto& agent : GetGpuDeviceAgents()) {
     VLOG(1) << "agent id = " << agent.id.handle << ", dev = " << agent.device_id
             << ", name = " << (agent.name ? agent.name : "null");
     agents_[agent.id.handle] = agent;
     if (agent.type == ROCPROFILER_AGENT_TYPE_GPU) {
+      gpu_agents_.push_back(agent);
       num_gpus_++;
     }
   }

--- a/xla/backends/profiler/gpu/rocm_profiler_sdk.h
+++ b/xla/backends/profiler/gpu/rocm_profiler_sdk.h
@@ -59,7 +59,10 @@ class RocmTracer {
   void Disable();
 
   static uint64_t GetTimestamp();
-  uint32_t NumGpus() const { return num_gpus_; };
+  uint32_t NumGpus() const { return num_gpus_; }
+  const std::vector<rocprofiler_agent_v0_t>& GpuAgents() const {
+    return gpu_agents_;
+  }
   RocmTraceCollector* collector() { return collector_; }
 
   int toolInit(rocprofiler_client_finalize_t finalize_func, void* tool_data);
@@ -126,6 +129,7 @@ class RocmTracer {
 
   buffer_name_info name_info_;
   agent_info_map_t agents_;
+  std::vector<rocprofiler_agent_v0_t> gpu_agents_;
 
  public:
   // Disable copy and move.

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -88,6 +88,44 @@ TEST(RocmTracerTest, SingletonInstance) {
   EXPECT_EQ(&tracer1, &tracer2) << "RocmTracer must be a singleton";
 }
 
+TEST(RocmTracerTest, GpuAgentDataMatchesHipDeviceProperties) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  const auto& agents = tracer.GpuAgents();
+  ASSERT_GT(agents.size(), 0u);
+
+  hipDeviceProp_t props;
+  ASSERT_EQ(hipGetDeviceProperties(&props, 0), hipSuccess);
+  const auto& agent = agents[0];
+
+  EXPECT_EQ(agent.cu_count, static_cast<uint32_t>(props.multiProcessorCount));
+  // Agent clocks are in MHz, hipDeviceProp_t clocks are in KHz.
+  EXPECT_EQ(static_cast<uint64_t>(agent.max_engine_clk_fcompute) * 1000,
+            static_cast<uint64_t>(props.clockRate));
+
+  auto gfx_major = (agent.gfx_target_version / 10000) % 100;
+  auto gfx_minor = (agent.gfx_target_version / 100) % 100;
+  EXPECT_EQ(gfx_major, static_cast<uint32_t>(props.major));
+  EXPECT_EQ(gfx_minor, static_cast<uint32_t>(props.minor));
+
+  uint64_t vram_total = 0;
+  uint32_t vram_clock_mhz = 0;
+  uint32_t vram_bus_width = 0;
+  for (uint32_t i = 0; i < agent.mem_banks_count; ++i) {
+    if (agent.mem_banks[i].heap_type == HSA_HEAPTYPE_FRAME_BUFFER_PUBLIC ||
+        agent.mem_banks[i].heap_type == HSA_HEAPTYPE_FRAME_BUFFER_PRIVATE) {
+      vram_total += agent.mem_banks[i].size_in_bytes;
+      if (vram_clock_mhz == 0) {
+        vram_clock_mhz = agent.mem_banks[i].mem_clk_max;
+        vram_bus_width = agent.mem_banks[i].width;
+      }
+    }
+  }
+  EXPECT_EQ(vram_total, props.totalGlobalMem);
+  EXPECT_EQ(static_cast<uint64_t>(vram_clock_mhz) * 1000,
+            static_cast<uint64_t>(props.memoryClockRate));
+  EXPECT_EQ(vram_bus_width, static_cast<uint32_t>(props.memoryBusWidth));
+}
+
 TEST(RocmTracerTest, InitialStateIsAvailable) {
   RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
   EXPECT_TRUE(tracer.IsAvailable())


### PR DESCRIPTION


Imported from GitHub PR https://github.com/openxla/xla/pull/40199

📝 Summary of Changes
- Replace hipGetDeviceProperties in GetDeviceCapabilities with rocprofiler agent data already available from RocmTracer. This eliminates HIP runtime calls that fail for non-visible devices when ROCR_VISIBLE_DEVICES restricts GPU visibility (e.g. pytest-xdist workers).
- Since ROCm, hipGetLastError() is sticky: it retains errors even after subsequent successful HIP API calls. The stale hipErrorInvalidDevice from the profiler leaked into unrelated GPU operations, causing flaky test failures in JAX's FFI handlers (solver, linalg, prng).
- Agent clock rates are in MHz (vs KHz in hipDeviceProp_t); memory is filtered to VRAM-only banks (FRAME_BUFFER_PUBLIC/PRIVATE).
- Add unit test verifying agent data matches hipGetDeviceProperties.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

Since this issue was very interesting to debug adding bit more detail for future readers:

Random JAX tests fail intermittently when running the full test suite with pytest-xdist (parallel workers). The failing tests are always in solver/linalg/prng FFI handlers, with the error:

```
jaxlib/gpu/solver_kernels_ffi.cc:266: operation hipGetLastError() failed: invalid device ordinal
```

or

```
jaxlib/gpu/linalg_kernels.cc:113: operation gpuGetLastError() failed: invalid device ordinal
```

The failures are random,the same test passes on the next run, and a different test fails instead. It only happens with xdist (parallel workers on multi-GPU systems) and only on ROCm 7+.

**Step 1: xdist restricts GPU visibility per worker**

JAX's `conftest.py` assigns one GPU per xdist worker:

```python
os.environ.setdefault(
    "ROCR_VISIBLE_DEVICES", str(xdist_worker_number % num_rocm_devices)
)
```

So worker gw0 sees GPU 0 only, gw1 sees GPU 1 only, etc.

**Step 2: The profiler counts ALL physical GPUs**

XLA's ROCm profiler initializes its device count from `rocprofiler` agent enumeration:

```cpp
// rocm_tracer.cc line 403-409
num_gpus_ = 0;
for (const auto& agent : GetGpuDeviceAgents()) {
    if (agent.type == ROCPROFILER_AGENT_TYPE_GPU) {
        num_gpus_++;  // counts ALL physical GPUs (8), not visible ones (1)
    }
}
```

`rocprofiler` sees all 8 physical GPUs regardless of `ROCR_VISIBLE_DEVICES`.

**Step 3: The profiler calls `hipGetDeviceProperties` with invalid device IDs**

When the profiler collects data, it iterates all `num_gpus_` devices:

```cpp
// rocm_collector.cc line 556-562
for (int id = 0; id < num_gpus_; id++) {  // loops 0..7
    per_device_collector_[id].GetDeviceCapabilities(id, &device_plane);
}
```

Inside `GetDeviceCapabilities`:

```cpp
// rocm_collector.cc line 408-411
if (hipGetDeviceProperties(&device_properties_, device_ordinal) != hipSuccess) {
    return;  // handles error via return code, but...
}
```

For worker gw0 (which only sees GPU 0), devices 1-7 are invisible. `hipGetDeviceProperties` returns `hipErrorInvalidDevice` for each. The error is handled by the return code, but the HIP runtime also sets a per-thread sticky error.

**Step 4: ROCm 7 changed `hipGetLastError()` behavior**

Since ROCm 7, `hipGetLastError()` is per-thread sticky -- it retains the last error even after subsequent successful HIP API calls. Before ROCm 7, successful calls would clear it (like CUDA's `cudaGetLastError()`).

So the `hipErrorInvalidDevice` from step 3 persists in the thread's error state indefinitely.

**Step 5: A JAX FFI handler picks up the stale error**

Later, when a test runs a solver/linalg/prng operation, the FFI handler launches a GPU kernel and checks for errors:

```cpp
// solver_kernels_ffi.cc line 158
MakeBatchPointersAsync(stream, ...);
JAX_FFI_RETURN_IF_GPU_ERROR(gpuGetLastError());  // picks up stale hipErrorInvalidDevice!
```

The `gpuGetLastError()` call returns the stale `hipErrorInvalidDevice` from the profiler's earlier failed `hipGetDeviceProperties` call -- not from the kernel launch above it.

1. **Timing-dependent**: The profiler's `CollectData` doesn't run after every test. It fires at internal profiler flush points. The stale error only affects whichever test happens to run next on that thread after the flush.

2. **Test ordering matters**: With xdist shuffling tests across 16 workers, the probability that a solver/linalg test runs immediately after a profiler flush on the same worker thread is low but nonzero.

3. **ROCm 7+ only**: On ROCm 6 and earlier, `hipGetLastError()` wasn't sticky across successful calls, so the stale error would be cleared by the next successful HIP API call before any FFI handler could see it.

Populate device property using rocprof-agent instead of hipcall.

- **Debug trap in HIP runtime** (`HIP_RETURN` macro) confirmed the source: In 8 GPU setup : ``` [HIP TRAP] hipErrorInvalidDevice set by hipGetDevicePropertiesR0600 ``` 18 entries per test run (7 invisible devices × ~2-3 profiler flushes per worker).

- **Symbolized backtrace** confirmed the call chain: ```bash call 0  hipGetDevicePropertiesR0600 (hip_device.cpp:661) call 1  PerDeviceCollector::GetDeviceCapabilities (rocm_collector.cc) call 2  RocmTraceCollectorImpl::Export (rocm_collector.cc) call 3  GpuTracer::CollectData (device_tracer_rocm.cc) call 4  ProfilerSession::CollectData (profiler_session.cc) and so on... ```
- **`--xla_gpu_autotune_level=0`** (disables autotuning, reduces profiler activity) eliminated flakiness -- consistent with profiler being the trigger. Copybara import of the project:

--
4948ec96dbb35c68ec0cf76724ac20e612dbee12 by magaonka-amd <magaonka@amd.com>:

[ROCm] Fix profiler leaking stale hipErrorInvalidDevice

- Replace hipGetDeviceProperties in GetDeviceCapabilities with rocprofiler agent data already available from RocmTracer. This eliminates HIP runtime calls that fail for non-visible devices when ROCR_VISIBLE_DEVICES restricts GPU visibility (e.g. pytest-xdist workers).
- Since ROCm, hipGetLastError() is sticky: it retains errors even after subsequent successful HIP API calls. The stale hipErrorInvalidDevice from the profiler leaked into unrelated GPU operations, causing flaky test failures in JAX's FFI handlers (solver, linalg, prng).
- Agent clock rates are in MHz (vs KHz in hipDeviceProp_t); memory is filtered to VRAM-only banks (FRAME_BUFFER_PUBLIC/PRIVATE).
- Add unit test verifying agent data matches hipGetDeviceProperties.

Merging this change closes #40199

COPYBARA_INTEGRATE_REVIEW=https://github.com/openxla/xla/pull/40199 from magaonka-amd:fix/rocm-profiler-device-enum 4948ec96dbb35c68ec0cf76724ac20e612dbee12 PiperOrigin-RevId: 895796311

