### PR TITLE
Enable AllGather Triton Backend

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -914,6 +914,7 @@ cc_library(
     srcs = ["collective_emitter.cc"],
     hdrs = ["collective_emitter.h"],
     deps = [
+        ":lowering_util",
         "//xla:shape_util",
         "//xla:status_macros",
         "//xla:types",
@@ -926,8 +927,10 @@ cc_library(
         "//xla/codegen/xtile/ir:xtile",
         "//xla/core/collectives:reduction_kind",
         "//xla/hlo/ir:hlo",
+        "//xla/mlir/utils:type_util",
         "//xla/service:collective_ops_utils",
         "//xla/service/gpu:backend_configs_cc",
+        "//xla/service/gpu:gpu_constants",
         "//xla/service/gpu:ir_emission_utils",
         "//xla/service/gpu:launch_dimensions",
         "//xla/stream_executor:device_description",

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -595,13 +595,35 @@ class AllReduceEmitter {
 llvm::SmallVector<int64_t> GreedyPowerOfTwoTiles(const Shape& output_shape,
                                                  int32_t num_blocks) {
   CHECK_GT(num_blocks, 0) << "num_blocks must be positive. Was " << num_blocks;
+
+  // Triton has a hard limit of 1048576 elements per tensor
+  constexpr int64_t kMaxTensorNumElements = 1048576;
+
   // Rank fits in int32_t.
   const auto rank = static_cast<int32_t>(output_shape.dimensions().size());
   const llvm::ArrayRef<const int64_t> minor_to_major =
       LayoutUtil::MinorToMajor(output_shape);
   llvm::SmallVector<int64_t, 4> tile_sizes(rank);
+
+  // Calculate minimum blocks needed to respect the element limit
+  int64_t total_elements = ShapeUtil::ElementsIn(output_shape);
+  int64_t min_blocks_for_limit =
+      CeilOfRatio(total_elements, kMaxTensorNumElements);
+
+  // Use at least enough blocks to stay under the element limit
+  uint64_t effective_num_blocks =
+      std::max(static_cast<uint64_t>(num_blocks),
+               static_cast<uint64_t>(min_blocks_for_limit));
+
+  VLOG(3) << "GreedyPowerOfTwoTiles: shape=" << output_shape.ToString()
+          << " requested_blocks=" << num_blocks
+          << " total_elements=" << total_elements
+          << " min_blocks_for_limit=" << min_blocks_for_limit
+          << " effective_blocks=" << effective_num_blocks;
+
   // NB: Unsigned because llvm::bit_<> functions expect unsigned.
-  uint64_t remaining_blocks = num_blocks;
+  uint64_t remaining_blocks = effective_num_blocks;
+
   // Iterate from most major to most minor to keep memory contiguous for each
   // block.
   for (int32_t i = rank - 1; i >= 0; --i) {
@@ -615,8 +637,28 @@ llvm::SmallVector<int64_t> GreedyPowerOfTwoTiles(const Shape& output_shape,
         static_cast<int64_t>(llvm::bit_ceil(xla::CeilOfRatio(dim_size, k)));
     const uint64_t blocks_used =
         xla::CeilOfRatio(dim_size, static_cast<uint64_t>(tile_sizes[dim]));
+
+    VLOG(3) << "  dim=" << dim << " dim_size=" << dim_size << " k=" << k
+            << " tile_size=" << tile_sizes[dim]
+            << " blocks_used=" << blocks_used
+            << " remaining_blocks_before=" << remaining_blocks;
+
     remaining_blocks = xla::FloorOfRatio(remaining_blocks, blocks_used);
+
+    VLOG(3) << "  remaining_blocks_after=" << remaining_blocks;
   }
+
+  // Final check
+  int64_t tile_num_elements = Product(tile_sizes);
+  VLOG(3) << "Final tile_sizes: [" << absl::StrJoin(tile_sizes, ", ") << "]"
+          << " total_tile_elements=" << tile_num_elements;
+
+  if (tile_num_elements > kMaxTensorNumElements) {
+    LOG(ERROR) << "Generated tile with " << tile_num_elements << " elements, "
+               << "which exceeds Triton's limit of " << kMaxTensorNumElements
+               << ". This will cause compilation to fail.";
+  }
+
   return tile_sizes;
 }
 
@@ -1151,6 +1193,8 @@ class AllGatherEmitter {
     // Get the block/program ID
     mlir::Value program_id = ttir::GetProgramIdOp::create(builder_, 0);
 
+    // Calculate source rank: program_id % world_size
+    // The modulo operation guarantees the result is in [0, world_size-1]
     mlir::Value world_size_i32 =
         arith::ConstantOp::create(builder_, builder_.getI32Type(),
                                   builder_.getI32IntegerAttr(ctx_.world_size));
@@ -1207,7 +1251,6 @@ class AllGatherEmitter {
   // pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
   // pid_n = (tile_id % num_pid_in_group) // group_size_m
   mlir::LogicalResult EmitAllGatherSwizzled(int64_t group_size_m) {
-    VLOG(-1) << "EmitAllGatherSwizzled";
     CHECK(initialized_);
 
     llvm::ArrayRef<int64_t> shape = ctx_.input_tile.getType().getShape();
@@ -1375,8 +1418,7 @@ mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
   }
 
   VLOG(3) << "AllGatherEmitter::Emit for all-gather";
-  return AllGatherEmitter::Emit(maybe_context.value(), rewriter,
-                                false /*swizzled kernel*/);
+  return AllGatherEmitter::Emit(maybe_context.value(), rewriter);
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -592,14 +592,137 @@ class AllReduceEmitter {
 
 }  // namespace
 
+llvm::SmallVector<int64_t> GreedyPowerOfTwoTiles(const Shape& output_shape,
+                                                 int32_t num_blocks) {
+  CHECK_GT(num_blocks, 0) << "num_blocks must be positive. Was " << num_blocks;
+  // Rank fits in int32_t.
+  const auto rank = static_cast<int32_t>(output_shape.dimensions().size());
+  const llvm::ArrayRef<const int64_t> minor_to_major =
+      LayoutUtil::MinorToMajor(output_shape);
+  llvm::SmallVector<int64_t, 4> tile_sizes(rank);
+  // NB: Unsigned because llvm::bit_<> functions expect unsigned.
+  uint64_t remaining_blocks = num_blocks;
+  // Iterate from most major to most minor to keep memory contiguous for each
+  // block.
+  for (int32_t i = rank - 1; i >= 0; --i) {
+    const auto dim = static_cast<int32_t>(minor_to_major[i]);
+    const uint64_t dim_size = output_shape.dimensions(dim);
+    // Largest power-of-two k <= std::min(dim_size, remaining_blocks).
+    const uint64_t k = std::max(
+        uint64_t{1}, llvm::bit_floor(std::min(remaining_blocks, dim_size)));
+    // Round up number of tiles in this dimension to power of two.
+    tile_sizes[dim] =
+        static_cast<int64_t>(llvm::bit_ceil(xla::CeilOfRatio(dim_size, k)));
+    const uint64_t blocks_used =
+        xla::CeilOfRatio(dim_size, static_cast<uint64_t>(tile_sizes[dim]));
+    remaining_blocks = xla::FloorOfRatio(remaining_blocks, blocks_used);
+  }
+  return tile_sizes;
+}
+
+// Returns the block level fusion config for all-gather if supported.
+absl::StatusOr<std::optional<BlockLevelFusionConfig>>
+GetBlockLevelFusionConfigForAllGather(
+    const se::DeviceDescription& device_info,
+    const HloAllGatherInstruction* all_gather) {
+  LOG(INFO) << "GetBlockLevelFusionConfigForAllGather called for: "
+            << all_gather->name();
+
+  // Check if the device supports Triton collective codegen
+  bool is_supported = false;
+
+  // CUDA: Requires compute capability 9.0+ (Hopper or newer)
+  if (device_info.cuda_compute_capability().major >= 9) {
+    is_supported = true;
+  }
+
+  // ROCm: All versions with Triton support are enabled
+  if (device_info.gpu_compute_capability().IsRocm()) {
+    is_supported = true;
+  }
+
+  if (!is_supported) {
+    VLOG(3) << "Collective codegen requires CUDA compute capability >= 9.0 "
+            << "or ROCm with Triton support. Codegen will not be supported.";
+    return std::nullopt;
+  }
+
+  const Shape& input_shape = all_gather->operand(0)->shape();
+  const int64_t num_elements = ShapeUtil::ElementsIn(input_shape);
+
+  // Check alignment requirement (same as all-reduce)
+  // This ensures we fall back to NCCL for shapes that won't work with Triton
+  // tiling
+  const int64_t alignment_requirement = se::gpu::kNumElementsPerThread;
+  if (num_elements % alignment_requirement != 0) {
+    VLOG(3) << "AllGather: Number of elements (" << num_elements
+            << ") is not aligned to the alignment requirement ("
+            << alignment_requirement << "). Falling back to NCCL.";
+    return std::nullopt;
+  }
+
+  // Calculate launch dimensions for AllGather
+  // For AllGather, each rank processes its own input data, so elements_per_rank
+  // = num_elements
+  static constexpr int64_t kWarpSize = 32;
+  static constexpr uint64_t kMaxThreadsPerBlock = 512;
+  static constexpr int64_t kMaxBlocksPerGrid = 32;
+
+  const int64_t elements_per_rank = num_elements;
+  // Maximum number of threads such that each thread has elements to process
+  const int64_t total_threads =
+      RoundUpTo(elements_per_rank / se::gpu::kNumElementsPerThread, kWarpSize);
+  // Triton expects power of 2 for threads_per_block / threads_per_warp
+  const int64_t threads_per_block =
+      std::min(kMaxThreadsPerBlock,
+               static_cast<uint64_t>(llvm::PowerOf2Ceil(total_threads)));
+  const int64_t blocks_per_grid = std::min(
+      kMaxBlocksPerGrid, CeilOfRatio(total_threads, threads_per_block));
+  const LaunchDimensions launch_dims(blocks_per_grid, threads_per_block);
+
+  // Use input shape for tiling (output shape may not have layout properly set)
+  // The tiling is based on processing input-sized chunks from each rank
+  BlockLevelFusionConfig block_level_config;
+  block_level_config.set_num_warps(launch_dims.num_threads_per_block() /
+                                   WarpSize(device_info));
+  block_level_config.set_num_ctas(1);    // No block-level clustering
+  block_level_config.set_num_stages(1);  // No pipelining of loops
+
+  Tile* output_tile = block_level_config.add_output_tiles();
+  const llvm::SmallVector<int64_t> tile_sizes =
+      GreedyPowerOfTwoTiles(input_shape, launch_dims.num_blocks());
+  output_tile->mutable_sizes()->Assign(tile_sizes.begin(), tile_sizes.end());
+
+  VLOG(3) << "GetBlockLevelFusionConfigForAllGather: Created config with "
+          << "num_warps=" << block_level_config.num_warps()
+          << ", num_blocks=" << launch_dims.num_blocks() << ", tile_sizes=["
+          << absl::StrJoin(tile_sizes, ",") << "]";
+
+  VLOG(3) << "Block level fusion config for " << all_gather->name() << ": "
+          << block_level_config;
+  return block_level_config;
+}
+
 absl::StatusOr<std::optional<BlockLevelFusionConfig>>
 GetCollectiveBlockLevelFusionConfig(const se::DeviceDescription& device_info,
                                     const HloFusionInstruction* fusion_instr) {
   const HloInstruction* root = fusion_instr->fused_expression_root();
+
+  // For AllGather-start, the fusion root is a GetTupleElement that extracts
+  // the output from the AllGather-start tuple
+  if (root->opcode() == HloOpcode::kGetTupleElement &&
+      root->operand(0)->opcode() == HloOpcode::kAllGatherStart) {
+    return GetBlockLevelFusionConfigForAllGather(
+        device_info, Cast<HloAllGatherInstruction>(root->operand(0)));
+  }
+
   switch (root->opcode()) {
     case HloOpcode::kAllReduceStart:
       return GetBlockLevelFusionConfigForAllReduce(
           device_info, Cast<HloAllReduceInstruction>(root));
+    case HloOpcode::kAllGatherStart:
+      return GetBlockLevelFusionConfigForAllGather(
+          device_info, Cast<HloAllGatherInstruction>(root));
     default:
       return std::nullopt;
   }
@@ -625,14 +748,79 @@ absl::StatusOr<bool> TrySetGpuBackendConfigForCollective(
   return true;
 }
 
+// Returns unmanaged kernel arguments for all-gather
+absl::StatusOr<std::vector<Shape>> GetAllGatherUnmanagedKernelArguments(
+    const HloComputation* computation,
+    const HloAllGatherInstruction* all_gather) {
+  // Check if device_list is valid to prevent segfault
+  if (!all_gather->device_list()) {
+    return absl::InternalError(absl::StrCat(
+        "AllGather instruction ", all_gather->name(),
+        " has null device_list. Cannot generate Triton kernel arguments."));
+  }
+
+  const int32_t num_devices =
+      all_gather->device_list()->num_devices_per_group();
+
+  std::vector<Shape> unmanaged_arguments;
+  unmanaged_arguments.reserve(computation->num_parameters() +
+                              kNumCollectiveMetadataArgs);
+  // rank and signal_value
+  unmanaged_arguments.push_back(ShapeUtil::MakeShape(S32, {}));
+  unmanaged_arguments.push_back(ShapeUtil::MakeShape(S32, {}));
+
+  // Signal and scratch buffers (same as AllReduce)
+  static constexpr int32_t kMaxBlocksPerGrid = 24;
+  unmanaged_arguments.push_back(
+      ShapeUtil::MakeShape(S32, {num_devices, kMaxBlocksPerGrid}));
+
+  // Scratch buffers for AllGather
+  // Note: For AllGather, we need buffers to hold the gathered data
+
+  if (!computation) {
+    return absl::InternalError(
+        "Computation is null in GetAllGatherUnmanagedKernelArguments");
+  }
+
+  for (const HloInstruction* instr : computation->parameter_instructions()) {
+    if (!instr) {
+      return absl::InternalError(
+          "Null parameter instruction in GetAllGatherUnmanagedKernelArguments");
+    }
+    Shape shape =
+        ShapeUtil::InsertDimensionAtIndex(instr->shape(), 0, num_devices);
+    unmanaged_arguments.push_back(shape);
+  }
+
+  if (unmanaged_arguments.size() !=
+      computation->num_parameters() + kNumCollectiveMetadataArgs) {
+    return absl::InternalError(
+        absl::StrCat("AllGather unmanaged arguments size mismatch. Expected: ",
+                     computation->num_parameters() + kNumCollectiveMetadataArgs,
+                     ", Got: ", unmanaged_arguments.size()));
+  }
+  return unmanaged_arguments;
+}
+
 absl::StatusOr<std::vector<Shape>> GetCollectiveUnmanagedKernelArguments(
     const HloFusionInstruction* fusion) {
   const HloComputation* computation = fusion->fused_instructions_computation();
   const HloInstruction* root = computation->root_instruction();
+
+  // For AllGather-start wrapped in GetTupleElement
+  if (root->opcode() == HloOpcode::kGetTupleElement &&
+      root->operand(0)->opcode() == HloOpcode::kAllGatherStart) {
+    return GetAllGatherUnmanagedKernelArguments(
+        computation, Cast<HloAllGatherInstruction>(root->operand(0)));
+  }
+
   switch (root->opcode()) {
     case HloOpcode::kAllReduceStart:
       return GetAllReduceUnmanagedKernelArguments(
           computation, Cast<HloAllReduceInstruction>(root));
+    case HloOpcode::kAllGatherStart:
+      return GetAllGatherUnmanagedKernelArguments(
+          computation, Cast<HloAllGatherInstruction>(root));
     default:
       return std::vector<Shape>();
   }
@@ -681,6 +869,331 @@ mlir::LogicalResult RewriteAllReduce(mlir::stablehlo::AllReduceOp op,
                           maybe_context.status().message()));
   }
   return AllReduceEmitter::Emit(maybe_context.value(), rewriter);
+}
+
+// Context for AllGather emitter
+struct AllGatherEmitterContext {
+  mlir::stablehlo::AllGatherOp op;
+  int32_t num_input_output_args{0};
+  int32_t num_scratch_buffers{0};
+  xtile::EntryFuncOp xtile_entry_fn;
+  xtile::TensorValue input_tile;
+  xtile::ExtractTileOp input_extract;
+  llvm::SmallVector<int64_t, 4> non_tiled_input_shape;
+  PrimitiveType element_type;
+  int64_t world_size{0};
+  int64_t num_elements{0};
+  int64_t all_gather_dimension{0};
+};
+
+absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
+    mlir::stablehlo::AllGatherOp op) {
+  AllGatherEmitterContext ctx;
+  if (op.getOperands().size() != 1) {
+    return absl::InvalidArgumentError(
+        "AllGather op must have exactly one operand in order to be lowered "
+        "to triton.");
+  }
+
+  mlir::Type element_type =
+      mlir::cast<mlir::ShapedType>(op.getOperand(0).getType()).getElementType();
+  ctx.element_type = xla::ConvertMlirTypeToPrimitiveType(element_type);
+  if (ctx.element_type == PrimitiveType::PRIMITIVE_TYPE_INVALID) {
+    std::string type_string;
+    llvm::raw_string_ostream stream(type_string);
+    op.getOperand(0).print(stream);
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Could not convert operand type to a valid PrimitiveType. "
+        "Operand Type: %s",
+        type_string));
+  }
+
+  ctx.xtile_entry_fn = op->getParentOfType<xtile::EntryFuncOp>();
+  if (!ctx.xtile_entry_fn) {
+    return absl::InvalidArgumentError(
+        "AllGather op must be in an XTile entry function in order to be "
+        "lowered to triton.");
+  }
+
+  ctx.num_input_output_args = op->getNumOperands() * 2;
+  ctx.num_scratch_buffers = op->getNumOperands();
+  const int32_t expected_num_args =
+      ctx.num_input_output_args + ctx.num_scratch_buffers +
+      kNumCollectiveMetadataArgs + kNumTileIndexArgs;
+  if (ctx.xtile_entry_fn.getNumArguments() != expected_num_args) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("AllGather op must have ", expected_num_args,
+                     " arguments in order to "
+                     "be lowered to triton, but it has ",
+                     ctx.xtile_entry_fn.getNumArguments()));
+  }
+
+  ctx.input_tile = mlir::cast<xtile::TensorValue>(op->getOperand(0));
+  ctx.input_extract =
+      llvm::dyn_cast<xtile::ExtractTileOp>(ctx.input_tile.getDefiningOp());
+  if (!ctx.input_extract &&
+      ctx.input_tile.getDefiningOp()->getNumOperands() > 0) {
+    ctx.input_extract = llvm::dyn_cast<xtile::ExtractTileOp>(
+        ctx.input_tile.getDefiningOp()->getOperand(0).getDefiningOp());
+  }
+  if (!ctx.input_extract) {
+    return absl::InvalidArgumentError(
+        "AllGather op must have an extract tile op as operand in order to be "
+        "lowered to triton.");
+  }
+
+  ctx.non_tiled_input_shape = llvm::SmallVector<int64_t, 4>(
+      ctx.input_extract.getSource().getType().getShape());
+  ctx.num_elements = Product(ctx.non_tiled_input_shape);
+  // Get world_size from replica_groups, not from getAllGatherDim()
+  // getAllGatherDim() returns the dimension to gather along (e.g., 0)
+  // world_size is the number of devices in the group
+  ctx.world_size = op.getReplicaGroups().getShapedType().getDimSize(1);
+  ctx.all_gather_dimension = op.getAllGatherDim();
+  ctx.op = op;
+
+  return ctx;
+}
+
+class AllGatherEmitter {
+ public:
+  static mlir::LogicalResult Emit(AllGatherEmitterContext ctx,
+                                  mlir::PatternRewriter& rewriter) {
+    AllGatherEmitter emitter(std::move(ctx), rewriter);
+    if (auto result = emitter.Initialize(); !result.ok()) {
+      LOG(ERROR) << "Failed to initialize AllGatherEmitter: "
+                 << result.message();
+      return mlir::failure();
+    }
+    return emitter.EmitPersistentAllGather();
+  }
+
+ private:
+  AllGatherEmitter(AllGatherEmitterContext ctx, mlir::PatternRewriter& rewriter)
+      : ctx_(std::move(ctx)),
+        rewriter_(rewriter),
+        builder_(ctx_.op->getLoc(), rewriter) {}
+
+  absl::Status Initialize() {
+    CHECK(!initialized_);
+
+    // 1. Opaque arguments
+    const int32_t start_idx = ctx_.num_input_output_args;
+    device_rank_ = ctx_.xtile_entry_fn.getArgument(start_idx);
+    CHECK(device_rank_.getType().isInteger(32));
+    signal_value_ = ctx_.xtile_entry_fn.getArgument(start_idx + 1);
+    CHECK(signal_value_.getType().isInteger(32));
+    signal_buffers_ = ctx_.xtile_entry_fn.getArgument(start_idx + 2);
+    remote_input_buffers_ = ctx_.xtile_entry_fn.getArgument(start_idx + 3);
+
+    // 2. Constants and types
+    elem_type_ = mlir::getElementTypeOrSelf(ctx_.input_tile.getType());
+    elem_storage_type_ = xtile::StorageType(elem_type_);
+    ptr_to_i64_type_ =
+        ttir::PointerType::get(builder_.getI64Type(), kGlobalAddressSpace);
+    ptr_to_elem_type_ =
+        ttir::PointerType::get(elem_storage_type_, kGlobalAddressSpace);
+    TF_ASSIGN_OR_RETURN(layout_, xtile::GetPermutationMinorToMajor(
+                                     ctx_.input_extract.getSource().getType()));
+
+    // 3. Emit setup IR
+    remote_input_buffers_i64_ = ttir::BitcastOp::create(
+        builder_, ptr_to_i64_type_, remote_input_buffers_);
+    const mlir::Type i64_type = builder_.getI64Type();
+
+    mlir::Value buffer_index = arith::AndIOp::create(
+        builder_, i64_type,
+        arith::ExtSIOp::create(builder_, i64_type, signal_value_),
+        arith::ConstantOp::create(builder_, i64_type,
+                                  builder_.getI64IntegerAttr(1)));
+
+    const int64_t buffer_size = xla::RoundUpTo<uint64_t>(
+        ctx_.num_elements *
+            ShapeUtil::ByteSizeOfPrimitiveType(ctx_.element_type),
+        kXlaAllocatedBufferAlignBytes);
+    const int64_t elements_per_buffer =
+        buffer_size / ShapeUtil::ByteSizeOfPrimitiveType(ctx_.element_type);
+    buffer_offset_ = arith::MulIOp::create(
+        builder_, i64_type, buffer_index,
+        arith::ConstantOp::create(
+            builder_, i64_type,
+            builder_.getI64IntegerAttr(elements_per_buffer)));
+
+    initialized_ = true;
+    return absl::OkStatus();
+  }
+
+  mlir::Value GetRemoteBufferPtr(mlir::Value rank_idx) {
+    CHECK(initialized_);
+    mlir::Value remote_buf_ptr_addr = ttir::AddPtrOp::create(
+        builder_, ptr_to_i64_type_, remote_input_buffers_i64_, rank_idx);
+    mlir::Value remote_buf_i64 = ttir::LoadOp::create(
+        builder_, remote_buf_ptr_addr, ttir::CacheModifier::NONE,
+        ttir::EvictionPolicy::NORMAL,
+        /*isVolatile=*/false);
+    mlir::Value remote_buf_ptr_base =
+        ttir::IntToPtrOp::create(builder_, ptr_to_elem_type_, remote_buf_i64,
+                                 llvm::ArrayRef<mlir::NamedAttribute>{
+                                     xtile::GetDivisibilityAttr(builder_)});
+    mlir::Value remote_buf_ptr = ttir::AddPtrOp::create(
+        builder_, ptr_to_elem_type_, remote_buf_ptr_base, buffer_offset_);
+    return remote_buf_ptr;
+  }
+
+  xtile::TensorValue LoadTileForRank(mlir::Value rank_idx,
+                                     mlir::ValueRange offsets,
+                                     llvm::ArrayRef<int64_t> shape) {
+    CHECK(initialized_);
+    mlir::Value remote_buf_ptr = GetRemoteBufferPtr(rank_idx);
+    auto [ptrs, mask] = triton::CreateTensorOfPointersAndMask(
+        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_, offsets,
+        shape, ctx_.input_extract.getStrides(),
+        /*reduced_dims=*/{}, shape);
+
+    auto next_tile = mlir::cast<xtile::TensorValue>(
+        ttir::LoadOp::create(builder_, ptrs, mask, /*other=*/mlir::Value(),
+                             ttir::CacheModifier::NONE,
+                             ttir::EvictionPolicy::NORMAL,
+                             /*isVolatile=*/false)
+            .getResult());
+
+    if (elem_storage_type_ != elem_type_) {
+      next_tile = mlir::cast<xtile::TensorValue>(
+          xtile::Cast(builder_, next_tile, elem_type_));
+    }
+    return next_tile;
+  }
+
+  mlir::LogicalResult EmitCopyToSymmetric(mlir::Value tile_to_store,
+                                          mlir::ValueRange offsets,
+                                          llvm::ArrayRef<int64_t> shape) {
+    CHECK(initialized_);
+    mlir::Value remote_buf_ptr = GetRemoteBufferPtr(device_rank_);
+
+    mlir::Value storage_tile = tile_to_store;
+    if (elem_storage_type_ != elem_type_) {
+      storage_tile = mlir::cast<xtile::TensorValue>(
+          xtile::Cast(builder_, tile_to_store, elem_storage_type_));
+    }
+
+    auto [ptrs, mask] = triton::CreateTensorOfPointersAndMask(
+        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_, offsets,
+        shape, ctx_.input_extract.getStrides(),
+        /*reduced_dims=*/{}, shape);
+
+    ttir::StoreOp::create(builder_, ptrs, storage_tile, mask,
+                          ttir::CacheModifier::NONE,
+                          ttir::EvictionPolicy::NORMAL);
+    return mlir::success();
+  }
+
+  mlir::LogicalResult EmitSync(mlir::Value signal_value) {
+    CHECK(initialized_);
+    mlir::triton::gpu::BarrierOp::create(builder_,
+                                         mlir::triton::gpu::AddrSpace::Local);
+    mtx::BlockBarrierOp::create(builder_, signal_buffers_, device_rank_,
+                                signal_value,
+                                builder_.getI32IntegerAttr(ctx_.world_size));
+    return mlir::success();
+  }
+
+  mlir::LogicalResult EmitPersistentAllGather() {
+    CHECK(initialized_);
+
+    // For AllGather, the tiling framework processes the output in tiles
+    // Each tile corresponds to a portion of the concatenated output
+    // The block ID (program ID) determines which portion of the output this
+    // block processes
+    //
+    // For example, with 8 ranks and output size 8192:
+    // - Block 0 processes output[0:1024] (from rank 0's input)
+    // - Block 1 processes output[1024:2048] (from rank 1's input)
+    // - Block 7 processes output[7168:8192] (from rank 7's input)
+    //
+    // We use the program ID to determine which rank's data to load
+
+    llvm::ArrayRef<int64_t> shape = ctx_.input_tile.getType().getShape();
+
+    // Get the block/program ID to determine which rank's data to load
+    mlir::Value program_id = ttir::GetProgramIdOp::create(builder_, 0);
+
+    // For AllGather, each block corresponds to one rank's data
+    // source_rank = program_id (since we have one block per rank)
+    mlir::Value source_rank_i32 = program_id;
+    mlir::Value source_rank = arith::ExtSIOp::create(
+        builder_, builder_.getI64Type(), source_rank_i32);
+
+    // 1. Copy local tile to symmetric buffer (all ranks do this)
+    if (mlir::failed(EmitCopyToSymmetric(
+            ctx_.input_tile, ctx_.input_extract.getOffsets(),
+            ctx_.input_tile.getType().getShape()))) {
+      return rewriter_.notifyMatchFailure(ctx_.op,
+                                          "Failed to emit copy to symmetric");
+    }
+
+    // 2. Synchronization: Wait for all ranks to complete the copy
+    if (mlir::failed(EmitSync(signal_value_))) {
+      return rewriter_.notifyMatchFailure(ctx_.op,
+                                          "Failed to emit sync for all-gather");
+    }
+
+    // 3. Load the appropriate rank's data based on this block's program ID
+    // Calculate the local offset within the source rank's buffer
+    // For the gather dimension, offset is always 0 (we load the full input
+    // size) For other dimensions, use the tile offset from input_extract
+    mlir::ValueRange tile_offsets = ctx_.input_extract.getOffsets();
+    llvm::SmallVector<mlir::Value> local_offsets;
+    for (size_t i = 0; i < ctx_.non_tiled_input_shape.size(); ++i) {
+      if (i == ctx_.all_gather_dimension) {
+        // For gather dimension, always start at 0 in the source rank's buffer
+        local_offsets.push_back(arith::ConstantOp::create(
+            builder_, builder_.getIndexType(), builder_.getIndexAttr(0)));
+      } else {
+        // For other dimensions, use the tile offset
+        local_offsets.push_back(tile_offsets[i]);
+      }
+    }
+
+    xtile::TensorValue result =
+        LoadTileForRank(source_rank, local_offsets, shape);
+
+    // Replace the AllGather op with the loaded result
+    rewriter_.replaceOp(ctx_.op, result);
+
+    return mlir::success();
+  }
+
+  AllGatherEmitterContext ctx_;
+  mlir::PatternRewriter& rewriter_;
+  mlir::ImplicitLocOpBuilder builder_;
+
+  mlir::Value device_rank_;
+  mlir::Value signal_value_;
+  mlir::Value signal_buffers_;
+  mlir::Value remote_input_buffers_;
+  mlir::Value remote_input_buffers_i64_;
+  mlir::Value buffer_offset_;
+
+  llvm::SmallVector<int64_t> layout_;
+  mlir::Type elem_type_;
+  mlir::Type elem_storage_type_;
+  ttir::PointerType ptr_to_i64_type_;
+  ttir::PointerType ptr_to_elem_type_;
+
+  bool initialized_ = false;
+};
+
+mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
+                                     mlir::PatternRewriter& rewriter) {
+  const mlir::Location loc = op->getLoc();
+  absl::StatusOr<AllGatherEmitterContext> maybe_context =
+      CreateAllGatherEmitterContext(op);
+  if (!maybe_context.ok()) {
+    return rewriter.notifyMatchFailure(
+        loc, absl::StrCat("Failed to create AllGatherEmitterContext: ",
+                          maybe_context.status().message()));
+  }
+  return AllGatherEmitter::Emit(maybe_context.value(), rewriter);
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -312,9 +312,8 @@ absl::StatusOr<std::vector<Shape>> GetAllReduceUnmanagedKernelArguments(
   // - num_devices * num_blocks for the signal buffer.
   // - num_devices * shape of the parameter for scratch buffers.
   // Since number of blocks is not known in this context we use a constant.
-  static constexpr int32_t kMaxBlocksPerGrid = 24;
   unmanaged_arguments.push_back(
-      ShapeUtil::MakeShape(S32, {num_devices, kMaxBlocksPerGrid}));
+      ShapeUtil::MakeShape(S32, {num_devices, kMaxCollectiveBlocksPerGrid}));
   // Scratch buffers
   for (const HloInstruction* instr : computation->parameter_instructions()) {
     Shape shape =
@@ -595,8 +594,6 @@ class AllReduceEmitter {
   bool initialized_ = false;
 };
 
-}  // namespace
-
 llvm::SmallVector<int64_t> GreedyPowerOfTwoTiles(const Shape& output_shape,
                                                  int32_t num_blocks) {
   CHECK_GT(num_blocks, 0) << "num_blocks must be positive. Was " << num_blocks;
@@ -667,6 +664,8 @@ llvm::SmallVector<int64_t> GreedyPowerOfTwoTiles(const Shape& output_shape,
   return tile_sizes;
 }
 
+}  // namespace
+
 // Returns the block level fusion config for all-gather if supported.
 absl::StatusOr<std::optional<BlockLevelFusionConfig>>
 GetBlockLevelFusionConfigForAllGather(
@@ -677,16 +676,16 @@ GetBlockLevelFusionConfigForAllGather(
            ->config()
            .debug_options()
            .xla_gpu_unsupported_use_all_gather_triton_backend()) {
-    LOG(INFO) << "AllGather Triton backend is not enabled. "
-              << "Set xla_gpu_unsupported_use_all_gather_triton_backend=true "
-                 "to enable.";
+    VLOG(3) << "AllGather Triton backend is not enabled. "
+            << "Set xla_gpu_unsupported_use_all_gather_triton_backend=true "
+               "to enable.";
     return std::nullopt;
   }
 
   // Check if replica groups are present (required for Triton backend)
   if (all_gather->device_list().replica_groups().empty()) {
-    LOG(INFO) << "Replica groups are empty for " << all_gather->name()
-              << ". Codegen will not be supported.";
+    VLOG(3) << "Replica groups are empty for " << all_gather->name()
+            << ". Codegen will not be supported.";
     return std::nullopt;
   }
 
@@ -711,8 +710,8 @@ GetBlockLevelFusionConfigForAllGather(
   }
 
   if (!is_supported) {
-    LOG(INFO) << "Collective codegen requires CUDA compute capability >= 9.0 "
-              << "or ROCm with Triton support. Codegen will not be supported.";
+    VLOG(3) << "Collective codegen requires CUDA compute capability >= 9.0 "
+            << "or ROCm with Triton support. Codegen will not be supported.";
     return std::nullopt;
   }
 
@@ -725,9 +724,9 @@ GetBlockLevelFusionConfigForAllGather(
   // Triton primarily supports floating-point types and some integer types
   // Unsigned integer types (u32, u16, etc.) are not well supported
   if (element_type == U32 || element_type == U16 || element_type == U64) {
-    LOG(INFO) << "AllGather: Unsigned integer type "
-              << PrimitiveType_Name(element_type)
-              << " is not supported by Triton backend. Falling back to NCCL.";
+    VLOG(3) << "AllGather: Unsigned integer type "
+            << PrimitiveType_Name(element_type)
+            << " is not supported by Triton backend. Falling back to NCCL.";
     return std::nullopt;
   }
 
@@ -736,9 +735,9 @@ GetBlockLevelFusionConfigForAllGather(
   // tiling
   const int64_t alignment_requirement = se::gpu::kNumElementsPerThread;
   if (num_elements % alignment_requirement != 0) {
-    LOG(INFO) << "AllGather: Number of elements (" << num_elements
-              << ") is not aligned to the alignment requirement ("
-              << alignment_requirement << "). Falling back to NCCL.";
+    VLOG(3) << "AllGather: Number of elements (" << num_elements
+            << ") is not aligned to the alignment requirement ("
+            << alignment_requirement << "). Falling back to NCCL.";
     return std::nullopt;
   }
 
@@ -747,7 +746,6 @@ GetBlockLevelFusionConfigForAllGather(
   // elements_per_rank = num_elements
   static constexpr int64_t kWarpSize = 32;
   static constexpr uint64_t kMaxThreadsPerBlock = 512;
-  static constexpr int64_t kMaxBlocksPerGrid = 32;
 
   const int64_t elements_per_rank =
       num_elements;  // AllGather doesn't split work like TwoShot
@@ -758,8 +756,9 @@ GetBlockLevelFusionConfigForAllGather(
   const int64_t threads_per_block =
       std::min(kMaxThreadsPerBlock,
                static_cast<uint64_t>(llvm::PowerOf2Ceil(total_threads)));
-  const int64_t blocks_per_grid = std::min(
-      kMaxBlocksPerGrid, CeilOfRatio(total_threads, threads_per_block));
+  const int64_t blocks_per_grid =
+      std::min(kMaxCollectiveBlocksPerGrid,
+               CeilOfRatio(total_threads, threads_per_block));
   const LaunchDimensions launch_dims(blocks_per_grid, threads_per_block);
 
   // Use input shape for tiling (output shape may not have layout properly set)
@@ -842,9 +841,8 @@ absl::StatusOr<std::vector<Shape>> GetAllGatherUnmanagedKernelArguments(
   unmanaged_arguments.push_back(ShapeUtil::MakeShape(S32, {}));
 
   // Signal and scratch buffers (same as AllReduce)
-  static constexpr int32_t kMaxBlocksPerGrid = 24;
   unmanaged_arguments.push_back(
-      ShapeUtil::MakeShape(S32, {num_devices, kMaxBlocksPerGrid}));
+      ShapeUtil::MakeShape(S32, {num_devices, kMaxCollectiveBlocksPerGrid}));
 
   // Scratch buffers for AllGather
   // Note: For AllGather, we need buffers to hold the gathered data
@@ -1258,10 +1256,18 @@ class AllGatherEmitter {
     const int64_t block_size_n = shape.size() > 1 ? shape[1] : 1;
 
     // Calculate total number of tiles needed
-    const int64_t total_m = ctx_.non_tiled_input_shape[0] * ctx_.world_size;
-    const int64_t total_n = ctx_.non_tiled_input_shape.size() > 1
-                                ? ctx_.non_tiled_input_shape[1]
-                                : 1;
+    // The gather dimension is multiplied by world_size, other dimensions remain
+    // the same
+    const int64_t total_m =
+        ctx_.all_gather_dimension == 0
+            ? ctx_.non_tiled_input_shape[0] * ctx_.world_size
+            : ctx_.non_tiled_input_shape[0];
+    const int64_t total_n =
+        ctx_.non_tiled_input_shape.size() > 1
+            ? (ctx_.all_gather_dimension == 1
+                   ? ctx_.non_tiled_input_shape[1] * ctx_.world_size
+                   : ctx_.non_tiled_input_shape[1])
+            : 1;
 
     const int64_t num_pid_m = (total_m + block_size_m - 1) / block_size_m;
     const int64_t num_pid_n = (total_n + block_size_n - 1) / block_size_n;
@@ -1309,15 +1315,24 @@ class AllGatherEmitter {
     mlir::Value pid_n =
         arith::DivSIOp::create(builder_, tile_id_mod, group_size_m_actual);
 
-    // Determine which rank's data to load based on pid_m
-    // Each rank owns M/world_size rows
-    const int64_t rows_per_rank = ctx_.non_tiled_input_shape[0];
-    mlir::Value rows_per_rank_val = arith::ConstantOp::create(
-        builder_, builder_.getI32Type(),
-        builder_.getI32IntegerAttr(rows_per_rank / block_size_m));
+    // Determine which rank's data to load based on the gather dimension
+    // Each rank owns (gather_dim_size) elements along the gather dimension
+    const int64_t gather_dim_size =
+        ctx_.non_tiled_input_shape[ctx_.all_gather_dimension];
+    const int64_t block_size_gather =
+        ctx_.all_gather_dimension == 0 ? block_size_m : block_size_n;
+    // Calculate number of blocks per rank along the gather dimension
+    // Use max(1, ...) to avoid division by zero
+    const int64_t blocks_per_rank =
+        std::max(int64_t{1}, gather_dim_size / block_size_gather);
+    mlir::Value elements_per_rank_val =
+        arith::ConstantOp::create(builder_, builder_.getI32Type(),
+                                  builder_.getI32IntegerAttr(blocks_per_rank));
 
+    // Determine source rank based on which dimension is the gather dimension
+    mlir::Value pid_gather = ctx_.all_gather_dimension == 0 ? pid_m : pid_n;
     mlir::Value source_rank_i32 =
-        arith::DivSIOp::create(builder_, pid_m, rows_per_rank_val);
+        arith::DivSIOp::create(builder_, pid_gather, elements_per_rank_val);
     mlir::Value source_rank = arith::ExtSIOp::create(
         builder_, builder_.getI64Type(), source_rank_i32);
 
@@ -1339,9 +1354,12 @@ class AllGatherEmitter {
     mlir::ValueRange tile_offsets = ctx_.input_extract.getOffsets();
     llvm::SmallVector<mlir::Value> local_offsets;
 
-    // For M dimension (gather dimension), calculate offset within source rank
+    // For M dimension, calculate offset within source rank if it's the gather
+    // dimension
     mlir::Value local_pid_m =
-        arith::RemSIOp::create(builder_, pid_m, rows_per_rank_val);
+        ctx_.all_gather_dimension == 0
+            ? arith::RemSIOp::create(builder_, pid_m, elements_per_rank_val)
+            : pid_m;
     mlir::Value m_offset = arith::MulIOp::create(
         builder_, local_pid_m,
         arith::ConstantOp::create(builder_, builder_.getI32Type(),
@@ -1349,10 +1367,15 @@ class AllGatherEmitter {
     local_offsets.push_back(arith::IndexCastOp::create(
         builder_, builder_.getIndexType(), m_offset));
 
-    // For N dimension, use pid_n
+    // For N dimension, calculate offset within source rank if it's the gather
+    // dimension
     if (ctx_.non_tiled_input_shape.size() > 1) {
+      mlir::Value local_pid_n =
+          ctx_.all_gather_dimension == 1
+              ? arith::RemSIOp::create(builder_, pid_n, elements_per_rank_val)
+              : pid_n;
       mlir::Value n_offset = arith::MulIOp::create(
-          builder_, pid_n,
+          builder_, local_pid_n,
           arith::ConstantOp::create(builder_, builder_.getI32Type(),
                                     builder_.getI32IntegerAttr(block_size_n)));
       local_offsets.push_back(arith::IndexCastOp::create(

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -28,8 +28,10 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/MathExtras.h"
+#include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -46,6 +48,7 @@ limitations under the License.
 #include "mlir/Support/LLVM.h"
 #include "stablehlo/dialect/StablehloOps.h"
 #include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"
+#include "xla/backends/gpu/codegen/triton/lowering_util.h"
 #include "xla/backends/gpu/runtime/all_reduce.h"
 #include "xla/codegen/xtile/codegen/emitter_helpers.h"
 #include "xla/codegen/xtile/ir/xtile_ops.h"
@@ -54,8 +57,10 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/mlir/utils/type_util.h"
 #include "xla/service/collective_ops_utils.h"
 #include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/gpu_constants.h"
 #include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/launch_dimensions.h"
 #include "xla/shape.h"
@@ -679,21 +684,14 @@ GetBlockLevelFusionConfigForAllGather(
   }
 
   // Check if replica groups are present (required for Triton backend)
-  if (!all_gather->device_list()) {
-    LOG(INFO) << "AllGather device_list is null for " << all_gather->name()
-              << ". This likely means replica_groups were not properly set. "
-              << "Codegen will not be supported.";
-    return std::nullopt;
-  }
-
-  if (all_gather->device_list()->replica_groups().empty()) {
+  if (all_gather->device_list().replica_groups().empty()) {
     LOG(INFO) << "Replica groups are empty for " << all_gather->name()
               << ". Codegen will not be supported.";
     return std::nullopt;
   }
 
   const int64_t num_devices =
-      all_gather->device_list()->num_devices_per_group();
+      all_gather->device_list().num_devices_per_group();
   if (!llvm::has_single_bit(static_cast<uint64_t>(num_devices))) {
     VLOG(1) << "Number of devices is not a power of 2 for "
             << all_gather->name() << ". Codegen will not be supported.";
@@ -835,15 +833,8 @@ absl::StatusOr<bool> TrySetGpuBackendConfigForCollective(
 absl::StatusOr<std::vector<Shape>> GetAllGatherUnmanagedKernelArguments(
     const HloComputation* computation,
     const HloAllGatherInstruction* all_gather) {
-  // Check if device_list is valid to prevent segfault
-  if (!all_gather->device_list()) {
-    return absl::InternalError(absl::StrCat(
-        "AllGather instruction ", all_gather->name(),
-        " has null device_list. Cannot generate Triton kernel arguments."));
-  }
-
   const int32_t num_devices =
-      all_gather->device_list()->num_devices_per_group();
+      all_gather->device_list().num_devices_per_group();
 
   std::vector<Shape> unmanaged_arguments;
   unmanaged_arguments.reserve(computation->num_parameters() +

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -269,7 +269,7 @@ GetBlockLevelFusionConfigForAllReduce(
     return std::nullopt;
   }
   const Shape& output_shape = all_reduce->shape();
-  const LaunchDimensions launch_dims = AllReduceLaunchDimensions(
+  const LaunchDimensions launch_dims = CollectiveLaunchDimensions(
       all_reduce_info->num_elements, all_reduce_info->num_devices,
       all_reduce_info->all_reduce_strategy);
   BlockLevelFusionConfig block_level_config;

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -1245,96 +1245,81 @@ class AllGatherEmitter {
     // Get the tile/block ID
     mlir::Value tile_id = ttir::GetProgramIdOp::create(builder_, 0);
 
-    // Calculate num_pid_m and num_pid_n based on the input shape and tile shape
-    // For simplicity, assume 2D tiling with M and N dimensions
-    // num_pid_m = ceil(M / BLOCK_SIZE_M)
-    // num_pid_n = ceil(N / BLOCK_SIZE_N)
+    // Calculate the number of tiles needed in each dimension
+    // The gather dimension is multiplied by world_size
+    llvm::SmallVector<int64_t> num_tiles_per_dim;
+    int64_t total_tiles = 1;
+    
+    for (size_t i = 0; i < ctx_.non_tiled_input_shape.size(); ++i) {
+      int64_t dim_size = ctx_.non_tiled_input_shape[i];
+      if (i == ctx_.all_gather_dimension) {
+        dim_size *= ctx_.world_size;
+      }
+      
+      int64_t block_size = i < shape.size() ? shape[i] : 1;
+      int64_t num_tiles = (dim_size + block_size - 1) / block_size;
+      num_tiles_per_dim.push_back(num_tiles);
+      total_tiles *= num_tiles;
+    }
 
-    // For AllGather, we need to determine the number of tiles in each dimension
-    // This depends on the tile shape and the total output shape
-    const int64_t block_size_m = shape.size() > 0 ? shape[0] : 1;
-    const int64_t block_size_n = shape.size() > 1 ? shape[1] : 1;
+    // For swizzling, we use the first two dimensions (M and N)
+    const int64_t num_pid_m = num_tiles_per_dim.size() > 0 ? num_tiles_per_dim[0] : 1;
+    const int64_t num_pid_n = num_tiles_per_dim.size() > 1 ? num_tiles_per_dim[1] : 1;
 
-    // Calculate total number of tiles needed
-    // The gather dimension is multiplied by world_size, other dimensions remain
-    // the same
-    const int64_t total_m =
-        ctx_.all_gather_dimension == 0
-            ? ctx_.non_tiled_input_shape[0] * ctx_.world_size
-            : ctx_.non_tiled_input_shape[0];
-    const int64_t total_n =
-        ctx_.non_tiled_input_shape.size() > 1
-            ? (ctx_.all_gather_dimension == 1
-                   ? ctx_.non_tiled_input_shape[1] * ctx_.world_size
-                   : ctx_.non_tiled_input_shape[1])
-            : 1;
-
-    const int64_t num_pid_m = (total_m + block_size_m - 1) / block_size_m;
-    const int64_t num_pid_n = (total_n + block_size_n - 1) / block_size_n;
-
-    // Create constants
+    // Create constants (always needed)
     mlir::Value num_pid_m_val = arith::ConstantOp::create(
         builder_, builder_.getI32Type(), builder_.getI32IntegerAttr(num_pid_m));
     mlir::Value num_pid_n_val = arith::ConstantOp::create(
         builder_, builder_.getI32Type(), builder_.getI32IntegerAttr(num_pid_n));
-    mlir::Value group_size_m_val =
-        arith::ConstantOp::create(builder_, builder_.getI32Type(),
-                                  builder_.getI32IntegerAttr(group_size_m));
 
-    // Swizzled tiling calculation
-    // num_pid_in_group = GROUP_SIZE_M * num_pid_n
-    mlir::Value num_pid_in_group =
-        arith::MulIOp::create(builder_, group_size_m_val, num_pid_n_val);
+    mlir::Value pid_m, pid_n;
+    
+    // If both M and N dimensions have only 1 tile, swizzling is unnecessary
+    // Just use tile_id directly for higher dimensions
+    if (num_pid_m == 1 && num_pid_n == 1) {
+      // No swizzling needed - both pid_m and pid_n are always 0
+      pid_m = arith::ConstantOp::create(builder_, builder_.getI32Type(),
+                                        builder_.getI32IntegerAttr(0));
+      pid_n = arith::ConstantOp::create(builder_, builder_.getI32Type(),
+                                        builder_.getI32IntegerAttr(0));
+    } else {
+      mlir::Value group_size_m_val =
+          arith::ConstantOp::create(builder_, builder_.getI32Type(),
+                                    builder_.getI32IntegerAttr(group_size_m));
 
-    // group_id = tile_id // num_pid_in_group
-    mlir::Value group_id =
-        arith::DivSIOp::create(builder_, tile_id, num_pid_in_group);
+      // Swizzled tiling calculation
+      // num_pid_in_group = GROUP_SIZE_M * num_pid_n
+      mlir::Value num_pid_in_group =
+          arith::MulIOp::create(builder_, group_size_m_val, num_pid_n_val);
 
-    // first_pid_m = group_id * GROUP_SIZE_M
-    mlir::Value first_pid_m =
-        arith::MulIOp::create(builder_, group_id, group_size_m_val);
+      // group_id = tile_id // num_pid_in_group
+      mlir::Value group_id =
+          arith::DivSIOp::create(builder_, tile_id, num_pid_in_group);
 
-    // group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
-    mlir::Value remaining_m =
-        arith::SubIOp::create(builder_, num_pid_m_val, first_pid_m);
-    mlir::Value cmp = arith::CmpIOp::create(builder_, arith::CmpIPredicate::slt,
-                                            remaining_m, group_size_m_val);
-    mlir::Value group_size_m_actual =
-        arith::SelectOp::create(builder_, cmp, remaining_m, group_size_m_val);
+      // first_pid_m = group_id * GROUP_SIZE_M
+      mlir::Value first_pid_m =
+          arith::MulIOp::create(builder_, group_id, group_size_m_val);
 
-    // tile_id % num_pid_in_group
-    mlir::Value tile_id_mod =
-        arith::RemSIOp::create(builder_, tile_id, num_pid_in_group);
+      // group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+      mlir::Value remaining_m =
+          arith::SubIOp::create(builder_, num_pid_m_val, first_pid_m);
+      mlir::Value cmp = arith::CmpIOp::create(builder_, arith::CmpIPredicate::slt,
+                                              remaining_m, group_size_m_val);
+      mlir::Value group_size_m_actual =
+          arith::SelectOp::create(builder_, cmp, remaining_m, group_size_m_val);
 
-    // pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
-    mlir::Value offset_m =
-        arith::RemSIOp::create(builder_, tile_id_mod, group_size_m_actual);
-    mlir::Value pid_m = arith::AddIOp::create(builder_, first_pid_m, offset_m);
+      // tile_id % num_pid_in_group
+      mlir::Value tile_id_mod =
+          arith::RemSIOp::create(builder_, tile_id, num_pid_in_group);
 
-    // pid_n = (tile_id % num_pid_in_group) // group_size_m
-    mlir::Value pid_n =
-        arith::DivSIOp::create(builder_, tile_id_mod, group_size_m_actual);
+      // pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+      mlir::Value offset_m =
+          arith::RemSIOp::create(builder_, tile_id_mod, group_size_m_actual);
+      pid_m = arith::AddIOp::create(builder_, first_pid_m, offset_m);
 
-    // Determine which rank's data to load based on the gather dimension
-    // Each rank owns (gather_dim_size) elements along the gather dimension
-    const int64_t gather_dim_size =
-        ctx_.non_tiled_input_shape[ctx_.all_gather_dimension];
-    const int64_t block_size_gather =
-        ctx_.all_gather_dimension == 0 ? block_size_m : block_size_n;
-    // Calculate number of blocks per rank along the gather dimension
-    // Use max(1, ...) to avoid division by zero
-    const int64_t blocks_per_rank =
-        std::max(int64_t{1}, gather_dim_size / block_size_gather);
-    mlir::Value elements_per_rank_val =
-        arith::ConstantOp::create(builder_, builder_.getI32Type(),
-                                  builder_.getI32IntegerAttr(blocks_per_rank));
-
-    // Determine source rank based on which dimension is the gather dimension
-    mlir::Value pid_gather = ctx_.all_gather_dimension == 0 ? pid_m : pid_n;
-    mlir::Value source_rank_i32 =
-        arith::DivSIOp::create(builder_, pid_gather, elements_per_rank_val);
-    mlir::Value source_rank = arith::ExtSIOp::create(
-        builder_, builder_.getI64Type(), source_rank_i32);
+      // pid_n = (tile_id % num_pid_in_group) // group_size_m
+      pid_n = arith::DivSIOp::create(builder_, tile_id_mod, group_size_m_actual);
+    }
 
     // 1. Copy local tile to symmetric buffer (all ranks do this)
     if (mlir::failed(EmitCopyToSymmetric(
@@ -1350,42 +1335,78 @@ class AllGatherEmitter {
                                           "Failed to emit sync for all-gather");
     }
 
-    // 3. Calculate offsets based on swizzled pid_m and pid_n
-    mlir::ValueRange tile_offsets = ctx_.input_extract.getOffsets();
+    // 3. Decompose into per-dimension PIDs
+    llvm::SmallVector<mlir::Value> pids;
+    
+    for (size_t i = 0; i < ctx_.non_tiled_input_shape.size(); ++i) {
+      if (i < 2) {
+        // For first two dimensions, use the swizzled values
+        pids.push_back(i == 0 ? pid_m : pid_n);
+      } else {
+        // For higher dimensions, extract from tile_id
+        // Calculate stride: product of all previous dimension tile counts
+        int64_t stride = 1;
+        for (size_t j = 0; j < i; ++j) {
+          stride *= num_tiles_per_dim[j];
+        }
+        
+        mlir::Value stride_val = arith::ConstantOp::create(
+            builder_, builder_.getI32Type(),
+            builder_.getI32IntegerAttr(stride));
+        mlir::Value num_tiles_val = arith::ConstantOp::create(
+            builder_, builder_.getI32Type(),
+            builder_.getI32IntegerAttr(num_tiles_per_dim[i]));
+        
+        // pid_i = (tile_id / stride) % num_tiles_i
+        mlir::Value pid_i = arith::DivSIOp::create(builder_, tile_id, stride_val);
+        pid_i = arith::RemSIOp::create(builder_, pid_i, num_tiles_val);
+        pids.push_back(pid_i);
+      }
+    }
+    
+    // Now calculate offsets and source rank for each dimension
     llvm::SmallVector<mlir::Value> local_offsets;
-
-    // For M dimension, calculate offset within source rank if it's the gather
-    // dimension
-    mlir::Value local_pid_m =
-        ctx_.all_gather_dimension == 0
-            ? arith::RemSIOp::create(builder_, pid_m, elements_per_rank_val)
-            : pid_m;
-    mlir::Value m_offset = arith::MulIOp::create(
-        builder_, local_pid_m,
-        arith::ConstantOp::create(builder_, builder_.getI32Type(),
-                                  builder_.getI32IntegerAttr(block_size_m)));
-    local_offsets.push_back(arith::IndexCastOp::create(
-        builder_, builder_.getIndexType(), m_offset));
-
-    // For N dimension, calculate offset within source rank if it's the gather
-    // dimension
-    if (ctx_.non_tiled_input_shape.size() > 1) {
-      mlir::Value local_pid_n =
-          ctx_.all_gather_dimension == 1
-              ? arith::RemSIOp::create(builder_, pid_n, elements_per_rank_val)
-              : pid_n;
-      mlir::Value n_offset = arith::MulIOp::create(
-          builder_, local_pid_n,
-          arith::ConstantOp::create(builder_, builder_.getI32Type(),
-                                    builder_.getI32IntegerAttr(block_size_n)));
-      local_offsets.push_back(arith::IndexCastOp::create(
-          builder_, builder_.getIndexType(), n_offset));
+    mlir::Value source_rank_i32 = nullptr;
+    
+    for (size_t i = 0; i < ctx_.non_tiled_input_shape.size(); ++i) {
+      mlir::Value pid = pids[i];
+      int64_t block_size = i < shape.size() ? shape[i] : 1;
+      int64_t dim_size = ctx_.non_tiled_input_shape[i];
+      
+      if (i == ctx_.all_gather_dimension) {
+        // This is the gather dimension
+        int64_t blocks_per_rank = std::max(int64_t{1}, 
+            (dim_size + block_size - 1) / block_size);
+        mlir::Value blocks_per_rank_val = arith::ConstantOp::create(
+            builder_, builder_.getI32Type(),
+            builder_.getI32IntegerAttr(blocks_per_rank));
+        
+        // source_rank = pid / blocks_per_rank
+        source_rank_i32 = arith::DivSIOp::create(builder_, pid, blocks_per_rank_val);
+        
+        // local_pid = pid % blocks_per_rank
+        mlir::Value local_pid = arith::RemSIOp::create(builder_, pid, blocks_per_rank_val);
+        
+        // offset = local_pid * block_size
+        mlir::Value offset = arith::MulIOp::create(
+            builder_, local_pid,
+            arith::ConstantOp::create(builder_, builder_.getI32Type(),
+                                      builder_.getI32IntegerAttr(block_size)));
+        local_offsets.push_back(arith::IndexCastOp::create(
+            builder_, builder_.getIndexType(), offset));
+      } else {
+        // Not the gather dimension - use pid directly
+        mlir::Value offset = arith::MulIOp::create(
+            builder_, pid,
+            arith::ConstantOp::create(builder_, builder_.getI32Type(),
+                                      builder_.getI32IntegerAttr(block_size)));
+        local_offsets.push_back(arith::IndexCastOp::create(
+            builder_, builder_.getIndexType(), offset));
+      }
     }
-
-    // Add remaining dimensions from tile_offsets
-    for (size_t i = 2; i < ctx_.non_tiled_input_shape.size(); ++i) {
-      local_offsets.push_back(tile_offsets[i]);
-    }
+    
+    mlir::Value source_rank = arith::ExtSIOp::create(
+        builder_, builder_.getI64Type(), source_rank_i32);
 
     xtile::TensorValue result =
         LoadTileForRank(source_rank, local_offsets, shape);
@@ -1430,7 +1451,7 @@ mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
   }
 
   VLOG(3) << "AllGatherEmitter::Emit for all-gather";
-  return AllGatherEmitter::Emit(maybe_context.value(), rewriter);
+  return AllGatherEmitter::Emit(maybe_context.value(), rewriter, true);
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -627,7 +627,46 @@ GetBlockLevelFusionConfigForAllGather(
     const HloAllGatherInstruction* all_gather) {
   LOG(INFO) << "GetBlockLevelFusionConfigForAllGather called for: "
             << all_gather->name();
-
+  LOG(INFO) << "AllGather instruction details:";
+  LOG(INFO) << "  - device_list() is null: " << (all_gather->device_list() == nullptr);
+  if (all_gather->device_list()) {
+    LOG(INFO) << "  - replica_groups().size(): " << all_gather->device_list()->replica_groups().size();
+    LOG(INFO) << "  - num_devices_per_group(): " << all_gather->device_list()->num_devices_per_group();
+  }
+  LOG(INFO) << "  - HLO: " << all_gather->ToString();
+  
+  // Check if the Triton AllGather backend is enabled
+  if (!all_gather->GetModule()
+           ->config()
+           .debug_options()
+           .xla_gpu_unsupported_use_all_gather_triton_backend()) {
+    LOG(INFO) << "AllGather Triton backend is not enabled. "
+            << "Set xla_gpu_unsupported_use_all_gather_triton_backend=true to enable.";
+    return std::nullopt;
+  }
+  
+  // Check if replica groups are present (required for Triton backend)
+  if (!all_gather->device_list()) {
+    LOG(INFO) << "AllGather device_list is null for " << all_gather->name()
+            << ". This likely means replica_groups were not properly set. "
+            << "Codegen will not be supported.";
+    return std::nullopt;
+  }
+  
+  if (all_gather->device_list()->replica_groups().empty()) {
+    LOG(INFO) << "Replica groups are empty for " << all_gather->name()
+            << ". Codegen will not be supported.";
+    return std::nullopt;
+  }
+  
+  const int64_t num_devices =
+      all_gather->device_list()->num_devices_per_group();
+  if (!llvm::has_single_bit(static_cast<uint64_t>(num_devices))) {
+    VLOG(1) << "Number of devices is not a power of 2 for "
+            << all_gather->name() << ". Codegen will not be supported.";
+    return std::nullopt;
+  }
+  
   // Check if the device supports Triton collective codegen
   bool is_supported = false;
 
@@ -642,62 +681,73 @@ GetBlockLevelFusionConfigForAllGather(
   }
 
   if (!is_supported) {
-    VLOG(3) << "Collective codegen requires CUDA compute capability >= 9.0 "
+    LOG(INFO) << "Collective codegen requires CUDA compute capability >= 9.0 "
             << "or ROCm with Triton support. Codegen will not be supported.";
     return std::nullopt;
   }
 
+  // Follow AllReduce pattern: calculate launch dimensions and tile sizes
   const Shape& input_shape = all_gather->operand(0)->shape();
   const int64_t num_elements = ShapeUtil::ElementsIn(input_shape);
-
+  const PrimitiveType element_type = input_shape.element_type();
+  
+  // Check if the element type is supported by Triton
+  // Triton primarily supports floating-point types and some integer types
+  // Unsigned integer types (u32, u16, etc.) are not well supported
+  if (element_type == U32 || element_type == U16 || element_type == U64) {
+    LOG(INFO) << "AllGather: Unsigned integer type "
+            << PrimitiveType_Name(element_type)
+            << " is not supported by Triton backend. Falling back to NCCL.";
+    return std::nullopt;
+  }
+  
   // Check alignment requirement (same as all-reduce)
-  // This ensures we fall back to NCCL for shapes that won't work with Triton
-  // tiling
+  // This ensures we fall back to NCCL for shapes that won't work with Triton tiling
   const int64_t alignment_requirement = se::gpu::kNumElementsPerThread;
   if (num_elements % alignment_requirement != 0) {
-    VLOG(3) << "AllGather: Number of elements (" << num_elements
+    LOG(INFO) << "AllGather: Number of elements (" << num_elements
             << ") is not aligned to the alignment requirement ("
             << alignment_requirement << "). Falling back to NCCL.";
     return std::nullopt;
   }
-
-  // Calculate launch dimensions for AllGather
-  // For AllGather, each rank processes its own input data, so elements_per_rank
-  // = num_elements
+  
+  // Calculate launch dimensions for AllGather (similar to AllReduce but without strategy)
+  // For AllGather, each rank processes its own input data, so elements_per_rank = num_elements
   static constexpr int64_t kWarpSize = 32;
   static constexpr uint64_t kMaxThreadsPerBlock = 512;
   static constexpr int64_t kMaxBlocksPerGrid = 32;
-
-  const int64_t elements_per_rank = num_elements;
+  
+  const int64_t elements_per_rank = num_elements;  // AllGather doesn't split work like TwoShot
   // Maximum number of threads such that each thread has elements to process
   const int64_t total_threads =
       RoundUpTo(elements_per_rank / se::gpu::kNumElementsPerThread, kWarpSize);
   // Triton expects power of 2 for threads_per_block / threads_per_warp
   const int64_t threads_per_block =
-      std::min(kMaxThreadsPerBlock,
-               static_cast<uint64_t>(llvm::PowerOf2Ceil(total_threads)));
-  const int64_t blocks_per_grid = std::min(
-      kMaxBlocksPerGrid, CeilOfRatio(total_threads, threads_per_block));
+      std::min(kMaxThreadsPerBlock, static_cast<uint64_t>(llvm::PowerOf2Ceil(total_threads)));
+  const int64_t blocks_per_grid = std::min(kMaxBlocksPerGrid,
+                                           CeilOfRatio(total_threads, threads_per_block));
   const LaunchDimensions launch_dims(blocks_per_grid, threads_per_block);
-
+  
   // Use input shape for tiling (output shape may not have layout properly set)
   // The tiling is based on processing input-sized chunks from each rank
   BlockLevelFusionConfig block_level_config;
-  block_level_config.set_num_warps(launch_dims.num_threads_per_block() /
-                                   WarpSize(device_info));
+  // Ensure at least 1 warp (minimum valid value)
+  const int64_t num_warps = std::max(
+      int64_t{1}, static_cast<int64_t>(launch_dims.num_threads_per_block() / WarpSize(device_info)));
+  block_level_config.set_num_warps(num_warps);
   block_level_config.set_num_ctas(1);    // No block-level clustering
   block_level_config.set_num_stages(1);  // No pipelining of loops
-
+  
   Tile* output_tile = block_level_config.add_output_tiles();
   const llvm::SmallVector<int64_t> tile_sizes =
       GreedyPowerOfTwoTiles(input_shape, launch_dims.num_blocks());
   output_tile->mutable_sizes()->Assign(tile_sizes.begin(), tile_sizes.end());
-
-  VLOG(3) << "GetBlockLevelFusionConfigForAllGather: Created config with "
-          << "num_warps=" << block_level_config.num_warps()
-          << ", num_blocks=" << launch_dims.num_blocks() << ", tile_sizes=["
-          << absl::StrJoin(tile_sizes, ",") << "]";
-
+  
+  LOG(INFO) << "GetBlockLevelFusionConfigForAllGather: Created config with "
+            << "num_warps=" << block_level_config.num_warps()
+            << ", num_blocks=" << launch_dims.num_blocks()
+            << ", tile_sizes=[" << absl::StrJoin(tile_sizes, ",") << "]";
+  
   VLOG(3) << "Block level fusion config for " << all_gather->name() << ": "
           << block_level_config;
   return block_level_config;
@@ -707,15 +757,19 @@ absl::StatusOr<std::optional<BlockLevelFusionConfig>>
 GetCollectiveBlockLevelFusionConfig(const se::DeviceDescription& device_info,
                                     const HloFusionInstruction* fusion_instr) {
   const HloInstruction* root = fusion_instr->fused_expression_root();
-
+  LOG(INFO) << "GetCollectiveBlockLevelFusionConfig called for opcode: "
+            << HloOpcodeString(root->opcode());
+  
   // For AllGather-start, the fusion root is a GetTupleElement that extracts
   // the output from the AllGather-start tuple
   if (root->opcode() == HloOpcode::kGetTupleElement &&
       root->operand(0)->opcode() == HloOpcode::kAllGatherStart) {
+    LOG(INFO) << "GetCollectiveBlockLevelFusionConfig: Detected GetTupleElement "
+              << "wrapping AllGather-start, using AllGather config";
     return GetBlockLevelFusionConfigForAllGather(
         device_info, Cast<HloAllGatherInstruction>(root->operand(0)));
   }
-
+  
   switch (root->opcode()) {
     case HloOpcode::kAllReduceStart:
       return GetBlockLevelFusionConfigForAllReduce(
@@ -748,57 +802,75 @@ absl::StatusOr<bool> TrySetGpuBackendConfigForCollective(
   return true;
 }
 
-// Returns unmanaged kernel arguments for all-gather
+// Returns unmanaged kernel arguments for all-gather (similar to all-reduce).
 absl::StatusOr<std::vector<Shape>> GetAllGatherUnmanagedKernelArguments(
     const HloComputation* computation,
     const HloAllGatherInstruction* all_gather) {
+  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments called for: "
+            << all_gather->name();
+  
   // Check if device_list is valid to prevent segfault
   if (!all_gather->device_list()) {
     return absl::InternalError(absl::StrCat(
         "AllGather instruction ", all_gather->name(),
         " has null device_list. Cannot generate Triton kernel arguments."));
   }
-
+  
   const int32_t num_devices =
       all_gather->device_list()->num_devices_per_group();
 
+  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments : num_devices "
+            << num_devices;
+  
   std::vector<Shape> unmanaged_arguments;
   unmanaged_arguments.reserve(computation->num_parameters() +
                               kNumCollectiveMetadataArgs);
   // rank and signal_value
   unmanaged_arguments.push_back(ShapeUtil::MakeShape(S32, {}));
   unmanaged_arguments.push_back(ShapeUtil::MakeShape(S32, {}));
-
+  
   // Signal and scratch buffers (same as AllReduce)
   static constexpr int32_t kMaxBlocksPerGrid = 24;
   unmanaged_arguments.push_back(
       ShapeUtil::MakeShape(S32, {num_devices, kMaxBlocksPerGrid}));
 
+  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments : before for loop ";
+  
   // Scratch buffers for AllGather
   // Note: For AllGather, we need buffers to hold the gathered data
-
+  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments: num_parameters=" 
+            << computation->num_parameters();
+  
   if (!computation) {
-    return absl::InternalError(
-        "Computation is null in GetAllGatherUnmanagedKernelArguments");
+    return absl::InternalError("Computation is null in GetAllGatherUnmanagedKernelArguments");
   }
-
+  
   for (const HloInstruction* instr : computation->parameter_instructions()) {
     if (!instr) {
-      return absl::InternalError(
-          "Null parameter instruction in GetAllGatherUnmanagedKernelArguments");
+      return absl::InternalError("Null parameter instruction in GetAllGatherUnmanagedKernelArguments");
     }
+    LOG(INFO) << "GetAllGatherUnmanagedKernelArguments: processing parameter " 
+              << instr->name();
     Shape shape =
         ShapeUtil::InsertDimensionAtIndex(instr->shape(), 0, num_devices);
     unmanaged_arguments.push_back(shape);
   }
-
+  
+  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments: after for loop, total args=" 
+            << unmanaged_arguments.size();
+  
+  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments: before TF_RET_CHECK, expected=" 
+            << (computation->num_parameters() + kNumCollectiveMetadataArgs);
+  
   if (unmanaged_arguments.size() !=
       computation->num_parameters() + kNumCollectiveMetadataArgs) {
-    return absl::InternalError(
-        absl::StrCat("AllGather unmanaged arguments size mismatch. Expected: ",
-                     computation->num_parameters() + kNumCollectiveMetadataArgs,
-                     ", Got: ", unmanaged_arguments.size()));
+    return absl::InternalError(absl::StrCat(
+        "AllGather unmanaged arguments size mismatch. Expected: ",
+        computation->num_parameters() + kNumCollectiveMetadataArgs,
+        ", Got: ", unmanaged_arguments.size()));
   }
+  
+  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments: before return";
   return unmanaged_arguments;
 }
 
@@ -806,14 +878,18 @@ absl::StatusOr<std::vector<Shape>> GetCollectiveUnmanagedKernelArguments(
     const HloFusionInstruction* fusion) {
   const HloComputation* computation = fusion->fused_instructions_computation();
   const HloInstruction* root = computation->root_instruction();
-
+  LOG(INFO) << "GetCollectiveUnmanagedKernelArguments called for opcode: "
+            << HloOpcodeString(root->opcode());
+  
   // For AllGather-start wrapped in GetTupleElement
   if (root->opcode() == HloOpcode::kGetTupleElement &&
       root->operand(0)->opcode() == HloOpcode::kAllGatherStart) {
+    LOG(INFO) << "GetCollectiveUnmanagedKernelArguments: Detected GetTupleElement "
+              << "wrapping AllGather-start";
     return GetAllGatherUnmanagedKernelArguments(
         computation, Cast<HloAllGatherInstruction>(root->operand(0)));
   }
-
+  
   switch (root->opcode()) {
     case HloOpcode::kAllReduceStart:
       return GetAllReduceUnmanagedKernelArguments(
@@ -894,7 +970,7 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
         "AllGather op must have exactly one operand in order to be lowered "
         "to triton.");
   }
-
+  
   mlir::Type element_type =
       mlir::cast<mlir::ShapedType>(op.getOperand(0).getType()).getElementType();
   ctx.element_type = xla::ConvertMlirTypeToPrimitiveType(element_type);
@@ -907,14 +983,14 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
         "Operand Type: %s",
         type_string));
   }
-
+  
   ctx.xtile_entry_fn = op->getParentOfType<xtile::EntryFuncOp>();
   if (!ctx.xtile_entry_fn) {
     return absl::InvalidArgumentError(
         "AllGather op must be in an XTile entry function in order to be "
         "lowered to triton.");
   }
-
+  
   ctx.num_input_output_args = op->getNumOperands() * 2;
   ctx.num_scratch_buffers = op->getNumOperands();
   const int32_t expected_num_args =
@@ -927,7 +1003,7 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
                      "be lowered to triton, but it has ",
                      ctx.xtile_entry_fn.getNumArguments()));
   }
-
+  
   ctx.input_tile = mlir::cast<xtile::TensorValue>(op->getOperand(0));
   ctx.input_extract =
       llvm::dyn_cast<xtile::ExtractTileOp>(ctx.input_tile.getDefiningOp());
@@ -941,7 +1017,7 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
         "AllGather op must have an extract tile op as operand in order to be "
         "lowered to triton.");
   }
-
+  
   ctx.non_tiled_input_shape = llvm::SmallVector<int64_t, 4>(
       ctx.input_extract.getSource().getType().getShape());
   ctx.num_elements = Product(ctx.non_tiled_input_shape);
@@ -951,7 +1027,7 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
   ctx.world_size = op.getReplicaGroups().getShapedType().getDimSize(1);
   ctx.all_gather_dimension = op.getAllGatherDim();
   ctx.op = op;
-
+  
   return ctx;
 }
 
@@ -976,7 +1052,7 @@ class AllGatherEmitter {
 
   absl::Status Initialize() {
     CHECK(!initialized_);
-
+    
     // 1. Opaque arguments
     const int32_t start_idx = ctx_.num_input_output_args;
     device_rank_ = ctx_.xtile_entry_fn.getArgument(start_idx);
@@ -1000,13 +1076,13 @@ class AllGatherEmitter {
     remote_input_buffers_i64_ = ttir::BitcastOp::create(
         builder_, ptr_to_i64_type_, remote_input_buffers_);
     const mlir::Type i64_type = builder_.getI64Type();
-
+    
     mlir::Value buffer_index = arith::AndIOp::create(
         builder_, i64_type,
         arith::ExtSIOp::create(builder_, i64_type, signal_value_),
         arith::ConstantOp::create(builder_, i64_type,
                                   builder_.getI64IntegerAttr(1)));
-
+    
     const int64_t buffer_size = xla::RoundUpTo<uint64_t>(
         ctx_.num_elements *
             ShapeUtil::ByteSizeOfPrimitiveType(ctx_.element_type),
@@ -1018,7 +1094,7 @@ class AllGatherEmitter {
         arith::ConstantOp::create(
             builder_, i64_type,
             builder_.getI64IntegerAttr(elements_per_buffer)));
-
+    
     initialized_ = true;
     return absl::OkStatus();
   }
@@ -1027,10 +1103,11 @@ class AllGatherEmitter {
     CHECK(initialized_);
     mlir::Value remote_buf_ptr_addr = ttir::AddPtrOp::create(
         builder_, ptr_to_i64_type_, remote_input_buffers_i64_, rank_idx);
-    mlir::Value remote_buf_i64 = ttir::LoadOp::create(
-        builder_, remote_buf_ptr_addr, ttir::CacheModifier::NONE,
-        ttir::EvictionPolicy::NORMAL,
-        /*isVolatile=*/false);
+    mlir::Value remote_buf_i64 =
+        ttir::LoadOp::create(builder_, remote_buf_ptr_addr,
+                             ttir::CacheModifier::NONE,
+                             ttir::EvictionPolicy::NORMAL,
+                             /*isVolatile=*/false);
     mlir::Value remote_buf_ptr_base =
         ttir::IntToPtrOp::create(builder_, ptr_to_elem_type_, remote_buf_i64,
                                  llvm::ArrayRef<mlir::NamedAttribute>{
@@ -1046,17 +1123,17 @@ class AllGatherEmitter {
     CHECK(initialized_);
     mlir::Value remote_buf_ptr = GetRemoteBufferPtr(rank_idx);
     auto [ptrs, mask] = triton::CreateTensorOfPointersAndMask(
-        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_, offsets,
-        shape, ctx_.input_extract.getStrides(),
+        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_,
+        offsets, shape, ctx_.input_extract.getStrides(),
         /*reduced_dims=*/{}, shape);
-
+    
     auto next_tile = mlir::cast<xtile::TensorValue>(
         ttir::LoadOp::create(builder_, ptrs, mask, /*other=*/mlir::Value(),
                              ttir::CacheModifier::NONE,
                              ttir::EvictionPolicy::NORMAL,
                              /*isVolatile=*/false)
             .getResult());
-
+    
     if (elem_storage_type_ != elem_type_) {
       next_tile = mlir::cast<xtile::TensorValue>(
           xtile::Cast(builder_, next_tile, elem_type_));
@@ -1069,18 +1146,18 @@ class AllGatherEmitter {
                                           llvm::ArrayRef<int64_t> shape) {
     CHECK(initialized_);
     mlir::Value remote_buf_ptr = GetRemoteBufferPtr(device_rank_);
-
+    
     mlir::Value storage_tile = tile_to_store;
     if (elem_storage_type_ != elem_type_) {
       storage_tile = mlir::cast<xtile::TensorValue>(
           xtile::Cast(builder_, tile_to_store, elem_storage_type_));
     }
-
+    
     auto [ptrs, mask] = triton::CreateTensorOfPointersAndMask(
-        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_, offsets,
-        shape, ctx_.input_extract.getStrides(),
+        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_,
+        offsets, shape, ctx_.input_extract.getStrides(),
         /*reduced_dims=*/{}, shape);
-
+    
     ttir::StoreOp::create(builder_, ptrs, storage_tile, mask,
                           ttir::CacheModifier::NONE,
                           ttir::EvictionPolicy::NORMAL);
@@ -1099,11 +1176,10 @@ class AllGatherEmitter {
 
   mlir::LogicalResult EmitPersistentAllGather() {
     CHECK(initialized_);
-
+    
     // For AllGather, the tiling framework processes the output in tiles
     // Each tile corresponds to a portion of the concatenated output
-    // The block ID (program ID) determines which portion of the output this
-    // block processes
+    // The block ID (program ID) determines which portion of the output this block processes
     //
     // For example, with 8 ranks and output size 8192:
     // - Block 0 processes output[0:1024] (from rank 0's input)
@@ -1111,18 +1187,18 @@ class AllGatherEmitter {
     // - Block 7 processes output[7168:8192] (from rank 7's input)
     //
     // We use the program ID to determine which rank's data to load
-
+    
     llvm::ArrayRef<int64_t> shape = ctx_.input_tile.getType().getShape();
-
+    
     // Get the block/program ID to determine which rank's data to load
     mlir::Value program_id = ttir::GetProgramIdOp::create(builder_, 0);
-
+    
     // For AllGather, each block corresponds to one rank's data
     // source_rank = program_id (since we have one block per rank)
     mlir::Value source_rank_i32 = program_id;
     mlir::Value source_rank = arith::ExtSIOp::create(
         builder_, builder_.getI64Type(), source_rank_i32);
-
+    
     // 1. Copy local tile to symmetric buffer (all ranks do this)
     if (mlir::failed(EmitCopyToSymmetric(
             ctx_.input_tile, ctx_.input_extract.getOffsets(),
@@ -1130,17 +1206,17 @@ class AllGatherEmitter {
       return rewriter_.notifyMatchFailure(ctx_.op,
                                           "Failed to emit copy to symmetric");
     }
-
+    
     // 2. Synchronization: Wait for all ranks to complete the copy
     if (mlir::failed(EmitSync(signal_value_))) {
       return rewriter_.notifyMatchFailure(ctx_.op,
                                           "Failed to emit sync for all-gather");
     }
-
+    
     // 3. Load the appropriate rank's data based on this block's program ID
     // Calculate the local offset within the source rank's buffer
-    // For the gather dimension, offset is always 0 (we load the full input
-    // size) For other dimensions, use the tile offset from input_extract
+    // For the gather dimension, offset is always 0 (we load the full input size)
+    // For other dimensions, use the tile offset from input_extract
     mlir::ValueRange tile_offsets = ctx_.input_extract.getOffsets();
     llvm::SmallVector<mlir::Value> local_offsets;
     for (size_t i = 0; i < ctx_.non_tiled_input_shape.size(); ++i) {
@@ -1154,12 +1230,11 @@ class AllGatherEmitter {
       }
     }
 
-    xtile::TensorValue result =
-        LoadTileForRank(source_rank, local_offsets, shape);
-
+    xtile::TensorValue result = LoadTileForRank(source_rank, local_offsets, shape);
+    
     // Replace the AllGather op with the loaded result
     rewriter_.replaceOp(ctx_.op, result);
-
+    
     return mlir::success();
   }
 
@@ -1185,14 +1260,21 @@ class AllGatherEmitter {
 
 mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
                                      mlir::PatternRewriter& rewriter) {
+  LOG(INFO) << "=== RewriteAllGather CALLED ===";
+  LOG(INFO) << "Implementing AllGather Triton backend based on IRIS persistent variant";
+  
   const mlir::Location loc = op->getLoc();
   absl::StatusOr<AllGatherEmitterContext> maybe_context =
       CreateAllGatherEmitterContext(op);
   if (!maybe_context.ok()) {
+    VLOG(3) << "Failed to create AllGatherEmitterContext: "
+            << maybe_context.status().message();
     return rewriter.notifyMatchFailure(
         loc, absl::StrCat("Failed to create AllGatherEmitterContext: ",
                           maybe_context.status().message()));
   }
+  
+  VLOG(3) << "AllGatherEmitter::Emit for persistent all-gather";
   return AllGatherEmitter::Emit(maybe_context.value(), rewriter);
 }
 

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -690,8 +690,7 @@ GetBlockLevelFusionConfigForAllGather(
     return std::nullopt;
   }
 
-  const int64_t num_devices =
-      all_gather->device_list().num_devices_per_group();
+  const int64_t num_devices = all_gather->device_list().num_devices_per_group();
   if (!llvm::has_single_bit(static_cast<uint64_t>(num_devices))) {
     VLOG(1) << "Number of devices is not a power of 2 for "
             << all_gather->name() << ". Codegen will not be supported.";
@@ -833,8 +832,7 @@ absl::StatusOr<bool> TrySetGpuBackendConfigForCollective(
 absl::StatusOr<std::vector<Shape>> GetAllGatherUnmanagedKernelArguments(
     const HloComputation* computation,
     const HloAllGatherInstruction* all_gather) {
-  const int32_t num_devices =
-      all_gather->device_list().num_devices_per_group();
+  const int32_t num_devices = all_gather->device_list().num_devices_per_group();
 
   std::vector<Shape> unmanaged_arguments;
   unmanaged_arguments.reserve(computation->num_parameters() +

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -998,12 +998,18 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
 class AllGatherEmitter {
  public:
   static mlir::LogicalResult Emit(AllGatherEmitterContext ctx,
-                                  mlir::PatternRewriter& rewriter) {
+                                  mlir::PatternRewriter& rewriter,
+                                  bool use_swizzled = false,
+                                  int64_t group_size_m = 8) {
     AllGatherEmitter emitter(std::move(ctx), rewriter);
     if (auto result = emitter.Initialize(); !result.ok()) {
       LOG(ERROR) << "Failed to initialize AllGatherEmitter: "
                  << result.message();
       return mlir::failure();
+    }
+
+    if (use_swizzled) {
+      return emitter.EmitAllGatherSwizzled(group_size_m);
     }
     return emitter.EmitAllGather();
   }
@@ -1193,6 +1199,148 @@ class AllGatherEmitter {
     return mlir::success();
   }
 
+  // Swizzled memory access variant that implements the tiling pattern:
+  // num_pid_in_group = GROUP_SIZE_M * num_pid_n
+  // group_id = tile_id // num_pid_in_group
+  // first_pid_m = group_id * GROUP_SIZE_M
+  // group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+  // pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+  // pid_n = (tile_id % num_pid_in_group) // group_size_m
+  mlir::LogicalResult EmitAllGatherSwizzled(int64_t group_size_m) {
+    VLOG(-1) << "EmitAllGatherSwizzled";
+    CHECK(initialized_);
+
+    llvm::ArrayRef<int64_t> shape = ctx_.input_tile.getType().getShape();
+
+    // Get the tile/block ID
+    mlir::Value tile_id = ttir::GetProgramIdOp::create(builder_, 0);
+
+    // Calculate num_pid_m and num_pid_n based on the input shape and tile shape
+    // For simplicity, assume 2D tiling with M and N dimensions
+    // num_pid_m = ceil(M / BLOCK_SIZE_M)
+    // num_pid_n = ceil(N / BLOCK_SIZE_N)
+
+    // For AllGather, we need to determine the number of tiles in each dimension
+    // This depends on the tile shape and the total output shape
+    const int64_t block_size_m = shape.size() > 0 ? shape[0] : 1;
+    const int64_t block_size_n = shape.size() > 1 ? shape[1] : 1;
+
+    // Calculate total number of tiles needed
+    const int64_t total_m = ctx_.non_tiled_input_shape[0] * ctx_.world_size;
+    const int64_t total_n = ctx_.non_tiled_input_shape.size() > 1
+                                ? ctx_.non_tiled_input_shape[1]
+                                : 1;
+
+    const int64_t num_pid_m = (total_m + block_size_m - 1) / block_size_m;
+    const int64_t num_pid_n = (total_n + block_size_n - 1) / block_size_n;
+
+    // Create constants
+    mlir::Value num_pid_m_val = arith::ConstantOp::create(
+        builder_, builder_.getI32Type(), builder_.getI32IntegerAttr(num_pid_m));
+    mlir::Value num_pid_n_val = arith::ConstantOp::create(
+        builder_, builder_.getI32Type(), builder_.getI32IntegerAttr(num_pid_n));
+    mlir::Value group_size_m_val =
+        arith::ConstantOp::create(builder_, builder_.getI32Type(),
+                                  builder_.getI32IntegerAttr(group_size_m));
+
+    // Swizzled tiling calculation
+    // num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    mlir::Value num_pid_in_group =
+        arith::MulIOp::create(builder_, group_size_m_val, num_pid_n_val);
+
+    // group_id = tile_id // num_pid_in_group
+    mlir::Value group_id =
+        arith::DivSIOp::create(builder_, tile_id, num_pid_in_group);
+
+    // first_pid_m = group_id * GROUP_SIZE_M
+    mlir::Value first_pid_m =
+        arith::MulIOp::create(builder_, group_id, group_size_m_val);
+
+    // group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    mlir::Value remaining_m =
+        arith::SubIOp::create(builder_, num_pid_m_val, first_pid_m);
+    mlir::Value cmp = arith::CmpIOp::create(builder_, arith::CmpIPredicate::slt,
+                                            remaining_m, group_size_m_val);
+    mlir::Value group_size_m_actual =
+        arith::SelectOp::create(builder_, cmp, remaining_m, group_size_m_val);
+
+    // tile_id % num_pid_in_group
+    mlir::Value tile_id_mod =
+        arith::RemSIOp::create(builder_, tile_id, num_pid_in_group);
+
+    // pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+    mlir::Value offset_m =
+        arith::RemSIOp::create(builder_, tile_id_mod, group_size_m_actual);
+    mlir::Value pid_m = arith::AddIOp::create(builder_, first_pid_m, offset_m);
+
+    // pid_n = (tile_id % num_pid_in_group) // group_size_m
+    mlir::Value pid_n =
+        arith::DivSIOp::create(builder_, tile_id_mod, group_size_m_actual);
+
+    // Determine which rank's data to load based on pid_m
+    // Each rank owns M/world_size rows
+    const int64_t rows_per_rank = ctx_.non_tiled_input_shape[0];
+    mlir::Value rows_per_rank_val = arith::ConstantOp::create(
+        builder_, builder_.getI32Type(),
+        builder_.getI32IntegerAttr(rows_per_rank / block_size_m));
+
+    mlir::Value source_rank_i32 =
+        arith::DivSIOp::create(builder_, pid_m, rows_per_rank_val);
+    mlir::Value source_rank = arith::ExtSIOp::create(
+        builder_, builder_.getI64Type(), source_rank_i32);
+
+    // 1. Copy local tile to symmetric buffer (all ranks do this)
+    if (mlir::failed(EmitCopyToSymmetric(
+            ctx_.input_tile, ctx_.input_extract.getOffsets(),
+            ctx_.input_tile.getType().getShape()))) {
+      return rewriter_.notifyMatchFailure(ctx_.op,
+                                          "Failed to emit copy to symmetric");
+    }
+
+    // 2. Synchronization: Wait for all ranks to complete the copy
+    if (mlir::failed(EmitSync(signal_value_))) {
+      return rewriter_.notifyMatchFailure(ctx_.op,
+                                          "Failed to emit sync for all-gather");
+    }
+
+    // 3. Calculate offsets based on swizzled pid_m and pid_n
+    mlir::ValueRange tile_offsets = ctx_.input_extract.getOffsets();
+    llvm::SmallVector<mlir::Value> local_offsets;
+
+    // For M dimension (gather dimension), calculate offset within source rank
+    mlir::Value local_pid_m =
+        arith::RemSIOp::create(builder_, pid_m, rows_per_rank_val);
+    mlir::Value m_offset = arith::MulIOp::create(
+        builder_, local_pid_m,
+        arith::ConstantOp::create(builder_, builder_.getI32Type(),
+                                  builder_.getI32IntegerAttr(block_size_m)));
+    local_offsets.push_back(arith::IndexCastOp::create(
+        builder_, builder_.getIndexType(), m_offset));
+
+    // For N dimension, use pid_n
+    if (ctx_.non_tiled_input_shape.size() > 1) {
+      mlir::Value n_offset = arith::MulIOp::create(
+          builder_, pid_n,
+          arith::ConstantOp::create(builder_, builder_.getI32Type(),
+                                    builder_.getI32IntegerAttr(block_size_n)));
+      local_offsets.push_back(arith::IndexCastOp::create(
+          builder_, builder_.getIndexType(), n_offset));
+    }
+
+    // Add remaining dimensions from tile_offsets
+    for (size_t i = 2; i < ctx_.non_tiled_input_shape.size(); ++i) {
+      local_offsets.push_back(tile_offsets[i]);
+    }
+
+    xtile::TensorValue result =
+        LoadTileForRank(source_rank, local_offsets, shape);
+
+    // Replace the AllGather op with the loaded result
+    rewriter_.replaceOp(ctx_.op, result);
+
+    return mlir::success();
+  }
+
   AllGatherEmitterContext ctx_;
   mlir::PatternRewriter& rewriter_;
   mlir::ImplicitLocOpBuilder builder_;
@@ -1227,7 +1375,8 @@ mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
   }
 
   VLOG(3) << "AllGatherEmitter::Emit for all-gather";
-  return AllGatherEmitter::Emit(maybe_context.value(), rewriter);
+  return AllGatherEmitter::Emit(maybe_context.value(), rewriter,
+                                false /*swizzled kernel*/);
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -625,40 +625,31 @@ absl::StatusOr<std::optional<BlockLevelFusionConfig>>
 GetBlockLevelFusionConfigForAllGather(
     const se::DeviceDescription& device_info,
     const HloAllGatherInstruction* all_gather) {
-  LOG(INFO) << "GetBlockLevelFusionConfigForAllGather called for: "
-            << all_gather->name();
-  LOG(INFO) << "AllGather instruction details:";
-  LOG(INFO) << "  - device_list() is null: " << (all_gather->device_list() == nullptr);
-  if (all_gather->device_list()) {
-    LOG(INFO) << "  - replica_groups().size(): " << all_gather->device_list()->replica_groups().size();
-    LOG(INFO) << "  - num_devices_per_group(): " << all_gather->device_list()->num_devices_per_group();
-  }
-  LOG(INFO) << "  - HLO: " << all_gather->ToString();
-  
   // Check if the Triton AllGather backend is enabled
   if (!all_gather->GetModule()
            ->config()
            .debug_options()
            .xla_gpu_unsupported_use_all_gather_triton_backend()) {
     LOG(INFO) << "AllGather Triton backend is not enabled. "
-            << "Set xla_gpu_unsupported_use_all_gather_triton_backend=true to enable.";
+              << "Set xla_gpu_unsupported_use_all_gather_triton_backend=true "
+                 "to enable.";
     return std::nullopt;
   }
-  
+
   // Check if replica groups are present (required for Triton backend)
   if (!all_gather->device_list()) {
     LOG(INFO) << "AllGather device_list is null for " << all_gather->name()
-            << ". This likely means replica_groups were not properly set. "
-            << "Codegen will not be supported.";
+              << ". This likely means replica_groups were not properly set. "
+              << "Codegen will not be supported.";
     return std::nullopt;
   }
-  
+
   if (all_gather->device_list()->replica_groups().empty()) {
     LOG(INFO) << "Replica groups are empty for " << all_gather->name()
-            << ". Codegen will not be supported.";
+              << ". Codegen will not be supported.";
     return std::nullopt;
   }
-  
+
   const int64_t num_devices =
       all_gather->device_list()->num_devices_per_group();
   if (!llvm::has_single_bit(static_cast<uint64_t>(num_devices))) {
@@ -666,7 +657,7 @@ GetBlockLevelFusionConfigForAllGather(
             << all_gather->name() << ". Codegen will not be supported.";
     return std::nullopt;
   }
-  
+
   // Check if the device supports Triton collective codegen
   bool is_supported = false;
 
@@ -682,7 +673,7 @@ GetBlockLevelFusionConfigForAllGather(
 
   if (!is_supported) {
     LOG(INFO) << "Collective codegen requires CUDA compute capability >= 9.0 "
-            << "or ROCm with Triton support. Codegen will not be supported.";
+              << "or ROCm with Triton support. Codegen will not be supported.";
     return std::nullopt;
   }
 
@@ -690,64 +681,64 @@ GetBlockLevelFusionConfigForAllGather(
   const Shape& input_shape = all_gather->operand(0)->shape();
   const int64_t num_elements = ShapeUtil::ElementsIn(input_shape);
   const PrimitiveType element_type = input_shape.element_type();
-  
+
   // Check if the element type is supported by Triton
   // Triton primarily supports floating-point types and some integer types
   // Unsigned integer types (u32, u16, etc.) are not well supported
   if (element_type == U32 || element_type == U16 || element_type == U64) {
     LOG(INFO) << "AllGather: Unsigned integer type "
-            << PrimitiveType_Name(element_type)
-            << " is not supported by Triton backend. Falling back to NCCL.";
+              << PrimitiveType_Name(element_type)
+              << " is not supported by Triton backend. Falling back to NCCL.";
     return std::nullopt;
   }
-  
+
   // Check alignment requirement (same as all-reduce)
-  // This ensures we fall back to NCCL for shapes that won't work with Triton tiling
+  // This ensures we fall back to NCCL for shapes that won't work with Triton
+  // tiling
   const int64_t alignment_requirement = se::gpu::kNumElementsPerThread;
   if (num_elements % alignment_requirement != 0) {
     LOG(INFO) << "AllGather: Number of elements (" << num_elements
-            << ") is not aligned to the alignment requirement ("
-            << alignment_requirement << "). Falling back to NCCL.";
+              << ") is not aligned to the alignment requirement ("
+              << alignment_requirement << "). Falling back to NCCL.";
     return std::nullopt;
   }
-  
-  // Calculate launch dimensions for AllGather (similar to AllReduce but without strategy)
-  // For AllGather, each rank processes its own input data, so elements_per_rank = num_elements
+
+  // Calculate launch dimensions for AllGather (similar to AllReduce but without
+  // strategy) For AllGather, each rank processes its own input data, so
+  // elements_per_rank = num_elements
   static constexpr int64_t kWarpSize = 32;
   static constexpr uint64_t kMaxThreadsPerBlock = 512;
   static constexpr int64_t kMaxBlocksPerGrid = 32;
-  
-  const int64_t elements_per_rank = num_elements;  // AllGather doesn't split work like TwoShot
+
+  const int64_t elements_per_rank =
+      num_elements;  // AllGather doesn't split work like TwoShot
   // Maximum number of threads such that each thread has elements to process
   const int64_t total_threads =
       RoundUpTo(elements_per_rank / se::gpu::kNumElementsPerThread, kWarpSize);
   // Triton expects power of 2 for threads_per_block / threads_per_warp
   const int64_t threads_per_block =
-      std::min(kMaxThreadsPerBlock, static_cast<uint64_t>(llvm::PowerOf2Ceil(total_threads)));
-  const int64_t blocks_per_grid = std::min(kMaxBlocksPerGrid,
-                                           CeilOfRatio(total_threads, threads_per_block));
+      std::min(kMaxThreadsPerBlock,
+               static_cast<uint64_t>(llvm::PowerOf2Ceil(total_threads)));
+  const int64_t blocks_per_grid = std::min(
+      kMaxBlocksPerGrid, CeilOfRatio(total_threads, threads_per_block));
   const LaunchDimensions launch_dims(blocks_per_grid, threads_per_block);
-  
+
   // Use input shape for tiling (output shape may not have layout properly set)
   // The tiling is based on processing input-sized chunks from each rank
   BlockLevelFusionConfig block_level_config;
   // Ensure at least 1 warp (minimum valid value)
   const int64_t num_warps = std::max(
-      int64_t{1}, static_cast<int64_t>(launch_dims.num_threads_per_block() / WarpSize(device_info)));
+      int64_t{1}, static_cast<int64_t>(launch_dims.num_threads_per_block() /
+                                       WarpSize(device_info)));
   block_level_config.set_num_warps(num_warps);
   block_level_config.set_num_ctas(1);    // No block-level clustering
   block_level_config.set_num_stages(1);  // No pipelining of loops
-  
+
   Tile* output_tile = block_level_config.add_output_tiles();
   const llvm::SmallVector<int64_t> tile_sizes =
       GreedyPowerOfTwoTiles(input_shape, launch_dims.num_blocks());
   output_tile->mutable_sizes()->Assign(tile_sizes.begin(), tile_sizes.end());
-  
-  LOG(INFO) << "GetBlockLevelFusionConfigForAllGather: Created config with "
-            << "num_warps=" << block_level_config.num_warps()
-            << ", num_blocks=" << launch_dims.num_blocks()
-            << ", tile_sizes=[" << absl::StrJoin(tile_sizes, ",") << "]";
-  
+
   VLOG(3) << "Block level fusion config for " << all_gather->name() << ": "
           << block_level_config;
   return block_level_config;
@@ -757,19 +748,15 @@ absl::StatusOr<std::optional<BlockLevelFusionConfig>>
 GetCollectiveBlockLevelFusionConfig(const se::DeviceDescription& device_info,
                                     const HloFusionInstruction* fusion_instr) {
   const HloInstruction* root = fusion_instr->fused_expression_root();
-  LOG(INFO) << "GetCollectiveBlockLevelFusionConfig called for opcode: "
-            << HloOpcodeString(root->opcode());
-  
+
   // For AllGather-start, the fusion root is a GetTupleElement that extracts
   // the output from the AllGather-start tuple
   if (root->opcode() == HloOpcode::kGetTupleElement &&
       root->operand(0)->opcode() == HloOpcode::kAllGatherStart) {
-    LOG(INFO) << "GetCollectiveBlockLevelFusionConfig: Detected GetTupleElement "
-              << "wrapping AllGather-start, using AllGather config";
     return GetBlockLevelFusionConfigForAllGather(
         device_info, Cast<HloAllGatherInstruction>(root->operand(0)));
   }
-  
+
   switch (root->opcode()) {
     case HloOpcode::kAllReduceStart:
       return GetBlockLevelFusionConfigForAllReduce(
@@ -806,71 +793,52 @@ absl::StatusOr<bool> TrySetGpuBackendConfigForCollective(
 absl::StatusOr<std::vector<Shape>> GetAllGatherUnmanagedKernelArguments(
     const HloComputation* computation,
     const HloAllGatherInstruction* all_gather) {
-  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments called for: "
-            << all_gather->name();
-  
   // Check if device_list is valid to prevent segfault
   if (!all_gather->device_list()) {
     return absl::InternalError(absl::StrCat(
         "AllGather instruction ", all_gather->name(),
         " has null device_list. Cannot generate Triton kernel arguments."));
   }
-  
+
   const int32_t num_devices =
       all_gather->device_list()->num_devices_per_group();
 
-  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments : num_devices "
-            << num_devices;
-  
   std::vector<Shape> unmanaged_arguments;
   unmanaged_arguments.reserve(computation->num_parameters() +
                               kNumCollectiveMetadataArgs);
   // rank and signal_value
   unmanaged_arguments.push_back(ShapeUtil::MakeShape(S32, {}));
   unmanaged_arguments.push_back(ShapeUtil::MakeShape(S32, {}));
-  
+
   // Signal and scratch buffers (same as AllReduce)
   static constexpr int32_t kMaxBlocksPerGrid = 24;
   unmanaged_arguments.push_back(
       ShapeUtil::MakeShape(S32, {num_devices, kMaxBlocksPerGrid}));
 
-  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments : before for loop ";
-  
   // Scratch buffers for AllGather
   // Note: For AllGather, we need buffers to hold the gathered data
-  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments: num_parameters=" 
-            << computation->num_parameters();
-  
   if (!computation) {
-    return absl::InternalError("Computation is null in GetAllGatherUnmanagedKernelArguments");
+    return absl::InternalError(
+        "Computation is null in GetAllGatherUnmanagedKernelArguments");
   }
-  
+
   for (const HloInstruction* instr : computation->parameter_instructions()) {
     if (!instr) {
-      return absl::InternalError("Null parameter instruction in GetAllGatherUnmanagedKernelArguments");
+      return absl::InternalError(
+          "Null parameter instruction in GetAllGatherUnmanagedKernelArguments");
     }
-    LOG(INFO) << "GetAllGatherUnmanagedKernelArguments: processing parameter " 
-              << instr->name();
     Shape shape =
         ShapeUtil::InsertDimensionAtIndex(instr->shape(), 0, num_devices);
     unmanaged_arguments.push_back(shape);
   }
-  
-  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments: after for loop, total args=" 
-            << unmanaged_arguments.size();
-  
-  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments: before TF_RET_CHECK, expected=" 
-            << (computation->num_parameters() + kNumCollectiveMetadataArgs);
-  
+
   if (unmanaged_arguments.size() !=
       computation->num_parameters() + kNumCollectiveMetadataArgs) {
-    return absl::InternalError(absl::StrCat(
-        "AllGather unmanaged arguments size mismatch. Expected: ",
-        computation->num_parameters() + kNumCollectiveMetadataArgs,
-        ", Got: ", unmanaged_arguments.size()));
+    return absl::InternalError(
+        absl::StrCat("AllGather unmanaged arguments size mismatch. Expected: ",
+                     computation->num_parameters() + kNumCollectiveMetadataArgs,
+                     ", Got: ", unmanaged_arguments.size()));
   }
-  
-  LOG(INFO) << "GetAllGatherUnmanagedKernelArguments: before return";
   return unmanaged_arguments;
 }
 
@@ -878,18 +846,14 @@ absl::StatusOr<std::vector<Shape>> GetCollectiveUnmanagedKernelArguments(
     const HloFusionInstruction* fusion) {
   const HloComputation* computation = fusion->fused_instructions_computation();
   const HloInstruction* root = computation->root_instruction();
-  LOG(INFO) << "GetCollectiveUnmanagedKernelArguments called for opcode: "
-            << HloOpcodeString(root->opcode());
-  
+
   // For AllGather-start wrapped in GetTupleElement
   if (root->opcode() == HloOpcode::kGetTupleElement &&
       root->operand(0)->opcode() == HloOpcode::kAllGatherStart) {
-    LOG(INFO) << "GetCollectiveUnmanagedKernelArguments: Detected GetTupleElement "
-              << "wrapping AllGather-start";
     return GetAllGatherUnmanagedKernelArguments(
         computation, Cast<HloAllGatherInstruction>(root->operand(0)));
   }
-  
+
   switch (root->opcode()) {
     case HloOpcode::kAllReduceStart:
       return GetAllReduceUnmanagedKernelArguments(
@@ -970,7 +934,7 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
         "AllGather op must have exactly one operand in order to be lowered "
         "to triton.");
   }
-  
+
   mlir::Type element_type =
       mlir::cast<mlir::ShapedType>(op.getOperand(0).getType()).getElementType();
   ctx.element_type = xla::ConvertMlirTypeToPrimitiveType(element_type);
@@ -983,14 +947,14 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
         "Operand Type: %s",
         type_string));
   }
-  
+
   ctx.xtile_entry_fn = op->getParentOfType<xtile::EntryFuncOp>();
   if (!ctx.xtile_entry_fn) {
     return absl::InvalidArgumentError(
         "AllGather op must be in an XTile entry function in order to be "
         "lowered to triton.");
   }
-  
+
   ctx.num_input_output_args = op->getNumOperands() * 2;
   ctx.num_scratch_buffers = op->getNumOperands();
   const int32_t expected_num_args =
@@ -1003,7 +967,7 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
                      "be lowered to triton, but it has ",
                      ctx.xtile_entry_fn.getNumArguments()));
   }
-  
+
   ctx.input_tile = mlir::cast<xtile::TensorValue>(op->getOperand(0));
   ctx.input_extract =
       llvm::dyn_cast<xtile::ExtractTileOp>(ctx.input_tile.getDefiningOp());
@@ -1017,7 +981,7 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
         "AllGather op must have an extract tile op as operand in order to be "
         "lowered to triton.");
   }
-  
+
   ctx.non_tiled_input_shape = llvm::SmallVector<int64_t, 4>(
       ctx.input_extract.getSource().getType().getShape());
   ctx.num_elements = Product(ctx.non_tiled_input_shape);
@@ -1027,7 +991,7 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
   ctx.world_size = op.getReplicaGroups().getShapedType().getDimSize(1);
   ctx.all_gather_dimension = op.getAllGatherDim();
   ctx.op = op;
-  
+
   return ctx;
 }
 
@@ -1041,7 +1005,7 @@ class AllGatherEmitter {
                  << result.message();
       return mlir::failure();
     }
-    return emitter.EmitPersistentAllGather();
+    return emitter.EmitAllGather();
   }
 
  private:
@@ -1052,7 +1016,7 @@ class AllGatherEmitter {
 
   absl::Status Initialize() {
     CHECK(!initialized_);
-    
+
     // 1. Opaque arguments
     const int32_t start_idx = ctx_.num_input_output_args;
     device_rank_ = ctx_.xtile_entry_fn.getArgument(start_idx);
@@ -1076,13 +1040,13 @@ class AllGatherEmitter {
     remote_input_buffers_i64_ = ttir::BitcastOp::create(
         builder_, ptr_to_i64_type_, remote_input_buffers_);
     const mlir::Type i64_type = builder_.getI64Type();
-    
+
     mlir::Value buffer_index = arith::AndIOp::create(
         builder_, i64_type,
         arith::ExtSIOp::create(builder_, i64_type, signal_value_),
         arith::ConstantOp::create(builder_, i64_type,
                                   builder_.getI64IntegerAttr(1)));
-    
+
     const int64_t buffer_size = xla::RoundUpTo<uint64_t>(
         ctx_.num_elements *
             ShapeUtil::ByteSizeOfPrimitiveType(ctx_.element_type),
@@ -1094,7 +1058,7 @@ class AllGatherEmitter {
         arith::ConstantOp::create(
             builder_, i64_type,
             builder_.getI64IntegerAttr(elements_per_buffer)));
-    
+
     initialized_ = true;
     return absl::OkStatus();
   }
@@ -1103,11 +1067,10 @@ class AllGatherEmitter {
     CHECK(initialized_);
     mlir::Value remote_buf_ptr_addr = ttir::AddPtrOp::create(
         builder_, ptr_to_i64_type_, remote_input_buffers_i64_, rank_idx);
-    mlir::Value remote_buf_i64 =
-        ttir::LoadOp::create(builder_, remote_buf_ptr_addr,
-                             ttir::CacheModifier::NONE,
-                             ttir::EvictionPolicy::NORMAL,
-                             /*isVolatile=*/false);
+    mlir::Value remote_buf_i64 = ttir::LoadOp::create(
+        builder_, remote_buf_ptr_addr, ttir::CacheModifier::NONE,
+        ttir::EvictionPolicy::NORMAL,
+        /*isVolatile=*/false);
     mlir::Value remote_buf_ptr_base =
         ttir::IntToPtrOp::create(builder_, ptr_to_elem_type_, remote_buf_i64,
                                  llvm::ArrayRef<mlir::NamedAttribute>{
@@ -1123,17 +1086,17 @@ class AllGatherEmitter {
     CHECK(initialized_);
     mlir::Value remote_buf_ptr = GetRemoteBufferPtr(rank_idx);
     auto [ptrs, mask] = triton::CreateTensorOfPointersAndMask(
-        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_,
-        offsets, shape, ctx_.input_extract.getStrides(),
+        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_, offsets,
+        shape, ctx_.input_extract.getStrides(),
         /*reduced_dims=*/{}, shape);
-    
+
     auto next_tile = mlir::cast<xtile::TensorValue>(
         ttir::LoadOp::create(builder_, ptrs, mask, /*other=*/mlir::Value(),
                              ttir::CacheModifier::NONE,
                              ttir::EvictionPolicy::NORMAL,
                              /*isVolatile=*/false)
             .getResult());
-    
+
     if (elem_storage_type_ != elem_type_) {
       next_tile = mlir::cast<xtile::TensorValue>(
           xtile::Cast(builder_, next_tile, elem_type_));
@@ -1146,18 +1109,18 @@ class AllGatherEmitter {
                                           llvm::ArrayRef<int64_t> shape) {
     CHECK(initialized_);
     mlir::Value remote_buf_ptr = GetRemoteBufferPtr(device_rank_);
-    
+
     mlir::Value storage_tile = tile_to_store;
     if (elem_storage_type_ != elem_type_) {
       storage_tile = mlir::cast<xtile::TensorValue>(
           xtile::Cast(builder_, tile_to_store, elem_storage_type_));
     }
-    
+
     auto [ptrs, mask] = triton::CreateTensorOfPointersAndMask(
-        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_,
-        offsets, shape, ctx_.input_extract.getStrides(),
+        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_, offsets,
+        shape, ctx_.input_extract.getStrides(),
         /*reduced_dims=*/{}, shape);
-    
+
     ttir::StoreOp::create(builder_, ptrs, storage_tile, mask,
                           ttir::CacheModifier::NONE,
                           ttir::EvictionPolicy::NORMAL);
@@ -1174,31 +1137,22 @@ class AllGatherEmitter {
     return mlir::success();
   }
 
-  mlir::LogicalResult EmitPersistentAllGather() {
+  mlir::LogicalResult EmitAllGather() {
     CHECK(initialized_);
-    
-    // For AllGather, the tiling framework processes the output in tiles
-    // Each tile corresponds to a portion of the concatenated output
-    // The block ID (program ID) determines which portion of the output this block processes
-    //
-    // For example, with 8 ranks and output size 8192:
-    // - Block 0 processes output[0:1024] (from rank 0's input)
-    // - Block 1 processes output[1024:2048] (from rank 1's input)
-    // - Block 7 processes output[7168:8192] (from rank 7's input)
-    //
-    // We use the program ID to determine which rank's data to load
-    
+
     llvm::ArrayRef<int64_t> shape = ctx_.input_tile.getType().getShape();
-    
-    // Get the block/program ID to determine which rank's data to load
+
+    // Get the block/program ID
     mlir::Value program_id = ttir::GetProgramIdOp::create(builder_, 0);
-    
-    // For AllGather, each block corresponds to one rank's data
-    // source_rank = program_id (since we have one block per rank)
-    mlir::Value source_rank_i32 = program_id;
+
+    mlir::Value world_size_i32 =
+        arith::ConstantOp::create(builder_, builder_.getI32Type(),
+                                  builder_.getI32IntegerAttr(ctx_.world_size));
+    mlir::Value source_rank_i32 =
+        arith::RemSIOp::create(builder_, program_id, world_size_i32);
     mlir::Value source_rank = arith::ExtSIOp::create(
         builder_, builder_.getI64Type(), source_rank_i32);
-    
+
     // 1. Copy local tile to symmetric buffer (all ranks do this)
     if (mlir::failed(EmitCopyToSymmetric(
             ctx_.input_tile, ctx_.input_extract.getOffsets(),
@@ -1206,17 +1160,17 @@ class AllGatherEmitter {
       return rewriter_.notifyMatchFailure(ctx_.op,
                                           "Failed to emit copy to symmetric");
     }
-    
+
     // 2. Synchronization: Wait for all ranks to complete the copy
     if (mlir::failed(EmitSync(signal_value_))) {
       return rewriter_.notifyMatchFailure(ctx_.op,
                                           "Failed to emit sync for all-gather");
     }
-    
+
     // 3. Load the appropriate rank's data based on this block's program ID
     // Calculate the local offset within the source rank's buffer
-    // For the gather dimension, offset is always 0 (we load the full input size)
-    // For other dimensions, use the tile offset from input_extract
+    // For the gather dimension, offset is always 0 (we load the full input
+    // size) For other dimensions, use the tile offset from input_extract
     mlir::ValueRange tile_offsets = ctx_.input_extract.getOffsets();
     llvm::SmallVector<mlir::Value> local_offsets;
     for (size_t i = 0; i < ctx_.non_tiled_input_shape.size(); ++i) {
@@ -1230,11 +1184,12 @@ class AllGatherEmitter {
       }
     }
 
-    xtile::TensorValue result = LoadTileForRank(source_rank, local_offsets, shape);
-    
+    xtile::TensorValue result =
+        LoadTileForRank(source_rank, local_offsets, shape);
+
     // Replace the AllGather op with the loaded result
     rewriter_.replaceOp(ctx_.op, result);
-    
+
     return mlir::success();
   }
 
@@ -1260,9 +1215,6 @@ class AllGatherEmitter {
 
 mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
                                      mlir::PatternRewriter& rewriter) {
-  LOG(INFO) << "=== RewriteAllGather CALLED ===";
-  LOG(INFO) << "Implementing AllGather Triton backend based on IRIS persistent variant";
-  
   const mlir::Location loc = op->getLoc();
   absl::StatusOr<AllGatherEmitterContext> maybe_context =
       CreateAllGatherEmitterContext(op);
@@ -1273,8 +1225,8 @@ mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
         loc, absl::StrCat("Failed to create AllGatherEmitterContext: ",
                           maybe_context.status().message()));
   }
-  
-  VLOG(3) << "AllGatherEmitter::Emit for persistent all-gather";
+
+  VLOG(3) << "AllGatherEmitter::Emit for all-gather";
   return AllGatherEmitter::Emit(maybe_context.value(), rewriter);
 }
 

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -1027,18 +1027,12 @@ absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
 class AllGatherEmitter {
  public:
   static mlir::LogicalResult Emit(AllGatherEmitterContext ctx,
-                                  mlir::PatternRewriter& rewriter,
-                                  bool use_swizzled = false,
-                                  int64_t group_size_m = 8) {
+                                  mlir::PatternRewriter& rewriter) {
     AllGatherEmitter emitter(std::move(ctx), rewriter);
     if (auto result = emitter.Initialize(); !result.ok()) {
       LOG(ERROR) << "Failed to initialize AllGatherEmitter: "
                  << result.message();
       return mlir::failure();
-    }
-
-    if (use_swizzled) {
-      return emitter.EmitAllGatherSwizzled(group_size_m);
     }
     return emitter.EmitAllGather();
   }
@@ -1230,193 +1224,6 @@ class AllGatherEmitter {
     return mlir::success();
   }
 
-  // Swizzled memory access variant that implements the tiling pattern:
-  // num_pid_in_group = GROUP_SIZE_M * num_pid_n
-  // group_id = tile_id // num_pid_in_group
-  // first_pid_m = group_id * GROUP_SIZE_M
-  // group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
-  // pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
-  // pid_n = (tile_id % num_pid_in_group) // group_size_m
-  mlir::LogicalResult EmitAllGatherSwizzled(int64_t group_size_m) {
-    CHECK(initialized_);
-
-    llvm::ArrayRef<int64_t> shape = ctx_.input_tile.getType().getShape();
-
-    // Get the tile/block ID
-    mlir::Value tile_id = ttir::GetProgramIdOp::create(builder_, 0);
-
-    // Calculate the number of tiles needed in each dimension
-    // The gather dimension is multiplied by world_size
-    llvm::SmallVector<int64_t> num_tiles_per_dim;
-    int64_t total_tiles = 1;
-    
-    for (size_t i = 0; i < ctx_.non_tiled_input_shape.size(); ++i) {
-      int64_t dim_size = ctx_.non_tiled_input_shape[i];
-      if (i == ctx_.all_gather_dimension) {
-        dim_size *= ctx_.world_size;
-      }
-      
-      int64_t block_size = i < shape.size() ? shape[i] : 1;
-      int64_t num_tiles = (dim_size + block_size - 1) / block_size;
-      num_tiles_per_dim.push_back(num_tiles);
-      total_tiles *= num_tiles;
-    }
-
-    // For swizzling, we use the first two dimensions (M and N)
-    const int64_t num_pid_m = num_tiles_per_dim.size() > 0 ? num_tiles_per_dim[0] : 1;
-    const int64_t num_pid_n = num_tiles_per_dim.size() > 1 ? num_tiles_per_dim[1] : 1;
-
-    // Create constants (always needed)
-    mlir::Value num_pid_m_val = arith::ConstantOp::create(
-        builder_, builder_.getI32Type(), builder_.getI32IntegerAttr(num_pid_m));
-    mlir::Value num_pid_n_val = arith::ConstantOp::create(
-        builder_, builder_.getI32Type(), builder_.getI32IntegerAttr(num_pid_n));
-
-    mlir::Value pid_m, pid_n;
-    
-    // If both M and N dimensions have only 1 tile, swizzling is unnecessary
-    // Just use tile_id directly for higher dimensions
-    if (num_pid_m == 1 && num_pid_n == 1) {
-      // No swizzling needed - both pid_m and pid_n are always 0
-      pid_m = arith::ConstantOp::create(builder_, builder_.getI32Type(),
-                                        builder_.getI32IntegerAttr(0));
-      pid_n = arith::ConstantOp::create(builder_, builder_.getI32Type(),
-                                        builder_.getI32IntegerAttr(0));
-    } else {
-      mlir::Value group_size_m_val =
-          arith::ConstantOp::create(builder_, builder_.getI32Type(),
-                                    builder_.getI32IntegerAttr(group_size_m));
-
-      // Swizzled tiling calculation
-      // num_pid_in_group = GROUP_SIZE_M * num_pid_n
-      mlir::Value num_pid_in_group =
-          arith::MulIOp::create(builder_, group_size_m_val, num_pid_n_val);
-
-      // group_id = tile_id // num_pid_in_group
-      mlir::Value group_id =
-          arith::DivSIOp::create(builder_, tile_id, num_pid_in_group);
-
-      // first_pid_m = group_id * GROUP_SIZE_M
-      mlir::Value first_pid_m =
-          arith::MulIOp::create(builder_, group_id, group_size_m_val);
-
-      // group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
-      mlir::Value remaining_m =
-          arith::SubIOp::create(builder_, num_pid_m_val, first_pid_m);
-      mlir::Value cmp = arith::CmpIOp::create(builder_, arith::CmpIPredicate::slt,
-                                              remaining_m, group_size_m_val);
-      mlir::Value group_size_m_actual =
-          arith::SelectOp::create(builder_, cmp, remaining_m, group_size_m_val);
-
-      // tile_id % num_pid_in_group
-      mlir::Value tile_id_mod =
-          arith::RemSIOp::create(builder_, tile_id, num_pid_in_group);
-
-      // pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
-      mlir::Value offset_m =
-          arith::RemSIOp::create(builder_, tile_id_mod, group_size_m_actual);
-      pid_m = arith::AddIOp::create(builder_, first_pid_m, offset_m);
-
-      // pid_n = (tile_id % num_pid_in_group) // group_size_m
-      pid_n = arith::DivSIOp::create(builder_, tile_id_mod, group_size_m_actual);
-    }
-
-    // 1. Copy local tile to symmetric buffer (all ranks do this)
-    if (mlir::failed(EmitCopyToSymmetric(
-            ctx_.input_tile, ctx_.input_extract.getOffsets(),
-            ctx_.input_tile.getType().getShape()))) {
-      return rewriter_.notifyMatchFailure(ctx_.op,
-                                          "Failed to emit copy to symmetric");
-    }
-
-    // 2. Synchronization: Wait for all ranks to complete the copy
-    if (mlir::failed(EmitSync(signal_value_))) {
-      return rewriter_.notifyMatchFailure(ctx_.op,
-                                          "Failed to emit sync for all-gather");
-    }
-
-    // 3. Decompose into per-dimension PIDs
-    llvm::SmallVector<mlir::Value> pids;
-    
-    for (size_t i = 0; i < ctx_.non_tiled_input_shape.size(); ++i) {
-      if (i < 2) {
-        // For first two dimensions, use the swizzled values
-        pids.push_back(i == 0 ? pid_m : pid_n);
-      } else {
-        // For higher dimensions, extract from tile_id
-        // Calculate stride: product of all previous dimension tile counts
-        int64_t stride = 1;
-        for (size_t j = 0; j < i; ++j) {
-          stride *= num_tiles_per_dim[j];
-        }
-        
-        mlir::Value stride_val = arith::ConstantOp::create(
-            builder_, builder_.getI32Type(),
-            builder_.getI32IntegerAttr(stride));
-        mlir::Value num_tiles_val = arith::ConstantOp::create(
-            builder_, builder_.getI32Type(),
-            builder_.getI32IntegerAttr(num_tiles_per_dim[i]));
-        
-        // pid_i = (tile_id / stride) % num_tiles_i
-        mlir::Value pid_i = arith::DivSIOp::create(builder_, tile_id, stride_val);
-        pid_i = arith::RemSIOp::create(builder_, pid_i, num_tiles_val);
-        pids.push_back(pid_i);
-      }
-    }
-    
-    // Now calculate offsets and source rank for each dimension
-    llvm::SmallVector<mlir::Value> local_offsets;
-    mlir::Value source_rank_i32 = nullptr;
-    
-    for (size_t i = 0; i < ctx_.non_tiled_input_shape.size(); ++i) {
-      mlir::Value pid = pids[i];
-      int64_t block_size = i < shape.size() ? shape[i] : 1;
-      int64_t dim_size = ctx_.non_tiled_input_shape[i];
-      
-      if (i == ctx_.all_gather_dimension) {
-        // This is the gather dimension
-        int64_t blocks_per_rank = std::max(int64_t{1}, 
-            (dim_size + block_size - 1) / block_size);
-        mlir::Value blocks_per_rank_val = arith::ConstantOp::create(
-            builder_, builder_.getI32Type(),
-            builder_.getI32IntegerAttr(blocks_per_rank));
-        
-        // source_rank = pid / blocks_per_rank
-        source_rank_i32 = arith::DivSIOp::create(builder_, pid, blocks_per_rank_val);
-        
-        // local_pid = pid % blocks_per_rank
-        mlir::Value local_pid = arith::RemSIOp::create(builder_, pid, blocks_per_rank_val);
-        
-        // offset = local_pid * block_size
-        mlir::Value offset = arith::MulIOp::create(
-            builder_, local_pid,
-            arith::ConstantOp::create(builder_, builder_.getI32Type(),
-                                      builder_.getI32IntegerAttr(block_size)));
-        local_offsets.push_back(arith::IndexCastOp::create(
-            builder_, builder_.getIndexType(), offset));
-      } else {
-        // Not the gather dimension - use pid directly
-        mlir::Value offset = arith::MulIOp::create(
-            builder_, pid,
-            arith::ConstantOp::create(builder_, builder_.getI32Type(),
-                                      builder_.getI32IntegerAttr(block_size)));
-        local_offsets.push_back(arith::IndexCastOp::create(
-            builder_, builder_.getIndexType(), offset));
-      }
-    }
-    
-    mlir::Value source_rank = arith::ExtSIOp::create(
-        builder_, builder_.getI64Type(), source_rank_i32);
-
-    xtile::TensorValue result =
-        LoadTileForRank(source_rank, local_offsets, shape);
-
-    // Replace the AllGather op with the loaded result
-    rewriter_.replaceOp(ctx_.op, result);
-
-    return mlir::success();
-  }
-
   AllGatherEmitterContext ctx_;
   mlir::PatternRewriter& rewriter_;
   mlir::ImplicitLocOpBuilder builder_;
@@ -1451,7 +1258,7 @@ mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
   }
 
   VLOG(3) << "AllGatherEmitter::Emit for all-gather";
-  return AllGatherEmitter::Emit(maybe_context.value(), rewriter, true);
+  return AllGatherEmitter::Emit(maybe_context.value(), rewriter);
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/codegen/triton/collective_emitter.h
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.h
@@ -77,5 +77,10 @@ absl::StatusOr<std::vector<Shape>> GetCollectiveUnmanagedKernelArguments(
 mlir::LogicalResult RewriteAllReduce(mlir::stablehlo::AllReduceOp op,
                                      mlir::PatternRewriter& rewriter);
 
+// Rewrites stablehlo all-gather op to a triton implementation.
+// TODO(allgather-triton): Implement this function
+mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
+                                     mlir::PatternRewriter& rewriter);
+
 }  // namespace xla::gpu
 #endif  // XLA_BACKENDS_GPU_CODEGEN_TRITON_COLLECTIVE_EMITTER_H_

--- a/xla/backends/gpu/codegen/triton/collective_emitter.h
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.h
@@ -78,9 +78,6 @@ mlir::LogicalResult RewriteAllReduce(mlir::stablehlo::AllReduceOp op,
                                      mlir::PatternRewriter& rewriter);
 
 // Rewrites stablehlo all-gather op to a triton implementation.
-// The implementation automatically chooses between standard and swizzled
-// memory access patterns based on the target GPU and instruction
-// characteristics.
 mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
                                      mlir::PatternRewriter& rewriter);
 

--- a/xla/backends/gpu/codegen/triton/collective_emitter.h
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.h
@@ -78,7 +78,9 @@ mlir::LogicalResult RewriteAllReduce(mlir::stablehlo::AllReduceOp op,
                                      mlir::PatternRewriter& rewriter);
 
 // Rewrites stablehlo all-gather op to a triton implementation.
-// TODO(allgather-triton): Implement this function
+// The implementation automatically chooses between standard and swizzled
+// memory access patterns based on the target GPU and instruction
+// characteristics.
 mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
                                      mlir::PatternRewriter& rewriter);
 

--- a/xla/backends/gpu/codegen/triton/fusion.cc
+++ b/xla/backends/gpu/codegen/triton/fusion.cc
@@ -125,25 +125,36 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
     absl::Span<const Shape> unmanaged_arguments) const {
   std::string suggested_kernel_name = std::string(fusion.name());
   llvm::IRBuilder builder(*ir_emitter_context.llvm_context());
-  VLOG(3) << fusion.ToString();
-  TF_ASSIGN_OR_RETURN(
-      auto kernel_arguments,
-      emitters::KernelArguments::Create(
-          ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
-          instr_override != nullptr ? instr_override : &fusion,
-          unmanaged_arguments));
+
+  // Special handling for AllGather with tuple unpacking
+  absl::StatusOr<emitters::KernelArguments> kernel_arguments_or;
+  if (instr_override != nullptr &&
+      instr_override->opcode() == HloOpcode::kAllGatherStart &&
+      instr_override->shape().IsTuple() && !fusion.shape().IsTuple()) {
+    // Use the new overload: fusion for shapes, AllGather for buffers at index
+    // {1}
+    kernel_arguments_or = emitters::KernelArguments::Create(
+        ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
+        &fusion,         // shape_instruction
+        instr_override,  // buffer_instruction
+        ShapeIndex{1},   // output_index (element 1 of AllGather tuple)
+        unmanaged_arguments);
+  } else {
+    // Regular path for AllReduce and other operations
+    kernel_arguments_or = emitters::KernelArguments::Create(
+        ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
+        instr_override != nullptr ? instr_override : &fusion,
+        unmanaged_arguments);
+  }
+  TF_ASSIGN_OR_RETURN(auto kernel_arguments, std::move(kernel_arguments_or));
 
   const HloComputation* hlo_computation =
       fusion.fused_instructions_computation();
-  VLOG(3) << "hlo_computation: " << hlo_computation->ToString();
 
   std::unique_ptr<llvm::Module> local_module;
   auto generate = [&]() -> absl::StatusOr<KernelReuseCache::Entry> {
-    VLOG(3) << "Generating: " << suggested_kernel_name;
-
     const std::string sanitized_kernel_name =
         ir_emitter_context.GetSanitizedUniqueName(suggested_kernel_name);
-
     TF_ASSIGN_OR_RETURN(
         TritonWrapperResult triton_wrapper_result,
         GenerateTritonKernelAndWrapper(
@@ -152,11 +163,9 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
             ir_emitter_context.data_layout(), ir_emitter_context.llvm_context(),
             ir_emitter_context.mlir_context()));
     local_module = std::move(triton_wrapper_result.llvm_module);
-
     auto backend_config =
         fusion.backend_config<GpuBackendConfig>()->fusion_backend_config();
     absl::string_view fusion_kind = backend_config.kind();
-
     LaunchDimensions launch_dimensions;
 
     // TODO(bchetioui,pifon): this list should be consolidated; why do we need
@@ -166,11 +175,9 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
         kTritonNestedGemmFusionKind,
         kTritonCollectiveFusionKind,
     };
-
     if (!absl::c_linear_search(kSupportedFusionKinds, fusion_kind)) {
       return Internal("Unsupported fusion kind: %s", fusion_kind);
     }
-
     std::optional<LaunchConfig> launch_config;
     // Currently GetLaunchConfig will compute the same value as the extracted
     // one. They are different only when warp specialization is enabled.
@@ -197,11 +204,9 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
 
     AnnotateAttrsIfUnset(kernel_arguments, *kernel);
     PopulateNvvmAnnotations(local_module.get(), kernel, triton_wrapper_result);
-
     TF_RETURN_IF_ERROR(AnnotateKernelLaunchDimensions(
         ir_emitter_context.gpu_device_info(), launch_dimensions, kernel,
         local_module.get()));
-
     return {{kernel->getName().str(), launch_dimensions,
              /*cluster_dim=*/std::nullopt, triton_wrapper_result.shmem_bytes,
              /*binary=*/"", triton_wrapper_result.tma_metadata}};
@@ -242,25 +247,45 @@ std::optional<TritonFusion::LaunchConfig> TritonFusion::GetLaunchConfig(
 
     // We expect all roots to have the same number of blocks. Otherwise we
     // cannot codegen it.
+    LOG(INFO) << "GetLaunchConfig: fusion_root_count="
+              << analysis_.fusion_root_count();
+
+    if (analysis_.fusion_root_count() == 0) {
+      LOG(ERROR) << "GetLaunchConfig: No fusion roots found!";
+      return std::nullopt;
+    }
+
     int64_t num_blocks =
         GetNumberOfBlocks(analysis_.fusion_root(0).shape().dimensions(),
                           block_level_parameters.output_tile_sizes[0]);
     for (int64_t i = 1; i < analysis_.fusion_root_count(); ++i) {
-      CHECK_EQ(GetNumberOfBlocks(analysis_.fusion_root(i).shape().dimensions(),
-                                 block_level_parameters.output_tile_sizes[i]),
-               num_blocks);
-    }
+      if (i >= block_level_parameters.output_tile_sizes.size()) {
+        LOG(ERROR)
+            << "GetLaunchConfig: output_tile_sizes index out of bounds! i=" << i
+            << ", size=" << block_level_parameters.output_tile_sizes.size();
+        return std::nullopt;
+      }
 
+      int64_t blocks_for_root =
+          GetNumberOfBlocks(analysis_.fusion_root(i).shape().dimensions(),
+                            block_level_parameters.output_tile_sizes[i]);
+
+      CHECK_EQ(blocks_for_root, num_blocks);
+    }
     LaunchConfig launch_config;
     // TODO(b/451901200): We eventually also want to be able to predict this
     // value without compiling so the cost model can rely on it. Currently, we
     // need the override for auto warp specialization.
+    LOG(INFO) << "GetLaunchConfig: thread_dims_override.has_value()="
+              << thread_dims_override.has_value();
+
     if (thread_dims_override) {
       launch_config.launch_dimensions = LaunchDimensions{
           se::BlockDim(num_blocks), thread_dims_override.value()};
     } else {
+      int64_t warp_size = WarpSize(analysis_.device_info());
       int64_t estimated_threads_per_block =
-          block_level_parameters.num_warps * WarpSize(analysis_.device_info());
+          block_level_parameters.num_warps * warp_size;
       launch_config.launch_dimensions =
           LaunchDimensions{static_cast<uint64_t>(num_blocks),
                            static_cast<uint64_t>(estimated_threads_per_block)};

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -361,12 +361,13 @@ CodegenDecision IsTritonSupportedAllGather(
                           ->config()
                           .debug_options()
                           .xla_gpu_unsupported_use_all_gather_triton_backend();
-  
+
   VLOG(1) << "IsTritonSupportedAllGather called for: " << all_gather.name()
           << ", flag_enabled=" << flag_enabled;
-  
+
   if (!flag_enabled) {
-    VLOG(1) << "AllGather Triton backend is DISABLED for: " << all_gather.name();
+    VLOG(1) << "AllGather Triton backend is DISABLED for: "
+            << all_gather.name();
     return CodegenDecision::Forbid(
         "Triton backend for all-gather is disabled. Enable with "
         "--xla_gpu_unsupported_use_all_gather_triton_backend=true");
@@ -383,7 +384,8 @@ CodegenDecision IsTritonSupportedAllGather(
         "S4, F8E4M3FN and F8E5M2 are not supported for all-gathers.");
   }
 
-  // TODO(allgather-triton): Add additional validation checks similar to AllReduce
+  // TODO(allgather-triton): Add additional validation checks similar to
+  // AllReduce
   // - Check replica groups
   // - Check gather dimension constraints
   // - Check size thresholds

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -353,6 +353,49 @@ CodegenDecision IsTritonSupportedAllReduce(
   return CodegenDecision::Allow();
 }
 
+CodegenDecision IsTritonSupportedAllGather(
+    const HloAllGatherInstruction& all_gather,
+    const se::GpuComputeCapability& gpu_version) {
+  // Check if the flag is enabled
+  bool flag_enabled = all_gather.GetModule()
+                          ->config()
+                          .debug_options()
+                          .xla_gpu_unsupported_use_all_gather_triton_backend();
+  
+  VLOG(1) << "IsTritonSupportedAllGather called for: " << all_gather.name()
+          << ", flag_enabled=" << flag_enabled;
+  
+  if (!flag_enabled) {
+    VLOG(1) << "AllGather Triton backend is DISABLED for: " << all_gather.name();
+    return CodegenDecision::Forbid(
+        "Triton backend for all-gather is disabled. Enable with "
+        "--xla_gpu_unsupported_use_all_gather_triton_backend=true");
+  }
+
+  VLOG(1) << "AllGather Triton backend is ENABLED for: " << all_gather.name();
+
+  if (all_gather.shape().element_type() == PrimitiveType::F8E4M3FN ||
+      all_gather.shape().element_type() == PrimitiveType::F8E5M2 ||
+      all_gather.shape().element_type() == PrimitiveType::S4) {
+    VLOG(1) << "AllGather rejected due to unsupported data type: "
+            << all_gather.shape().element_type();
+    return CodegenDecision::Forbid(
+        "S4, F8E4M3FN and F8E5M2 are not supported for all-gathers.");
+  }
+
+  // TODO(allgather-triton): Add additional validation checks similar to AllReduce
+  // - Check replica groups
+  // - Check gather dimension constraints
+  // - Check size thresholds
+
+  VLOG(1) << "AllGather Triton backend ALLOWED for: " << all_gather.name()
+          << " (but fusion wrapping may not happen - check thunk_emitter.cc)";
+
+  // Allow codegen to proceed - the actual "not implemented" error will be
+  // generated in collective_emitter.cc::RewriteAllGather()
+  return CodegenDecision::Allow();
+}
+
 bool IsInTritonNestedGemmFusion(const HloInstruction& hlo) {
   if (!hlo.parent()->IsFusionComputation()) {
     return false;
@@ -792,6 +835,12 @@ CodegenDecision IsTritonSupportedInstructionImpl(
     case HloOpcode::kAllReduceDone:
       return IsTritonSupportedAllReduce(
           *Cast<HloAllReduceInstruction>(instr.operand(0)), gpu_version);
+    case HloOpcode::kAllGatherStart:
+      return IsTritonSupportedAllGather(*Cast<HloAllGatherInstruction>(&instr),
+                                        gpu_version);
+    case HloOpcode::kAllGatherDone:
+      return IsTritonSupportedAllGather(
+          *Cast<HloAllGatherInstruction>(instr.operand(0)), gpu_version);
     default:
       // Not all instructions have a special handling.
       break;

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -375,9 +375,9 @@ CodegenDecision IsTritonSupportedAllGather(
 
   VLOG(1) << "AllGather Triton backend is ENABLED for: " << all_gather.name();
 
-  if (all_gather.shape().element_type() == PrimitiveType::F8E4M3FN ||
-      all_gather.shape().element_type() == PrimitiveType::F8E5M2 ||
-      all_gather.shape().element_type() == PrimitiveType::S4) {
+  PrimitiveType element_type = all_gather.operand(0)->shape().element_type();
+  if (element_type == F8E4M3FN || element_type == F8E5M2 ||
+      element_type == S4) {
     VLOG(1) << "AllGather rejected due to unsupported data type: "
             << all_gather.shape().element_type();
     return CodegenDecision::Forbid(

--- a/xla/backends/gpu/codegen/triton/transforms/stablehlo_lower_to_triton.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/stablehlo_lower_to_triton.cc
@@ -819,6 +819,18 @@ class LowerAllReduce : public mlir::OpRewritePattern<stablehlo::AllReduceOp> {
   }
 };
 
+class LowerAllGather : public mlir::OpRewritePattern<stablehlo::AllGatherOp> {
+ public:
+  using OpRewritePattern::OpRewritePattern;
+
+ private:
+  mlir::LogicalResult matchAndRewrite(
+      stablehlo::AllGatherOp op,
+      mlir::PatternRewriter& rewriter) const override {
+    return ::xla::gpu::RewriteAllGather(op, rewriter);
+  }
+};
+
 class StableHLOLowerToTritonPass
     : public impl::StableHLOLowerToTritonPassBase<StableHLOLowerToTritonPass> {
  public:
@@ -828,7 +840,8 @@ class StableHLOLowerToTritonPass
     mlir::MLIRContext* mlir_context = &getContext();
     mlir::RewritePatternSet patterns(mlir_context);
     patterns.add<LowerTranspose, LowerIotaToMakeRange, LowerBroadcastInDim,
-                 LowerReduce, LowerReshape, LowerAllReduce>(mlir_context);
+                 LowerReduce, LowerReshape, LowerAllReduce, LowerAllGather>(
+        mlir_context);
     patterns.add<LowerDotGeneral>(mlir_context, warp_specialization_allowed_);
 
     if (mlir::failed(

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1589,6 +1589,7 @@ cc_library(
     srcs = ["all_gather_thunk.cc"],
     hdrs = ["all_gather_thunk.h"],
     deps = [
+        ":collective_kernel_thunk",
         ":collective_thunk",
         ":thunk",
         "//xla:future",

--- a/xla/backends/gpu/runtime/all_gather_thunk.cc
+++ b/xla/backends/gpu/runtime/all_gather_thunk.cc
@@ -102,8 +102,8 @@ AllGatherStartThunk::AllGatherStartThunk(
       buffers_(std::move(buffers)),
       collective_kernel_thunk_(std::move(collective_kernel_thunk)) {
   CHECK_EQ(config_.config.operand_element_type.size(), buffers_.size());
-  LOG(INFO) << "AllGatherStartThunk created with CollectiveKernelThunk for: "
-            << inst->name();
+  VLOG(3) << "AllGatherStartThunk created with CollectiveKernelThunk for: "
+          << inst->name();
 }
 
 /*static*/ absl::Status AllGatherStartThunk::CheckImplementable(
@@ -211,8 +211,8 @@ absl::StatusOr<bool> AllGatherStartThunk::RunCollective(
       TF_RETURN_IF_ERROR(collective_kernel_thunk_->ExecuteOnStream(params));
       return true;
     }
-    LOG(INFO) << "AllGatherStartThunk: Triton kernel not supported, falling "
-                 "back to NCCL/RCCL";
+    VLOG(3) << "AllGatherStartThunk: Triton kernel not supported, falling "
+               "back to NCCL/RCCL";
   }
 
   // Fallback to NCCL/RCCL

--- a/xla/backends/gpu/runtime/all_gather_thunk.cc
+++ b/xla/backends/gpu/runtime/all_gather_thunk.cc
@@ -193,10 +193,9 @@ absl::Status AllGatherStartThunk::Initialize(const InitializeParams& params) {
   return absl::OkStatus();
 }
 
-absl::Status AllGatherStartThunk::RunCollective(const ExecuteParams& params,
-                                                const GpuCliqueKey& clique_key,
-                                                se::Stream& stream,
-                                                Communicator& comm) {
+absl::StatusOr<bool> AllGatherStartThunk::RunCollective(
+    const ExecuteParams& params, const GpuCliqueKey& clique_key,
+    se::Stream& stream, Communicator& comm) {
   ASSIGN_OR_RETURN(std::vector<DeviceBufferPair> device_buffers,
                    ConvertToDeviceBuffers(params.buffer_allocations, buffers_,
                                           config_.config.operand_element_type));
@@ -209,15 +208,17 @@ absl::Status AllGatherStartThunk::RunCollective(const ExecuteParams& params,
             clique_key, *params.stream->parent(), *params.collective_params));
 
     if (use_collective_kernel) {
-      return collective_kernel_thunk_->ExecuteOnStream(params);
+      TF_RETURN_IF_ERROR(collective_kernel_thunk_->ExecuteOnStream(params));
+      return true;
     }
     LOG(INFO) << "AllGatherStartThunk: Triton kernel not supported, falling "
                  "back to NCCL/RCCL";
   }
 
   // Fallback to NCCL/RCCL
-  return xla::gpu::RunAllGather(device_buffers, stream, comm,
-                                config_.config.use_symmetric_buffer);
+  TF_RETURN_IF_ERROR(xla::gpu::RunAllGather(device_buffers, stream, comm,
+                                             config_.config.use_symmetric_buffer));
+  return true;
 }
 
 absl::Status RunAllGather(std::vector<DeviceBufferPair>& buffers,

--- a/xla/backends/gpu/runtime/all_gather_thunk.cc
+++ b/xla/backends/gpu/runtime/all_gather_thunk.cc
@@ -216,8 +216,8 @@ absl::StatusOr<bool> AllGatherStartThunk::RunCollective(
   }
 
   // Fallback to NCCL/RCCL
-  TF_RETURN_IF_ERROR(xla::gpu::RunAllGather(device_buffers, stream, comm,
-                                             config_.config.use_symmetric_buffer));
+  TF_RETURN_IF_ERROR(xla::gpu::RunAllGather(
+      device_buffers, stream, comm, config_.config.use_symmetric_buffer));
   return true;
 }
 

--- a/xla/backends/gpu/runtime/all_gather_thunk.cc
+++ b/xla/backends/gpu/runtime/all_gather_thunk.cc
@@ -40,9 +40,9 @@ limitations under the License.
 #include "xla/shape_util.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "tsl/platform/casts.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -89,6 +89,21 @@ AllGatherStartThunk::AllGatherStartThunk(ThunkInfo thunk_info,
       config_(GetAllGatherConfig(inst)),
       buffers_(std::move(buffers)) {
   CHECK_EQ(config_.config.operand_element_type.size(), buffers_.size());
+}
+
+AllGatherStartThunk::AllGatherStartThunk(
+    ThunkInfo thunk_info, const HloAllGatherInstruction* inst,
+    std::vector<Buffer> buffers,
+    std::unique_ptr<CollectiveKernelThunk> collective_kernel_thunk,
+    bool p2p_memcpy_enabled)
+    : CollectiveThunk(Thunk::kAllGatherStart, thunk_info,
+                      IsGPUSyncCollective(*inst), false),
+      config_(GetAllGatherConfig(inst)),
+      buffers_(std::move(buffers)),
+      collective_kernel_thunk_(std::move(collective_kernel_thunk)) {
+  CHECK_EQ(config_.config.operand_element_type.size(), buffers_.size());
+  LOG(INFO) << "AllGatherStartThunk created with CollectiveKernelThunk for: "
+            << inst->name();
 }
 
 /*static*/ absl::Status AllGatherStartThunk::CheckImplementable(
@@ -153,15 +168,56 @@ absl::StatusOr<ThunkProto> AllGatherStartThunk::ToProto() const {
   return proto;
 }
 
-absl::StatusOr<bool> AllGatherStartThunk::RunCollective(
-    const ExecuteParams& params, const GpuCliqueKey& clique_key,
-    se::Stream& stream, Communicator& comm) {
+absl::Status AllGatherStartThunk::Prepare(const PrepareParams& params) {
+  TF_RETURN_IF_ERROR(CollectiveThunk::Prepare(params));
+  if (collective_kernel_thunk_) {
+    return collective_kernel_thunk_->Prepare(params);
+  }
+  return absl::OkStatus();
+}
+
+absl::Status AllGatherStartThunk::Initialize(const InitializeParams& params) {
+  TF_RETURN_IF_ERROR(CollectiveThunk::Initialize(params));
+  if (collective_kernel_thunk_) {
+    TF_ASSIGN_OR_RETURN(GpuCliqueKey clique_key,
+                        GetCollectiveGpuCliqueKey(*params.collective_params,
+                                                  config(), /*is_p2p=*/false));
+    TF_ASSIGN_OR_RETURN(
+        bool use_collective_kernel,
+        collective_kernel_thunk_->IsSupported(clique_key, *params.executor,
+                                              *params.collective_params));
+    if (use_collective_kernel) {
+      TF_RETURN_IF_ERROR(collective_kernel_thunk_->Initialize(params));
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status AllGatherStartThunk::RunCollective(const ExecuteParams& params,
+                                                const GpuCliqueKey& clique_key,
+                                                se::Stream& stream,
+                                                Communicator& comm) {
   ASSIGN_OR_RETURN(std::vector<DeviceBufferPair> device_buffers,
                    ConvertToDeviceBuffers(params.buffer_allocations, buffers_,
                                           config_.config.operand_element_type));
-  RETURN_IF_ERROR(xla::gpu::RunAllGather(device_buffers, stream, comm,
-                                         config_.config.use_symmetric_buffer));
-  return true;
+
+  // Try to use Triton collective kernel if available
+  if (collective_kernel_thunk_) {
+    TF_ASSIGN_OR_RETURN(
+        bool use_collective_kernel,
+        collective_kernel_thunk_->IsSupported(
+            clique_key, *params.stream->parent(), *params.collective_params));
+
+    if (use_collective_kernel) {
+      return collective_kernel_thunk_->ExecuteOnStream(params);
+    }
+    LOG(INFO) << "AllGatherStartThunk: Triton kernel not supported, falling "
+                 "back to NCCL/RCCL";
+  }
+
+  // Fallback to NCCL/RCCL
+  return xla::gpu::RunAllGather(device_buffers, stream, comm,
+                                config_.config.use_symmetric_buffer);
 }
 
 absl::Status RunAllGather(std::vector<DeviceBufferPair>& buffers,

--- a/xla/backends/gpu/runtime/all_gather_thunk.h
+++ b/xla/backends/gpu/runtime/all_gather_thunk.h
@@ -87,13 +87,12 @@ class AllGatherStartThunk : public CollectiveThunk {
   }
 
  protected:
-  bool RequiresRendezvous() const override { return true; }
-
   absl::Status Prepare(const PrepareParams& params) override;
   absl::Status Initialize(const InitializeParams& params) override;
-  absl::Status RunCollective(const ExecuteParams& params,
-                             const GpuCliqueKey& clique_key, se::Stream& stream,
-                             Communicator& comm) override;
+  absl::StatusOr<bool> RunCollective(const ExecuteParams& params,
+                                     const GpuCliqueKey& clique_key,
+                                     se::Stream& stream,
+                                     Communicator& comm) override;
 
  private:
   const AllGatherConfig config_;

--- a/xla/backends/gpu/runtime/all_gather_thunk.h
+++ b/xla/backends/gpu/runtime/all_gather_thunk.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
+#include "xla/backends/gpu/runtime/collective_kernel_thunk.h"
 #include "xla/backends/gpu/runtime/collective_thunk.h"
 #include "xla/core/collectives/communicator.h"
 #include "xla/hlo/ir/hlo_instructions.h"
@@ -44,6 +45,11 @@ class AllGatherStartThunk : public CollectiveThunk {
   AllGatherStartThunk(ThunkInfo thunk_info, const HloAllGatherInstruction* inst,
                       std::vector<Buffer> buffers,
                       bool p2p_memcpy_enabled = false);
+  AllGatherStartThunk(
+      ThunkInfo thunk_info, const HloAllGatherInstruction* inst,
+      std::vector<Buffer> buffers,
+      std::unique_ptr<CollectiveKernelThunk> collective_kernel_thunk,
+      bool p2p_memcpy_enabled = false);
   AllGatherStartThunk(
       ThunkInfo thunk_info,
       std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
@@ -81,14 +87,18 @@ class AllGatherStartThunk : public CollectiveThunk {
   }
 
  protected:
-  absl::StatusOr<bool> RunCollective(const ExecuteParams& params,
-                                     const GpuCliqueKey& clique_key,
-                                     se::Stream& stream,
-                                     Communicator& comm) override;
+  bool RequiresRendezvous() const override { return true; }
+
+  absl::Status Prepare(const PrepareParams& params) override;
+  absl::Status Initialize(const InitializeParams& params) override;
+  absl::Status RunCollective(const ExecuteParams& params,
+                             const GpuCliqueKey& clique_key, se::Stream& stream,
+                             Communicator& comm) override;
 
  private:
   const AllGatherConfig config_;
   const std::vector<Buffer> buffers_;
+  std::unique_ptr<CollectiveKernelThunk> collective_kernel_thunk_;
 };
 
 absl::Status RunAllGather(std::vector<DeviceBufferPair>& buffers,

--- a/xla/backends/gpu/runtime/all_reduce.cc
+++ b/xla/backends/gpu/runtime/all_reduce.cc
@@ -69,7 +69,6 @@ static constexpr auto kAddBF16Tags =
     TagRegistry<bfloat16, ReductionKind::SUM>{};
 static constexpr auto kOrPredTags = TagRegistry<bool, ReductionKind::MAX>{};
 // Heuristic maxima after some benchmarking.
-static constexpr int64_t kMaxBlocksPerGrid = 24;
 static constexpr int64_t kMaxThreadsPerBlock = 512;
 static constexpr int64_t kWarpSize = 32;
 
@@ -192,7 +191,7 @@ LaunchDimensions CollectiveLaunchDimensions(int64_t elements, int64_t num_ranks,
   const int64_t total_threads =
       RoundUpTo(elements_per_rank / se::gpu::kNumElementsPerThread, kWarpSize);
   threads_per_block = std::min(kMaxThreadsPerBlock, total_threads);
-  blocks_per_grid = std::min(kMaxBlocksPerGrid,
+  blocks_per_grid = std::min(kMaxCollectiveBlocksPerGrid,
                              CeilOfRatio(total_threads, threads_per_block));
   return LaunchDimensions(blocks_per_grid, threads_per_block);
 }

--- a/xla/backends/gpu/runtime/all_reduce.cc
+++ b/xla/backends/gpu/runtime/all_reduce.cc
@@ -182,8 +182,8 @@ int64_t GetMaxSupportedAllReduceSizeBytes(AllReduceStrategy strategy) {
   }
 }
 
-LaunchDimensions AllReduceLaunchDimensions(int64_t elements, int64_t num_ranks,
-                                           AllReduceStrategy strategy) {
+LaunchDimensions CollectiveLaunchDimensions(int64_t elements, int64_t num_ranks,
+                                            AllReduceStrategy strategy) {
   int64_t threads_per_block;
   int64_t blocks_per_grid;
   const int64_t elements_per_rank =

--- a/xla/backends/gpu/runtime/all_reduce.h
+++ b/xla/backends/gpu/runtime/all_reduce.h
@@ -30,6 +30,11 @@ limitations under the License.
 
 namespace xla::gpu {
 
+// Maximum number of blocks per grid for collective operations.
+// This constant is used for both launch dimension calculations and
+// signal buffer shape sizing to ensure consistency.
+inline constexpr int64_t kMaxCollectiveBlocksPerGrid = 24;
+
 // Returns the all-reduce strategy for the given input size.
 // If `is_multimem_enabled` is true, then multimem strategies are also
 // considered.

--- a/xla/backends/gpu/runtime/all_reduce.h
+++ b/xla/backends/gpu/runtime/all_reduce.h
@@ -43,8 +43,8 @@ int64_t GetMaxSupportedAllReduceSizeBytes(se::gpu::AllReduceStrategy strategy);
 // Returns the launch dimensions for the all-reduce kernel.
 // The launch dimensions are determined by the number of elements and the
 // the all-reduce strategy.
-LaunchDimensions CollectiveLaunchDimensions(int64_t elements, int64_t num_ranks,
-                                            se::gpu::AllReduceStrategy strategy);
+LaunchDimensions CollectiveLaunchDimensions(
+    int64_t elements, int64_t num_ranks, se::gpu::AllReduceStrategy strategy);
 
 // Returns true if the all-reduce kernel is supported for the given number
 // of inputs, elements, element type and reduction kind.

--- a/xla/backends/gpu/runtime/all_reduce.h
+++ b/xla/backends/gpu/runtime/all_reduce.h
@@ -43,8 +43,8 @@ int64_t GetMaxSupportedAllReduceSizeBytes(se::gpu::AllReduceStrategy strategy);
 // Returns the launch dimensions for the all-reduce kernel.
 // The launch dimensions are determined by the number of elements and the
 // the all-reduce strategy.
-LaunchDimensions AllReduceLaunchDimensions(int64_t elements, int64_t num_ranks,
-                                           se::gpu::AllReduceStrategy strategy);
+LaunchDimensions CollectiveLaunchDimensions(int64_t elements, int64_t num_ranks,
+                                            se::gpu::AllReduceStrategy strategy);
 
 // Returns true if the all-reduce kernel is supported for the given number
 // of inputs, elements, element type and reduction kind.

--- a/xla/backends/gpu/runtime/all_reduce_test.cc
+++ b/xla/backends/gpu/runtime/all_reduce_test.cc
@@ -97,7 +97,7 @@ class AllReduceKernelTest : public ::testing::Test,
       const std::vector<se::StreamExecutor*>& executors,
       const std::vector<Array<T>>& input_data, ReductionKind reduction_kind) {
     const int64_t num_ranks = input_data.size();
-    const LaunchDimensions launch_dimensions = AllReduceLaunchDimensions(
+    const LaunchDimensions launch_dimensions = CollectiveLaunchDimensions(
         input_data[0].num_elements(), num_ranks, params_.all_reduce_strategy);
 
     int64_t num_elements = input_data[0].num_elements();

--- a/xla/backends/gpu/runtime/all_reduce_thunk.cc
+++ b/xla/backends/gpu/runtime/all_reduce_thunk.cc
@@ -247,6 +247,7 @@ AllReduceStartThunk::FromProto(
   auto kernel_thunk = std::make_unique<CollectiveKernelThunk>(
       thunk_info, config, reduction_kind, thunk_proto.is_async(), buffers,
       thunk_proto.collective_kernel_enabled(), thunk_proto.kernel_name(),
+      std::nullopt,  // launch_dimensions
       thunk_proto.shmem_bytes(), thunk_proto.is_multimem_enabled());
 
   return std::make_unique<AllReduceStartThunk>(

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.cc
@@ -151,6 +151,9 @@ absl::Status CopyCollectiveMetadataToDevice(
 absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
     const GpuCliqueKey& clique_key, se::StreamExecutor& executor,
     const CollectiveParams& collective_params) const {
+  const bool is_all_gather =
+      (collective_op_kind_ == CollectiveOpKind::kAllGather);
+
   if (!collective_kernel_enabled_) {
     XLA_VLOG_DEVICE(3, executor.device_ordinal())
         << "Collective kernel is not enabled.";
@@ -163,15 +166,20 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
         << "Variadic arguments are not implemented for collective kernels.";
     return false;
   }
+
   const int64_t num_elements = buffers_[0].element_count;
   const int64_t input_size_bytes = GetInputSizeBytes();
-  const AllReduceStrategy strategy =
-      GetAllReduceStrategy(input_size_bytes, is_multimem_enabled_);
-  // Custom all-reduce strategy is only supported for small inputs.
-  if (input_size_bytes > GetMaxSupportedAllReduceSizeBytes(strategy)) {
-    XLA_VLOG_DEVICE(3, executor.device_ordinal())
-        << "Custom all-reduce strategy is only supported for small inputs.";
-    return false;
+
+  // Skip all-reduce-specific checks for all-gather
+  if (!is_all_gather) {
+    const AllReduceStrategy strategy =
+        GetAllReduceStrategy(input_size_bytes, is_multimem_enabled_);
+    // Custom all-reduce strategy is only supported for small inputs.
+    if (input_size_bytes > GetMaxSupportedAllReduceSizeBytes(strategy)) {
+      XLA_VLOG_DEVICE(3, executor.device_ordinal())
+          << "Custom all-reduce strategy is only supported for small inputs.";
+      return false;
+    }
   }
 
   // Only single-host collectives are supported for now.
@@ -191,9 +199,20 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
     }
   }
 
-  return IsAllReduceKernelSupported(
+  // For all-gather, we need an emitted Triton kernel
+  // If no kernel was emitted (kernel_name_ is empty), fall back to NCCL
+  if (is_all_gather) {
+    bool has_kernel = !kernel_name_.empty();
+    return has_kernel;
+  }
+
+  // All-reduce specific validation
+  const AllReduceStrategy strategy =
+      GetAllReduceStrategy(input_size_bytes, is_multimem_enabled_);
+  bool supported = IsAllReduceKernelSupported(
       clique_key.num_local_participants(), num_elements,
       collective_config_.operand_element_type[0], reduction_kind_, strategy);
+  return supported;
 }
 
 absl::Status CollectiveKernelThunk::Prepare(const PrepareParams& params) {
@@ -404,8 +423,8 @@ absl::Status CollectiveKernelThunk::Initialize(const InitializeParams& params) {
           tsl::safe_reinterpret_cast<char*>(dst_mmem) + dst_mmem_offset;
 
       XLA_VLOG_DEVICE(3, params.executor->device_ordinal())
-          << "Constructed device state {"
-          << " metadata rank: " << metadata.rank << ", param_to_peers: ("
+          << "Constructed device state {" << " metadata rank: " << metadata.rank
+          << ", param_to_peers: ("
           << absl::StrJoin(param_to_peers_ptrs, ", ", PtrFormatter{})
           << "), multimem_addresses: ("
           << absl::StrJoin(multimem_addresses, ", ", PtrFormatter{}) << ")}";

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.cc
@@ -154,15 +154,15 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
   const bool is_all_gather =
       (collective_op_kind_ == CollectiveOpKind::kAllGather);
 
-  LOG(INFO) << "CollectiveKernelThunk::IsSupported called, is_all_gather="
-            << is_all_gather
-            << ", collective_kernel_enabled_=" << collective_kernel_enabled_;
+  VLOG(3) << "CollectiveKernelThunk::IsSupported called, is_all_gather="
+          << is_all_gather
+          << ", collective_kernel_enabled_=" << collective_kernel_enabled_;
 
   if (!collective_kernel_enabled_) {
     XLA_VLOG_DEVICE(3, executor.device_ordinal())
         << "Collective kernel is not enabled.";
-    LOG(INFO) << "CollectiveKernelThunk::IsSupported: "
-                 "collective_kernel_enabled_ is false";
+    VLOG(3) << "CollectiveKernelThunk::IsSupported: "
+               "collective_kernel_enabled_ is false";
     return false;
   }
 
@@ -170,7 +170,7 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
   if (buffers_.size() != 1) {
     XLA_VLOG_DEVICE(3, executor.device_ordinal())
         << "Variadic arguments are not implemented for collective kernels.";
-    LOG(INFO) << "CollectiveKernelThunk::IsSupported: buffers_.size() != 1";
+    VLOG(3) << "CollectiveKernelThunk::IsSupported: buffers_.size() != 1";
     return false;
   }
 
@@ -185,8 +185,8 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
     if (input_size_bytes > GetMaxSupportedAllReduceSizeBytes(strategy)) {
       XLA_VLOG_DEVICE(3, executor.device_ordinal())
           << "Custom all-reduce strategy is only supported for small inputs.";
-      LOG(INFO) << "CollectiveKernelThunk::IsSupported: input_size_bytes too "
-                   "large for all-reduce";
+      VLOG(3) << "CollectiveKernelThunk::IsSupported: input_size_bytes too "
+                 "large for all-reduce";
       return false;
     }
   }
@@ -195,7 +195,7 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
   if (!clique_key.is_local()) {
     XLA_VLOG_DEVICE(3, executor.device_ordinal())
         << "Cross-host symmetric memory collectives are not supported.";
-    LOG(INFO) << "CollectiveKernelThunk::IsSupported: clique_key is not local";
+    VLOG(3) << "CollectiveKernelThunk::IsSupported: clique_key is not local";
     return false;
   }
 
@@ -205,9 +205,9 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
     if (!executor.CanEnablePeerAccessTo(peer_device_id)) {
       XLA_VLOG_DEVICE(3, executor.device_ordinal())
           << "Peer access is not supported with device " << peer_device_id;
-      LOG(INFO) << "CollectiveKernelThunk::IsSupported: peer access not "
-                   "supported to device "
-                << peer_device_id;
+      VLOG(3) << "CollectiveKernelThunk::IsSupported: peer access not "
+                 "supported to device "
+              << peer_device_id;
       return false;
     }
   }
@@ -216,19 +216,22 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
   // If no kernel was emitted (kernel_name_ is empty), fall back to NCCL
   if (is_all_gather) {
     bool has_kernel = !kernel_name_.empty();
-    LOG(INFO) << "CollectiveKernelThunk::IsSupported: returning " << has_kernel
-              << " for all-gather (has_kernel=" << has_kernel << ")";
+    VLOG(3) << "CollectiveKernelThunk::IsSupported: returning " << has_kernel
+            << " for all-gather (has_kernel=" << has_kernel << ")";
     return has_kernel;
   }
 
   // All-reduce specific validation
+  TF_RET_CHECK(reduction_kind_.has_value())
+      << "Reduction kind must be set for AllReduce operations";
   const AllReduceStrategy strategy =
       GetAllReduceStrategy(input_size_bytes, is_multimem_enabled_);
   bool supported = IsAllReduceKernelSupported(
       clique_key.num_local_participants(), num_elements,
-      collective_config_.operand_element_type[0], reduction_kind_, strategy);
-  LOG(INFO) << "CollectiveKernelThunk::IsSupported: returning " << supported
-            << " for all-reduce";
+      collective_config_.operand_element_type[0], reduction_kind_.value(),
+      strategy);
+  VLOG(3) << "CollectiveKernelThunk::IsSupported: returning " << supported
+          << " for all-reduce";
   return supported;
 }
 
@@ -584,11 +587,18 @@ absl::Status CollectiveKernelThunk::ExecuteOnStream(
       << "(block x threadsPerBlock)";
 
   // TODO(b/407736956): Change this to emitted kernel.
+  // AllGather should not reach this code path as it requires an emitted kernel.
+  // The reduction_kind_ field is only valid for AllReduce operations.
+  CHECK(collective_op_kind_ == CollectiveOpKind::kAllReduce)
+      << "RunAllReduceKernel should only be called for AllReduce operations, "
+      << "not for AllGather. AllGather requires an emitted Triton kernel.";
+  TF_RET_CHECK(reduction_kind_.has_value())
+      << "Reduction kind must be set for AllReduce operations";
   return RunAllReduceKernel(
       /*stream=*/stream,
       /*launch_dimensions=*/launch_dimensions,
       /*element_type=*/element_type,
-      /*reduction_kind=*/reduction_kind_,
+      /*reduction_kind=*/reduction_kind_.value(),
       /*all_reduce_strategy=*/strategy,
       /*symmetric_input_buffer=*/input_buffer_ptr,
       /*local_input_buffer=*/source_buffer,

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.cc
@@ -154,9 +154,15 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
   const bool is_all_gather =
       (collective_op_kind_ == CollectiveOpKind::kAllGather);
 
+  LOG(INFO) << "CollectiveKernelThunk::IsSupported called, is_all_gather="
+            << is_all_gather
+            << ", collective_kernel_enabled_=" << collective_kernel_enabled_;
+
   if (!collective_kernel_enabled_) {
     XLA_VLOG_DEVICE(3, executor.device_ordinal())
         << "Collective kernel is not enabled.";
+    LOG(INFO) << "CollectiveKernelThunk::IsSupported: "
+                 "collective_kernel_enabled_ is false";
     return false;
   }
 
@@ -164,6 +170,7 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
   if (buffers_.size() != 1) {
     XLA_VLOG_DEVICE(3, executor.device_ordinal())
         << "Variadic arguments are not implemented for collective kernels.";
+    LOG(INFO) << "CollectiveKernelThunk::IsSupported: buffers_.size() != 1";
     return false;
   }
 
@@ -178,6 +185,8 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
     if (input_size_bytes > GetMaxSupportedAllReduceSizeBytes(strategy)) {
       XLA_VLOG_DEVICE(3, executor.device_ordinal())
           << "Custom all-reduce strategy is only supported for small inputs.";
+      LOG(INFO) << "CollectiveKernelThunk::IsSupported: input_size_bytes too "
+                   "large for all-reduce";
       return false;
     }
   }
@@ -186,6 +195,7 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
   if (!clique_key.is_local()) {
     XLA_VLOG_DEVICE(3, executor.device_ordinal())
         << "Cross-host symmetric memory collectives are not supported.";
+    LOG(INFO) << "CollectiveKernelThunk::IsSupported: clique_key is not local";
     return false;
   }
 
@@ -195,6 +205,9 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
     if (!executor.CanEnablePeerAccessTo(peer_device_id)) {
       XLA_VLOG_DEVICE(3, executor.device_ordinal())
           << "Peer access is not supported with device " << peer_device_id;
+      LOG(INFO) << "CollectiveKernelThunk::IsSupported: peer access not "
+                   "supported to device "
+                << peer_device_id;
       return false;
     }
   }
@@ -203,6 +216,8 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
   // If no kernel was emitted (kernel_name_ is empty), fall back to NCCL
   if (is_all_gather) {
     bool has_kernel = !kernel_name_.empty();
+    LOG(INFO) << "CollectiveKernelThunk::IsSupported: returning " << has_kernel
+              << " for all-gather (has_kernel=" << has_kernel << ")";
     return has_kernel;
   }
 
@@ -212,6 +227,8 @@ absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
   bool supported = IsAllReduceKernelSupported(
       clique_key.num_local_participants(), num_elements,
       collective_config_.operand_element_type[0], reduction_kind_, strategy);
+  LOG(INFO) << "CollectiveKernelThunk::IsSupported: returning " << supported
+            << " for all-reduce";
   return supported;
 }
 
@@ -253,8 +270,18 @@ absl::Status CollectiveKernelThunk::Prepare(const PrepareParams& params) {
         clique_key.num_local_participants() * launch_dimensions.num_blocks();
     const int64_t kSignalBufferSize = xla::RoundUpTo<uint64_t>(
         kNumSignalFlags * sizeof(int32_t), kXlaAllocatedBufferAlignBytes);
+
+    // For AllGather, we need to allocate buffers based on the destination size
+    // (which is num_replicas * source_size), not the source size.
+    // For AllReduce, source and destination sizes are the same.
+    const bool is_all_gather =
+        (collective_op_kind_ == CollectiveOpKind::kAllGather);
+    const int64_t buffer_size_to_allocate =
+        is_all_gather ? buffers_[0].destination_buffer.slice.size()
+                      : buffers_[0].source_buffer.slice.size();
+
     const int64_t kLocalBufferSize = xla::RoundUpTo<uint64_t>(
-        buffers_[0].source_buffer.slice.size(), kXlaAllocatedBufferAlignBytes);
+        buffer_size_to_allocate, kXlaAllocatedBufferAlignBytes);
     TF_ASSIGN_OR_RETURN(
         se::DeviceAddressHandle local_buffers_handle,
         AllocateMemory(params.executor, kLocalBufferSize * kNumBuffers,
@@ -429,6 +456,9 @@ absl::Status CollectiveKernelThunk::Initialize(const InitializeParams& params) {
           << "), multimem_addresses: ("
           << absl::StrJoin(multimem_addresses, ", ", PtrFormatter{}) << ")}";
     } else {
+      // For both AllReduce and AllGather, we exchange 2 buffers via P2P:
+      // - Parameter 0: Data symmetric buffer (local_buffers)
+      // - Parameter 1: Signal/synchronization buffer (signal_buffers)
       std::vector<se::DeviceAddressBase> parameters{
           memory_state->local_buffers_handle.address(),
           memory_state->signal_buffers_handle.address()};

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.cc
@@ -263,9 +263,10 @@ absl::Status CollectiveKernelThunk::Prepare(const PrepareParams& params) {
     // Allocate scratch buffers.
     const AllReduceStrategy strategy =
         GetAllReduceStrategy(GetInputSizeBytes(), is_multimem_enabled_);
-    const LaunchDimensions launch_dimensions = AllReduceLaunchDimensions(
-        buffers_[0].element_count, clique_key.num_local_participants(),
-        strategy);
+    const LaunchDimensions launch_dimensions =
+        launch_dimensions_.value_or(CollectiveLaunchDimensions(
+            buffers_[0].element_count, clique_key.num_local_participants(),
+            strategy));
     const int64_t kNumSignalFlags =
         clique_key.num_local_participants() * launch_dimensions.num_blocks();
     const int64_t kSignalBufferSize = xla::RoundUpTo<uint64_t>(
@@ -343,17 +344,20 @@ absl::Status CollectiveKernelThunk::Initialize(const InitializeParams& params) {
     if (!per_stream_state_.contains(params.executor)) {
       StreamMemory* memory_state = per_stream_memory_.at(params.executor).get();
       // Step1: We needs 1 atomic flag per block per device on each device.
-      // One-shot kernel expects that the signal flags buffer is zeroed out.
+      // The kernel expects that the signal flags buffer is zeroed out.
       // Initial state of device memory is undefined, so we need to zero out
       // the buffer. The kernel will take care of leaving the buffer in
       // correct state after use, so we don't need to zero out after
       // initialization.
       TF_RETURN_IF_ERROR(params.executor->SynchronousMemZero(
-          memory_state->signal_buffers_handle.memory_ptr(),
-          memory_state->signal_buffers_handle.memory().size()));
+          memory_state->signal_buffers_handle.address_ptr(),
+          memory_state->signal_buffers_handle.address().size()));
       // Create a kernel for execution.
       std::unique_ptr<se::Kernel> kernel = nullptr;
       if (!kernel_name_.empty()) {
+        TF_RET_CHECK(launch_dimensions_.has_value())
+            << "Launch dimensions are not set for when using emitted "
+               "collective kernel.";
         if (!params.src.binary.empty()) {
           TF_ASSIGN_OR_RETURN(
               kernel,
@@ -528,12 +532,11 @@ absl::Status CollectiveKernelThunk::ExecuteOnStream(
   const uint32_t buffer_index = state->invocation_count % kNumBuffers;
   const AllReduceStrategy strategy =
       GetAllReduceStrategy(GetInputSizeBytes(), is_multimem_enabled_);
-  const LaunchDimensions launch_dimensions =
-      AllReduceLaunchDimensions(buffer.element_count, num_devices, strategy);
   // In case of two-shot we want to increment in multiples of 2.
   state->invocation_count += 1 + static_cast<uint32_t>(strategy);
   XLA_VLOG_DEVICE(3, device_ordinal)
-      << "Performing one-shot all-reduce for clique " << clique_key.ToString();
+      << "Performing " << strategy << " all-reduce for clique "
+      << clique_key.ToString();
 
   se::DeviceAddressBase input_buffer_ptr =
       state->remote_buffer_ptrs[buffer_index];
@@ -542,12 +545,16 @@ absl::Status CollectiveKernelThunk::ExecuteOnStream(
   XLA_VLOG_DEVICE(3, device_ordinal)
       << "input_buffer_ptr: " << input_buffer_ptr.opaque()
       << " signal_buffer_ptr: " << signal_buffer_ptr.opaque();
-  XLA_VLOG_DEVICE(3, device_ordinal)
-      << "launch dimensions: " << launch_dimensions.num_blocks() << "x"
-      << launch_dimensions.num_threads_per_block()
-      << "(block x threadsPerBlock)";
 
   if (state->kernel != nullptr) {
+    TF_RET_CHECK(launch_dimensions_.has_value())
+        << "Launch dimensions are not set for when using emitted "
+           "collective kernel.";
+    XLA_VLOG_DEVICE(3, device_ordinal)
+        << "Emitted kernel launch dimensions: "
+        << launch_dimensions_->num_blocks() << "x"
+        << launch_dimensions_->num_threads_per_block()
+        << "(block x threadsPerBlock)";
     TF_ASSIGN_OR_RETURN(se::DeviceAddressBase remote_buffers,
                         GetParameterDeviceMemoryBase(
                             state->metadata, /*num_parameters=*/kNumParameters,
@@ -565,9 +572,16 @@ absl::Status CollectiveKernelThunk::ExecuteOnStream(
         /* signal_value= */ state->invocation_count,
         signal_buffers,
         remote_buffers};
-    return ExecuteKernelOnStream(*state->kernel, kernel_args, launch_dimensions,
+    return ExecuteKernelOnStream(*state->kernel, kernel_args,
+                                 launch_dimensions_.value(),
                                  /*cluster_dim=*/std::nullopt, stream);
   }
+  const LaunchDimensions launch_dimensions =
+      CollectiveLaunchDimensions(buffer.element_count, num_devices, strategy);
+  XLA_VLOG_DEVICE(3, device_ordinal)
+      << "CUDA kernel launch dimensions: " << launch_dimensions.num_blocks()
+      << "x" << launch_dimensions.num_threads_per_block()
+      << "(block x threadsPerBlock)";
 
   // TODO(b/407736956): Change this to emitted kernel.
   return RunAllReduceKernel(

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.h
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.h
@@ -54,16 +54,25 @@ namespace xla::gpu {
 // - Launch the kernel.
 class CollectiveKernelThunk : public Thunk {
  public:
+  enum class CollectiveOpKind {
+    kAllReduce,
+    kAllGather,
+  };
+
   static constexpr auto kMaxNumExecutors =
       ::stream_executor::gpu::kMaxNumAllReduceInputPtrs;
 
-  CollectiveKernelThunk(ThunkInfo info, CollectiveConfig collective_config,
-                        ReductionKind reduction_kind, bool is_async,
-                        std::vector<CollectiveThunk::Buffer> buffers,
-                        bool is_collective_kernel_enabled,
-                        absl::string_view kernel_name = "",
-                        int32_t shmem_bytes = 0,
-                        bool is_multimem_enabled = false)
+  CollectiveKernelThunk(
+      ThunkInfo info, CollectiveConfig collective_config,                //
+      ReductionKind reduction_kind,                                      //
+      bool is_async,                                                     //
+      std::vector<CollectiveThunk::Buffer> buffers,                      //
+      bool is_collective_kernel_enabled,                                 //
+      absl::string_view kernel_name = "",                                //
+      std::optional<LaunchDimensions> launch_dimensions = std::nullopt,  //
+      int32_t shmem_bytes = 0,                                           //
+      bool is_multimem_enabled = false,                                  //
+      CollectiveOpKind collective_op_kind = CollectiveOpKind::kAllReduce)
       : Thunk{Thunk::kCollectiveKernel, info},
         collective_kernel_enabled_(is_collective_kernel_enabled),
         is_async_(is_async),
@@ -72,7 +81,8 @@ class CollectiveKernelThunk : public Thunk {
         kernel_name_(kernel_name),
         shmem_bytes_(shmem_bytes),
         buffers_(std::move(buffers)),
-        is_multimem_enabled_(is_multimem_enabled) {
+        is_multimem_enabled_(is_multimem_enabled),
+        collective_op_kind_(collective_op_kind) {
     per_stream_state_.reserve(kMaxNumExecutors);
   }
 
@@ -188,6 +198,7 @@ class CollectiveKernelThunk : public Thunk {
   absl::flat_hash_map<se::StreamExecutor*, std::unique_ptr<StreamMemory>>
       per_stream_memory_ ABSL_GUARDED_BY(mutex_);
   const bool is_multimem_enabled_;
+  const CollectiveOpKind collective_op_kind_;
 };
 }  // namespace xla::gpu
 

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.h
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.h
@@ -65,15 +65,15 @@ class CollectiveKernelThunk : public Thunk {
       ::stream_executor::gpu::kMaxNumAllReduceInputPtrs;
 
   CollectiveKernelThunk(
-      ThunkInfo info, CollectiveConfig collective_config,                //
-      ReductionKind reduction_kind,                                      //
-      bool is_async,                                                     //
-      std::vector<CollectiveThunk::Buffer> buffers,                      //
-      bool is_collective_kernel_enabled,                                 //
-      absl::string_view kernel_name = "",                                //
-      std::optional<LaunchDimensions> launch_dimensions = std::nullopt,  //
-      int32_t shmem_bytes = 0,                                           //
-      bool is_multimem_enabled = false,                                  //
+      ThunkInfo info, CollectiveConfig collective_config,                     //
+      std::optional<ReductionKind> reduction_kind,                            //
+      bool is_async,                                                          //
+      std::vector<CollectiveThunk::Buffer> buffers,                           //
+      bool is_collective_kernel_enabled,                                      //
+      absl::string_view kernel_name = "",                                     //
+      std::optional<LaunchDimensions> launch_dimensions = std::nullopt,       //
+      int32_t shmem_bytes = 0,                                                //
+      bool is_multimem_enabled = false,                                       //
       CollectiveOpKind collective_op_kind = CollectiveOpKind::kAllReduce)
       : Thunk{Thunk::kCollectiveKernel, info},
         collective_kernel_enabled_(is_collective_kernel_enabled),
@@ -186,7 +186,8 @@ class CollectiveKernelThunk : public Thunk {
   // Collective config being used. Copied over to avoid lifetime issues.
   const CollectiveConfig collective_config_;
   // Reduction kind being to use for AllReduce collective.
-  const ReductionKind reduction_kind_;
+  // Optional - only set for AllReduce operations.
+  const std::optional<ReductionKind> reduction_kind_;
   // Launch dimensions for the kernel. Only relevant when the codegen kernel
   // is used.
   std::optional<LaunchDimensions> launch_dimensions_;

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.h
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.h
@@ -71,15 +71,16 @@ class CollectiveKernelThunk : public Thunk {
       std::vector<CollectiveThunk::Buffer> buffers,                      //
       bool is_collective_kernel_enabled,                                 //
       absl::string_view kernel_name = "",                                //
+      std::optional<LaunchDimensions> launch_dimensions = std::nullopt,  //
       int32_t shmem_bytes = 0,                                           //
       bool is_multimem_enabled = false,                                  //
-      CollectiveOpKind collective_op_kind = CollectiveOpKind::kAllReduce, //
-      std::optional<LaunchDimensions> launch_dimensions = std::nullopt)
+      CollectiveOpKind collective_op_kind = CollectiveOpKind::kAllReduce)
       : Thunk{Thunk::kCollectiveKernel, info},
         collective_kernel_enabled_(is_collective_kernel_enabled),
         is_async_(is_async),
         collective_config_(std::move(collective_config)),
         reduction_kind_(reduction_kind),
+        launch_dimensions_(launch_dimensions),
         kernel_name_(kernel_name),
         shmem_bytes_(shmem_bytes),
         buffers_(std::move(buffers)),
@@ -96,6 +97,9 @@ class CollectiveKernelThunk : public Thunk {
 
   bool collective_kernel_enabled() const { return collective_kernel_enabled_; }
   bool is_async() const { return is_async_; }
+  std::optional<LaunchDimensions> launch_dimensions() const {
+    return launch_dimensions_;
+  }
 
   // Returns true if the collective kernel is supported for the given clique.
   absl::StatusOr<bool> IsSupported(
@@ -183,6 +187,9 @@ class CollectiveKernelThunk : public Thunk {
   const CollectiveConfig collective_config_;
   // Reduction kind being to use for AllReduce collective.
   const ReductionKind reduction_kind_;
+  // Launch dimensions for the kernel. Only relevant when the codegen kernel
+  // is used.
+  std::optional<LaunchDimensions> launch_dimensions_;
   // Kernel name to execute. Required when Codegen/PTX kernel is used.
   // Must match the kernel name in the generated PTX kernel.
   const std::string kernel_name_;

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.h
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.h
@@ -34,13 +34,15 @@ limitations under the License.*/
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
+#include "xla/service/gpu/launch_dimensions.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/device_address_handle.h"
 #include "xla/stream_executor/gpu/all_reduce_kernel.h"
 #include "xla/stream_executor/kernel.h"
 #include "xla/stream_executor/stream.h"
 
-namespace xla::gpu {
+namespace xla {
+namespace gpu {
 
 // A thunk that runs single-host collective operations in a single shot.
 // Assumes multiple devices are present, but all on the same host.
@@ -69,10 +71,10 @@ class CollectiveKernelThunk : public Thunk {
       std::vector<CollectiveThunk::Buffer> buffers,                      //
       bool is_collective_kernel_enabled,                                 //
       absl::string_view kernel_name = "",                                //
-      std::optional<LaunchDimensions> launch_dimensions = std::nullopt,  //
       int32_t shmem_bytes = 0,                                           //
       bool is_multimem_enabled = false,                                  //
-      CollectiveOpKind collective_op_kind = CollectiveOpKind::kAllReduce)
+      CollectiveOpKind collective_op_kind = CollectiveOpKind::kAllReduce, //
+      std::optional<LaunchDimensions> launch_dimensions = std::nullopt)
       : Thunk{Thunk::kCollectiveKernel, info},
         collective_kernel_enabled_(is_collective_kernel_enabled),
         is_async_(is_async),
@@ -200,6 +202,8 @@ class CollectiveKernelThunk : public Thunk {
   const bool is_multimem_enabled_;
   const CollectiveOpKind collective_op_kind_;
 };
-}  // namespace xla::gpu
+
+}  // namespace gpu
+}  // namespace xla
 
 #endif  // XLA_BACKENDS_GPU_RUNTIME_COLLECTIVE_KERNEL_THUNK_H_

--- a/xla/backends/gpu/runtime/collective_kernel_thunk_test.cc
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk_test.cc
@@ -198,6 +198,7 @@ CollectiveKernelThunkMetadata CreateCollectiveKernelThunk(
       /*is_async=*/false, result.buffers,
       /*is_collective_kernel_enabled=*/true,
       /*kernel_name=*/kKernelName,
+      /*launch_dimensions=*/std::nullopt,
       /*shmem_bytes=*/0,
       /*is_multimem_enabled=*/is_multimem_enabled);
   result.total_buffer_size = total_buffer_size;

--- a/xla/codegen/emitters/kernel_arguments.cc
+++ b/xla/codegen/emitters/kernel_arguments.cc
@@ -190,6 +190,61 @@ absl::StatusOr<KernelArguments> KernelArguments::Create(
                                hlo_instruction, unmanaged_arguments);
 }
 
+// Special overload for AllGather with tuple unpacking
+absl::StatusOr<KernelArguments> KernelArguments::Create(
+    const BufferAssignment& buffer_assignment,
+    const BufferAlignment& buffer_alignment,
+    const HloInstruction* shape_instruction,
+    const HloInstruction* buffer_instruction, const ShapeIndex& output_index,
+    absl::Span<const Shape> unmanaged_arguments) {
+  std::vector<KernelArgument> kernel_arguments;
+
+  // Input arguments: use shape_instruction's operands for shapes,
+  // but buffer_instruction's operands for buffer lookups
+  for (int i = 0; i < shape_instruction->operand_count(); ++i) {
+    const HloInstruction* shape_operand = shape_instruction->operand(i);
+    const HloInstruction* buffer_operand = buffer_instruction->operand(i);
+    TF_ASSIGN_OR_RETURN(BufferAllocation::Slice slice,
+                        buffer_assignment.GetUniqueSlice(buffer_operand, {}));
+    kernel_arguments.emplace_back(
+        KernelArgument(shape_operand->shape(), slice));
+  }
+
+  // Output arguments: use shape_instruction's shape,
+  // but look up buffer from buffer_instruction at output_index
+  absl::flat_hash_set<BufferAllocation::Slice> buffers_written;
+  TF_RETURN_IF_ERROR(ShapeUtil::ForEachSubshapeWithStatus(
+      shape_instruction->shape(),
+      [&](const Shape& subshape, const ShapeIndex& index) {
+        if (!subshape.IsArray()) return absl::OkStatus();
+
+        // For output buffers, look them up from buffer_instruction at
+        // output_index
+        ShapeIndex buffer_index = output_index;
+        // Append the current index to output_index for nested shapes
+        for (int64_t i : index) {
+          buffer_index.push_back(i);
+        }
+
+        TF_ASSIGN_OR_RETURN(
+            BufferAllocation::Slice slice,
+            buffer_assignment.GetUniqueSlice(buffer_instruction, buffer_index));
+
+        kernel_arguments.emplace_back(KernelArgument(subshape, slice));
+        buffers_written.insert(slice);
+        return absl::OkStatus();
+      }));
+
+  // Add unmanaged arguments
+  for (const Shape& unmanaged_argument : unmanaged_arguments) {
+    kernel_arguments.emplace_back(unmanaged_argument);
+  }
+
+  FillKernelArgumentAttributes(kernel_arguments, buffer_alignment,
+                               buffers_written);
+  return KernelArguments(std::move(kernel_arguments));
+}
+
 absl::StatusOr<KernelArguments> KernelArguments::Create(
     const BufferAssignment& buffer_assignment,
     const BufferAlignment& buffer_alignment,

--- a/xla/codegen/emitters/kernel_arguments.h
+++ b/xla/codegen/emitters/kernel_arguments.h
@@ -111,6 +111,22 @@ class KernelArguments {
       const BufferAlignment& buffer_alignment,
       const HloInstruction* hlo_instruction);
 
+  // Special overload for collective operations where the fusion has a different
+  // output shape than the original instruction (e.g., AllGather with tuple
+  // unpacking).
+  // - shape_instruction: Used to determine argument shapes (typically the
+  // fusion)
+  // - buffer_instruction: Used to look up buffer assignments (typically the
+  // original instruction)
+  // - output_index: ShapeIndex to use when looking up output buffers from
+  // buffer_instruction
+  static absl::StatusOr<KernelArguments> Create(
+      const BufferAssignment& buffer_assignment,
+      const BufferAlignment& buffer_alignment,
+      const HloInstruction* shape_instruction,
+      const HloInstruction* buffer_instruction, const ShapeIndex& output_index,
+      absl::Span<const Shape> unmanaged_arguments);
+
   // Certain kernels require output arguments to be interleaved with input
   // arguments. This function creates a KernelArguments object where the output
   // arguments are interleaved with the input arguments according to the

--- a/xla/codegen/tiling/tiled_hlo_instruction.cc
+++ b/xla/codegen/tiling/tiled_hlo_instruction.cc
@@ -48,8 +48,13 @@ absl::Status VerifyTiledHloInstructionConstructorPreconditions(
     std::optional<IndexingMap> tile_offsets_indexing,
     const llvm::SmallVector<const TiledHloInstruction*>& runtime_variables) {
   // * Number of tile sizes, strides should match the rank of the HLO.
+  const Shape& shape_for_tiling =
+      (hlo->opcode() == HloOpcode::kAllGatherStart && hlo->shape().IsTuple())
+          ? ShapeUtil::GetTupleElementShape(hlo->shape(), 1)
+          : hlo->shape();
+
   const int rank =
-      hlo->shape().IsArray() ? hlo->shape().dimensions().size() : 0;
+      shape_for_tiling.IsArray() ? shape_for_tiling.dimensions().size() : 0;
 
   if (tile_sizes.size() != rank) {
     return absl::InvalidArgumentError(

--- a/xla/codegen/xtile/codegen/emitter_helpers.cc
+++ b/xla/codegen/xtile/codegen/emitter_helpers.cc
@@ -536,10 +536,14 @@ absl::StatusOr<TensorValue> EmitScope(
                hlo->opcode() == HloOpcode::kTranspose ||
                hlo->opcode() == HloOpcode::kSlice ||
                hlo->opcode() == HloOpcode::kReshape ||
-               hlo->opcode() == HloOpcode::kPad) {
+               hlo->opcode() == HloOpcode::kPad ||
+               hlo->opcode() == HloOpcode::kGetTupleElement ||
+               hlo->opcode() == HloOpcode::kAllGatherStart) {
       // All these are currently supported only as operations on indices
       // which are pushed to loads and stores. No operations on tiles are
       // performed here.
+      // For GetTupleElement and AllGatherStart, we pass through the operand
+      // value
       result = values[hlo->operand(0)];
     } else if (hlo->opcode() == HloOpcode::kFusion) {
       const auto* fusion_instruction = ::xla::Cast<HloFusionInstruction>(hlo);

--- a/xla/codegen/xtile/codegen/fusion_emitter.cc
+++ b/xla/codegen/xtile/codegen/fusion_emitter.cc
@@ -1577,7 +1577,7 @@ absl::StatusOr<TensorValue> EmitAllGather(
     operands.push_back(values[operand]);
   }
 
-  if (all_gather.device_list()->replica_groups().empty()) {
+  if (all_gather.device_list().replica_groups().empty()) {
     return Internal(
         "Triton emitting AllGather without replica groups is not supported.");
   }

--- a/xla/codegen/xtile/codegen/fusion_emitter.cc
+++ b/xla/codegen/xtile/codegen/fusion_emitter.cc
@@ -101,11 +101,11 @@ limitations under the License.
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/framework/mlir/status_scoped_diagnostic_handler.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::xtile {
 
@@ -1561,6 +1561,75 @@ absl::StatusOr<TensorValue> EmitAllReduce(
   return mlir::cast<TensorValue>(all_reduce_op.getResult(0));
 }
 
+absl::StatusOr<TensorValue> EmitAllGather(
+    mlir::ImplicitLocOpBuilder& b, const HloComputation* computation,
+    const HloAllGatherInstruction& all_gather,
+    const TiledHloInstruction& tiled_hlo_gather,
+    absl::flat_hash_map<const TiledHloInstruction*, TensorValue>& values) {
+  llvm::SmallVector<mlir::Value> operands;
+  operands.reserve(tiled_hlo_gather.operands().size());
+
+  for (const auto operand : tiled_hlo_gather.operands()) {
+    if (!values.contains(operand)) {
+      return Internal("Operand %s not found in the values map.",
+                      operand->ToString());
+    }
+    operands.push_back(values[operand]);
+  }
+
+  if (all_gather.device_list()->replica_groups().empty()) {
+    return Internal(
+        "Triton emitting AllGather without replica groups is not supported.");
+  }
+
+  llvm::SmallVector<int64_t> flattened_replica_group_ids;
+  for (const auto& replica_group : all_gather.replica_groups()) {
+    for (const auto& replica_id : replica_group.replica_ids()) {
+      flattened_replica_group_ids.push_back(replica_id);
+    }
+  }
+
+  std::optional<int64_t> channel_handle = all_gather.channel_id();
+  bool use_global_device_ids = all_gather.use_global_device_ids();
+  int64_t all_gather_dimension = all_gather.all_gather_dimension();
+
+  // AllGather-start returns a tuple (input, output), but we need the output
+  // shape (element 1)
+  const Shape& all_gather_output_shape =
+      all_gather.shape().IsTuple()
+          ? ShapeUtil::GetTupleElementShape(all_gather.shape(), 1)
+          : all_gather.shape();
+
+  TF_ASSIGN_OR_RETURN(auto output_element_type,
+                      xtile::PrimitiveTypeToMlirType(
+                          b, all_gather_output_shape.element_type()));
+
+  // Use the tiled output shape
+  llvm::SmallVector<int64_t> output_shape(tiled_hlo_gather.tile_sizes().begin(),
+                                          tiled_hlo_gather.tile_sizes().end());
+
+  auto output_type =
+      mlir::RankedTensorType::get(output_shape, output_element_type);
+
+  auto replica_groups_type = mlir::RankedTensorType::get(
+      {static_cast<int64_t>(all_gather.replica_groups().size()),
+       static_cast<int64_t>(all_gather.replica_groups()[0].replica_ids_size())},
+      b.getI64Type());
+  auto replica_groups_attr = mlir::DenseIntElementsAttr::get(
+      replica_groups_type, flattened_replica_group_ids);
+  auto channel_handle_attr =
+      channel_handle ? mlir::stablehlo::ChannelHandleAttr::get(b.getContext(),
+                                                               *channel_handle,
+                                                               /*type=*/0)
+                     : nullptr;
+
+  auto all_gather_op = mlir::stablehlo::AllGatherOp::create(
+      b, b.getLoc(), output_type, mlir::ValueRange(operands),
+      all_gather_dimension, replica_groups_attr, channel_handle_attr,
+      use_global_device_ids);
+  return mlir::cast<TensorValue>(all_gather_op.getResult(0));
+}
+
 absl::StatusOr<TensorValue> EmitTiledHloInstruction(
     mlir::ImplicitLocOpBuilder& b, const HloFusionInstruction* fusion,
     const TiledHloInstruction& tiled_hlo, mlir::FunctionOpInterface fn,
@@ -1674,6 +1743,29 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
     return values[tiled_hlo.operand(0)];
   }
 
+  if (hlo->opcode() == HloOpcode::kAllGatherStart) {
+    const HloComputation* computation =
+        fusion->fused_instructions_computation();
+    const HloInstruction* root_instruction = computation->root_instruction();
+
+    // Handle GetTupleElement wrapping
+    if (root_instruction->opcode() == HloOpcode::kGetTupleElement &&
+        root_instruction->operand(0)->opcode() == HloOpcode::kAllGatherStart) {
+      root_instruction = root_instruction->operand(0);
+    }
+    if (root_instruction->opcode() == HloOpcode::kAllGatherDone) {
+      root_instruction = root_instruction->operand(0);
+    }
+
+    return EmitAllGather(b, computation,
+                         *xla::Cast<HloAllGatherInstruction>(root_instruction),
+                         tiled_hlo, values);
+  }
+
+  if (hlo->opcode() == HloOpcode::kAllGatherDone) {
+    return values[tiled_hlo.operand(0)];
+  }
+
   if (hlo->IsElementwise()) {
     std::vector<Value> operands;
     operands.reserve(hlo->operands().size());
@@ -1711,6 +1803,11 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
   if (hlo->opcode() == HloOpcode::kDynamicSlice) {
     // Dynamic slice is implemented as a load and does not require any further
     // processing.
+    return values[tiled_hlo.operand(0)];
+  }
+
+  // GetTupleElement is a pass-through operation
+  if (hlo->opcode() == HloOpcode::kGetTupleElement) {
     return values[tiled_hlo.operand(0)];
   }
 

--- a/xla/codegen/xtile/ir/transforms/verify_legal_xtile_ops.cc
+++ b/xla/codegen/xtile/ir/transforms/verify_legal_xtile_ops.cc
@@ -83,13 +83,13 @@ std::optional<absl::string_view> IsLegalTensorOp(mlir::Operation* op) {
 std::optional<absl::string_view> IsLegalStablehloOp(mlir::Operation* op) {
   if (mlir::isa<
           // go/keep-sorted start
-          mlir::stablehlo::AllReduceOp, mlir::stablehlo::AddOp,
-          mlir::stablehlo::AndOp, mlir::stablehlo::BroadcastInDimOp,
-          mlir::stablehlo::CompareOp, mlir::stablehlo::ConvertOp,
-          mlir::stablehlo::DivOp, mlir::stablehlo::DotGeneralOp,
-          mlir::stablehlo::MaxOp, mlir::stablehlo::MinOp,
-          mlir::stablehlo::MulOp, mlir::stablehlo::ReduceOp,
-          mlir::stablehlo::OrOp, mlir::stablehlo::RemOp,
+          mlir::stablehlo::AddOp, mlir::stablehlo::AllGatherOp,
+          mlir::stablehlo::AllReduceOp, mlir::stablehlo::AndOp,
+          mlir::stablehlo::BroadcastInDimOp, mlir::stablehlo::CompareOp,
+          mlir::stablehlo::ConvertOp, mlir::stablehlo::DivOp,
+          mlir::stablehlo::DotGeneralOp, mlir::stablehlo::MaxOp,
+          mlir::stablehlo::MinOp, mlir::stablehlo::MulOp, mlir::stablehlo::OrOp,
+          mlir::stablehlo::ReduceOp, mlir::stablehlo::RemOp,
           mlir::stablehlo::ReshapeOp, mlir::stablehlo::ReturnOp,
           mlir::stablehlo::SubtractOp, mlir::stablehlo::TransposeOp,
           mlir::stablehlo::XorOp

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -455,6 +455,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_unsupported_enable_all_reduce_decomposer(false);
   opts.set_xla_gpu_unsupported_enable_ragged_all_to_all_decomposer(false);
   opts.set_xla_gpu_unsupported_use_all_reduce_one_shot_kernel(false);
+  opts.set_xla_gpu_unsupported_use_all_gather_triton_backend(false);
   opts.set_xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel(true);
   opts.set_xla_gpu_experimental_use_autotuner_pass(false);
   opts.set_xla_gpu_experimental_enable_fusion_autotuner(true);
@@ -2641,6 +2642,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_unsupported_use_all_reduce_one_shot_kernel(),
       "Internal: Enable the one-shot kernel for single-host all-reduce "
       "operations."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_unsupported_use_all_gather_triton_backend",
+      bool_setter_for(
+          &DebugOptions::
+              set_xla_gpu_unsupported_use_all_gather_triton_backend),
+      debug_options->xla_gpu_unsupported_use_all_gather_triton_backend(),
+      "Internal: Enable Triton backend for all-gather operations."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel",
       bool_setter_for(

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -105,7 +105,8 @@ absl::StatusOr<std::vector<RepeatedFlagModifier>> ParseRepeatedEnumModifiers(
 namespace {
 
 template <typename T>
-static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list, T value) {
+static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list,
+                                   T value) {
   for (auto it = list->begin(); it != list->end(); ++it) {
     if (*it == value) {
       return it;
@@ -2645,8 +2646,7 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
   flag_list->push_back(tsl::Flag(
       "xla_gpu_unsupported_use_all_gather_triton_backend",
       bool_setter_for(
-          &DebugOptions::
-              set_xla_gpu_unsupported_use_all_gather_triton_backend),
+          &DebugOptions::set_xla_gpu_unsupported_use_all_gather_triton_backend),
       debug_options->xla_gpu_unsupported_use_all_gather_triton_backend(),
       "Internal: Enable Triton backend for all-gather operations."));
   flag_list->push_back(tsl::Flag(
@@ -3033,8 +3033,7 @@ FlagStatus GetFlagStatus(absl::string_view flag_name) {
           "xla_gpu_all_reduce_combine_threshold_bytes",
           "xla_gpu_autotune_level",
           "xla_gpu_collective_permute_decomposer_threshold",
-          "xla_gpu_cublas_fallback",
-          "xla_gpu_dot_merger_threshold_mb",
+          "xla_gpu_cublas_fallback", "xla_gpu_dot_merger_threshold_mb",
           "xla_gpu_enable_dynamic_slice_fusion",
           "xla_gpu_enable_latency_hiding_scheduler",
           "xla_gpu_enable_pipelined_all_gather",

--- a/xla/hlo/analysis/indexing_analysis.cc
+++ b/xla/hlo/analysis/indexing_analysis.cc
@@ -1658,16 +1658,36 @@ HloInstructionIndexing ComputeOutputToInputIndexing(const HloInstruction* instr,
   if (auto transpose = DynCast<HloTransposeInstruction>(instr)) {
     return ComputeOutputToInputTransposeOpIndexing(transpose, mlir_context);
   }
-  // GetTupleElement is an identity operation for indexing - it just extracts
-  // an element from a tuple, so the indexing is the same as the operand
+  // GetTupleElement extracts an element from a tuple operand.
+  // An identity mapping is only valid when the tuple operand's extracted
+  // element has the same shape as the GTE output. This is the case for
+  // AllGather fusion tiling where GTE acts as a pass-through.
   if (instr->opcode() == HloOpcode::kGetTupleElement) {
-    // Create identity indexing map for the tuple operand
-    IndexingMap identity_map = CreateIdentityMap(instr->shape(), mlir_context);
-    HloInstructionIndexing indexing;
-    indexing.indexing_maps.resize(instr->operand_count());
-    indexing.indexing_maps[0].insert(
-        OperandIndexing{identity_map, /*runtime_variables=*/{}});
-    return indexing;
+    auto* gte = Cast<HloGetTupleElementInstruction>(instr);
+    const HloInstruction* tuple_operand = gte->operand(0);
+    const Shape& tuple_shape = tuple_operand->shape();
+    const Shape& output_shape = gte->shape();
+
+    // Verify the operand is a tuple and the extracted element shape matches
+    if (tuple_shape.IsTuple() &&
+        gte->tuple_index() < tuple_shape.tuple_shapes_size()) {
+      const Shape& element_shape = tuple_shape.tuple_shapes(gte->tuple_index());
+
+      // Only use identity mapping if the extracted element shape matches
+      // the GTE output shape
+      if (ShapeUtil::Equal(output_shape, element_shape)) {
+        IndexingMap identity_map =
+            CreateIdentityMap(output_shape, mlir_context);
+        HloInstructionIndexing indexing;
+        indexing.indexing_maps.resize(instr->operand_count());
+        indexing.indexing_maps[0].insert(
+            OperandIndexing{identity_map, /*runtime_variables=*/{}});
+        return indexing;
+      }
+    }
+
+    // If shapes don't match or context is invalid, return unknown indexing
+    return CreateUnknownIndexing(instr->operand_count());
   }
   // go/keep-sorted end
   LOG(ERROR) << "ComputeOutputToInputIndexing is not implemented for opcode "

--- a/xla/hlo/analysis/indexing_analysis.cc
+++ b/xla/hlo/analysis/indexing_analysis.cc
@@ -1539,14 +1539,15 @@ void AssignValuesToRTVars(IndexingMap* indexing_map) {
 
 HloInstructionIndexing ComputeOutputToInputAllGatherOpIndexing(
     const HloAllGatherInstruction* instr, MLIRContext* mlir_context) {
-  // CHECK_EQ(instr->all_gather_dimension(), 0);
-  // if (instr->all_gather_dimension() != 0) {
-  //   return CreateUnknownIndexing(instr->operand_count());
-  // }
+  // For AllGather-start, the shape is a tuple (input, output)
+  // We need to use the output element (index 1) for indexing
+  const Shape& output_shape =
+      instr->shape().IsTuple()
+          ? ShapeUtil::GetTupleElementShape(instr->shape(), 1)
+          : instr->shape();
 
   int64_t all_gather_dim = instr->all_gather_dimension();
-
-  auto output_rank = instr->shape().dimensions().size();
+  auto output_rank = output_shape.dimensions().size();
 
   std::vector<AffineExpr> exprs;
   exprs.reserve(output_rank);
@@ -1562,7 +1563,7 @@ HloInstructionIndexing ComputeOutputToInputAllGatherOpIndexing(
 
   IndexingMap indexing_map = IndexingMap::FromTensorSizes(
       AffineMap::get(output_rank, /*symbolCount=*/0, exprs, mlir_context),
-      instr->shape().dimensions(), {});
+      output_shape.dimensions(), {});
 
   AffineExpr replica_id_expr =
       mlir::getAffineDimExpr(all_gather_dim, mlir_context)
@@ -1571,7 +1572,7 @@ HloInstructionIndexing ComputeOutputToInputAllGatherOpIndexing(
   IndexingMap replica_id_map = IndexingMap::FromTensorSizes(
       AffineMap::get(output_rank, /*symbolCount=*/0, replica_id_expr,
                      mlir_context),
-      instr->shape().dimensions(), {});
+      output_shape.dimensions(), {});
 
   OperandIndexing operand_indexing(indexing_map, {}, replica_id_map);
 
@@ -1656,6 +1657,17 @@ HloInstructionIndexing ComputeOutputToInputIndexing(const HloInstruction* instr,
   }
   if (auto transpose = DynCast<HloTransposeInstruction>(instr)) {
     return ComputeOutputToInputTransposeOpIndexing(transpose, mlir_context);
+  }
+  // GetTupleElement is an identity operation for indexing - it just extracts
+  // an element from a tuple, so the indexing is the same as the operand
+  if (instr->opcode() == HloOpcode::kGetTupleElement) {
+    // Create identity indexing map for the tuple operand
+    IndexingMap identity_map = CreateIdentityMap(instr->shape(), mlir_context);
+    HloInstructionIndexing indexing;
+    indexing.indexing_maps.resize(instr->operand_count());
+    indexing.indexing_maps[0].insert(
+        OperandIndexing{identity_map, /*runtime_variables=*/{}});
+    return indexing;
   }
   // go/keep-sorted end
   LOG(ERROR) << "ComputeOutputToInputIndexing is not implemented for opcode "

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -165,7 +165,6 @@ limitations under the License.
 #include "xla/stream_executor/memory_space.h"
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/dnn.pb.h"
 #include "xla/util.h"
@@ -174,6 +173,7 @@ limitations under the License.
 #include "tsl/platform/casts.h"
 #include "tsl/platform/human_readable_json.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 namespace {
@@ -209,15 +209,13 @@ static constexpr bool kRequiresCollectiveKernelThunk =
 // function of ThunkEmitter.
 // As it stands now the collective kernel thunk is wrapped inside other
 // collective thunks such as AllReduceStart and AllGatherStart. So this function
-// is only responsible for emitting the collective kernel thunk and its
-// dependencies.
+// is only responsible for emitting the collective kernel thunk and its dependencies.
 absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
     Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
     const HloAllReduceInstruction* instr, const AllReduceConfig& config) {
-  LOG(INFO) << "EmitCollectiveKernelThunk called for AllReduce: "
-            << instr->name();
-
+  LOG(INFO) << "EmitCollectiveKernelThunk called for AllReduce: " << instr->name();
+  
   std::unique_ptr<HloModule> fused_module =
       NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
   HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
@@ -244,8 +242,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
                                                device_info, fusion_instr));
   if (!did_set_config) {
-    LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false - not "
-                 "using Triton";
+    LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false - not using Triton";
     return make_thunk(/*kernel_name=*/"",
                       /*shmem_bytes=*/0,
                       /*launch_dimensions=*/std::nullopt,
@@ -287,16 +284,15 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
     Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
     const HloAllGatherInstruction* instr) {
-  LOG(INFO) << "EmitCollectiveKernelThunk called for AllGather: "
-            << instr->name();
-
+  LOG(INFO) << "EmitCollectiveKernelThunk called for AllGather: " << instr->name();
+  
   std::unique_ptr<HloModule> fused_module =
       NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
   HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
       fused_module->entry_computation()->root_instruction());
   const se::DeviceDescription& device_info =
       ir_emitter_context->gpu_device_info();
-
+  
   // For AllGather, we don't have a reduction, so we create a dummy config
   const auto make_thunk = [&](absl::string_view kernel_name,
                               int32_t shmem_bytes,
@@ -305,8 +301,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     // AllGather doesn't have reduction, use a placeholder
     return EmitCollectiveResult{
         std::make_unique<CollectiveKernelThunk>(
-            thunk_info,
-            GetCollectiveConfig(instr, instr->use_global_device_ids()),
+            thunk_info, GetCollectiveConfig(instr, instr->use_global_device_ids()),
             ReductionKind::SUM,  // Placeholder, not used for AllGather
             /*is_async=*/!IsGPUSyncCollective(*instr), std::move(buffers),
             /*is_collective_kernel_enabled=*/
@@ -318,19 +313,20 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
             /*launch_dimensions=*/launch_dimensions,
             /*shmem_bytes=*/shmem_bytes,
             /*is_multimem_enabled=*/false,
-            /*collective_op_kind=*/
-            CollectiveKernelThunk::CollectiveOpKind::kAllGather),
+            /*collective_op_kind=*/CollectiveKernelThunk::CollectiveOpKind::kAllGather),
         std::move(local_module)};
   };
-
+  
   TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
                                                device_info, fusion_instr));
   if (!did_set_config) {
+    LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false for AllGather - not using Triton";
     return make_thunk(/*kernel_name=*/"",
                       /*shmem_bytes=*/0,
                       /*launch_dimensions=*/std::nullopt,
                       /*local_module=*/nullptr);
   }
+  LOG(INFO) << "TrySetGpuBackendConfigForCollective succeeded for AllGather - using Triton!";
   const HloFusionAnalysis fusion_analysis =
       HloFusionAnalysis::Create(*fusion_instr, device_info);
   auto emitter = std::make_unique<TritonFusion>(fusion_analysis);
@@ -339,7 +335,8 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     XLA_SCOPED_LOGGING_TIMER("Emit collective kernel thunk for AllGather");
     TF_ASSIGN_OR_RETURN(std::vector<Shape> unmanaged_arguments,
                         GetCollectiveUnmanagedKernelArguments(fusion_instr));
-
+    LOG(INFO) << "EmitCollectiveKernelThunk before emit!";
+    
     // For AllGather, use instr_override to get correct buffer assignments.
     // The special KernelArguments::Create overload in fusion.cc handles
     // the tuple unpacking, using fusion for shapes and AllGather for buffers.
@@ -354,9 +351,10 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
 
 }  // namespace
 
-ThunkEmitter::ThunkEmitter(IrEmitterContext* absl_nonnull ir_emitter_context,
-                           llvm_ir::LLVMCommandLineOptionsReleasableLock*
-                               absl_nonnull llvm_options_lock)
+ThunkEmitter::ThunkEmitter(
+    IrEmitterContext* absl_nonnull ir_emitter_context,
+    llvm_ir::LLVMCommandLineOptionsReleasableLock* absl_nonnull
+        llvm_options_lock)
     : ir_emitter_context_(ir_emitter_context),
       send_recv_events_(std::make_shared<HostSendRecvAsyncEvents>()),
       copy_events_(std::make_shared<CopyThunk::AsyncEvents>()),
@@ -1763,9 +1761,9 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectiveThunk(
     if constexpr (std::is_same_v<HloInstType, HloAllReduceInstruction>) {
       TF_ASSIGN_OR_RETURN(
           auto emit_result,
-          EmitCollectiveKernelThunk(ir_emitter_context_, call_graph_.get(),
-                                    thunk_info, buffers, inst,
-                                    GetAllReduceConfigInst(inst)));
+          EmitCollectiveKernelThunk(
+              ir_emitter_context_, call_graph_.get(), thunk_info, buffers,
+              inst, GetAllReduceConfigInst(inst)));
       if (emit_result.llvm_module != nullptr) {
         kernel_modules_.push_back(std::move(emit_result.llvm_module));
       }
@@ -1776,8 +1774,9 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectiveThunk(
     } else if constexpr (std::is_same_v<HloInstType, HloAllGatherInstruction>) {
       TF_ASSIGN_OR_RETURN(
           auto emit_result,
-          EmitCollectiveKernelThunk(ir_emitter_context_, call_graph_.get(),
-                                    thunk_info, buffers, inst));
+          EmitCollectiveKernelThunk(
+              ir_emitter_context_, call_graph_.get(), thunk_info, buffers,
+              inst));
       if (emit_result.llvm_module != nullptr) {
         kernel_modules_.push_back(std::move(emit_result.llvm_module));
       }

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -165,6 +165,7 @@ limitations under the License.
 #include "xla/stream_executor/memory_space.h"
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/dnn.pb.h"
 #include "xla/util.h"
@@ -173,7 +174,6 @@ limitations under the License.
 #include "tsl/platform/casts.h"
 #include "tsl/platform/human_readable_json.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 namespace {
@@ -209,13 +209,15 @@ static constexpr bool kRequiresCollectiveKernelThunk =
 // function of ThunkEmitter.
 // As it stands now the collective kernel thunk is wrapped inside other
 // collective thunks such as AllReduceStart and AllGatherStart. So this function
-// is only responsible for emitting the collective kernel thunk and its dependencies.
+// is only responsible for emitting the collective kernel thunk and its
+// dependencies.
 absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
     Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
     const HloAllReduceInstruction* instr, const AllReduceConfig& config) {
-  LOG(INFO) << "EmitCollectiveKernelThunk called for AllReduce: " << instr->name();
-  
+  LOG(INFO) << "EmitCollectiveKernelThunk called for AllReduce: "
+            << instr->name();
+
   std::unique_ptr<HloModule> fused_module =
       NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
   HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
@@ -244,7 +246,8 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
                                                device_info, fusion_instr));
   if (!did_set_config) {
-    LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false - not using Triton";
+    LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false - not "
+                 "using Triton";
     return make_thunk(/*kernel_name=*/"",
                       /*launch_dimensions=*/std::nullopt,
                       /*shmem_bytes=*/0,
@@ -287,15 +290,16 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
     Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
     const HloAllGatherInstruction* instr) {
-  LOG(INFO) << "EmitCollectiveKernelThunk called for AllGather: " << instr->name();
-  
+  LOG(INFO) << "EmitCollectiveKernelThunk called for AllGather: "
+            << instr->name();
+
   std::unique_ptr<HloModule> fused_module =
       NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
   HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
       fused_module->entry_computation()->root_instruction());
   const se::DeviceDescription& device_info =
       ir_emitter_context->gpu_device_info();
-  
+
   // For AllGather, we don't have a reduction, so we create a dummy config
   const auto make_thunk = [&](absl::string_view kernel_name,
                               std::optional<LaunchDimensions> launch_dimensions,
@@ -304,7 +308,8 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     // AllGather doesn't have reduction, use a placeholder
     return EmitCollectiveResult{
         std::make_unique<CollectiveKernelThunk>(
-            thunk_info, GetCollectiveConfig(instr, instr->use_global_device_ids()),
+            thunk_info,
+            GetCollectiveConfig(instr, instr->use_global_device_ids()),
             ReductionKind::SUM,  // Placeholder, not used for AllGather
             /*is_async=*/!IsGPUSyncCollective(*instr), std::move(buffers),
             /*is_collective_kernel_enabled=*/
@@ -316,20 +321,23 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
             /*launch_dimensions=*/launch_dimensions,
             /*shmem_bytes=*/shmem_bytes,
             /*is_multimem_enabled=*/false,
-            /*collective_op_kind=*/CollectiveKernelThunk::CollectiveOpKind::kAllGather),
+            /*collective_op_kind=*/
+            CollectiveKernelThunk::CollectiveOpKind::kAllGather),
         std::move(local_module)};
   };
-  
+
   TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
                                                device_info, fusion_instr));
   if (!did_set_config) {
-    LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false for AllGather - not using Triton";
+    LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false for "
+                 "AllGather - not using Triton";
     return make_thunk(/*kernel_name=*/"",
                       /*launch_dimensions=*/std::nullopt,
                       /*shmem_bytes=*/0,
                       /*local_module=*/nullptr);
   }
-  LOG(INFO) << "TrySetGpuBackendConfigForCollective succeeded for AllGather - using Triton!";
+  LOG(INFO) << "TrySetGpuBackendConfigForCollective succeeded for AllGather - "
+               "using Triton!";
   const HloFusionAnalysis fusion_analysis =
       HloFusionAnalysis::Create(*fusion_instr, device_info);
   auto emitter = std::make_unique<TritonFusion>(fusion_analysis);
@@ -339,7 +347,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     TF_ASSIGN_OR_RETURN(std::vector<Shape> unmanaged_arguments,
                         GetCollectiveUnmanagedKernelArguments(fusion_instr));
     LOG(INFO) << "EmitCollectiveKernelThunk before emit!";
-    
+
     // For AllGather, use instr_override to get correct buffer assignments.
     // The special KernelArguments::Create overload in fusion.cc handles
     // the tuple unpacking, using fusion for shapes and AllGather for buffers.
@@ -347,19 +355,17 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
         result, emitter->Emit(*ir_emitter_context, *fusion_instr,
                               /*instr_override=*/instr, unmanaged_arguments));
   }
-  return make_thunk(
-      result.kernel_thunk->kernel_name(),
-      result.kernel_thunk->launch_dimensions(),
-      result.kernel_thunk->shmem_bytes(),
-      std::move(result.llvm_module));
+  return make_thunk(result.kernel_thunk->kernel_name(),
+                    result.kernel_thunk->launch_dimensions(),
+                    result.kernel_thunk->shmem_bytes(),
+                    std::move(result.llvm_module));
 }
 
 }  // namespace
 
-ThunkEmitter::ThunkEmitter(
-    IrEmitterContext* absl_nonnull ir_emitter_context,
-    llvm_ir::LLVMCommandLineOptionsReleasableLock* absl_nonnull
-        llvm_options_lock)
+ThunkEmitter::ThunkEmitter(IrEmitterContext* absl_nonnull ir_emitter_context,
+                           llvm_ir::LLVMCommandLineOptionsReleasableLock*
+                               absl_nonnull llvm_options_lock)
     : ir_emitter_context_(ir_emitter_context),
       send_recv_events_(std::make_shared<HostSendRecvAsyncEvents>()),
       copy_events_(std::make_shared<CopyThunk::AsyncEvents>()),
@@ -1766,9 +1772,9 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectiveThunk(
     if constexpr (std::is_same_v<HloInstType, HloAllReduceInstruction>) {
       TF_ASSIGN_OR_RETURN(
           auto emit_result,
-          EmitCollectiveKernelThunk(
-              ir_emitter_context_, call_graph_.get(), thunk_info, buffers,
-              inst, GetAllReduceConfigInst(inst)));
+          EmitCollectiveKernelThunk(ir_emitter_context_, call_graph_.get(),
+                                    thunk_info, buffers, inst,
+                                    GetAllReduceConfigInst(inst)));
       if (emit_result.llvm_module != nullptr) {
         kernel_modules_.push_back(std::move(emit_result.llvm_module));
       }
@@ -1779,9 +1785,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectiveThunk(
     } else if constexpr (std::is_same_v<HloInstType, HloAllGatherInstruction>) {
       TF_ASSIGN_OR_RETURN(
           auto emit_result,
-          EmitCollectiveKernelThunk(
-              ir_emitter_context_, call_graph_.get(), thunk_info, buffers,
-              inst));
+          EmitCollectiveKernelThunk(ir_emitter_context_, call_graph_.get(),
+                                    thunk_info, buffers, inst));
       if (emit_result.llvm_module != nullptr) {
         kernel_modules_.push_back(std::move(emit_result.llvm_module));
       }

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -245,7 +245,6 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false - not using Triton";
     return make_thunk(/*kernel_name=*/"",
                       /*shmem_bytes=*/0,
-                      /*launch_dimensions=*/std::nullopt,
                       /*local_module=*/nullptr);
   }
   LOG(INFO) << "TrySetGpuBackendConfigForCollective succeeded - using Triton!";
@@ -296,7 +295,6 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   // For AllGather, we don't have a reduction, so we create a dummy config
   const auto make_thunk = [&](absl::string_view kernel_name,
                               int32_t shmem_bytes,
-                              std::optional<LaunchDimensions> launch_dimensions,
                               std::unique_ptr<llvm::Module> local_module) {
     // AllGather doesn't have reduction, use a placeholder
     return EmitCollectiveResult{
@@ -310,7 +308,6 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
                 .debug_options()
                 .xla_gpu_unsupported_use_all_gather_triton_backend(),
             /*kernel_name=*/kernel_name,
-            /*launch_dimensions=*/launch_dimensions,
             /*shmem_bytes=*/shmem_bytes,
             /*is_multimem_enabled=*/false,
             /*collective_op_kind=*/CollectiveKernelThunk::CollectiveOpKind::kAllGather),
@@ -323,7 +320,6 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false for AllGather - not using Triton";
     return make_thunk(/*kernel_name=*/"",
                       /*shmem_bytes=*/0,
-                      /*launch_dimensions=*/std::nullopt,
                       /*local_module=*/nullptr);
   }
   LOG(INFO) << "TrySetGpuBackendConfigForCollective succeeded for AllGather - using Triton!";
@@ -346,7 +342,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   }
   return make_thunk(
       result.kernel_thunk->kernel_name(), result.kernel_thunk->shmem_bytes(),
-      result.kernel_thunk->launch_dimensions(), std::move(result.llvm_module));
+      std::move(result.llvm_module));
 }
 
 }  // namespace

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -223,6 +223,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   const se::DeviceDescription& device_info =
       ir_emitter_context->gpu_device_info();
   const auto make_thunk = [&](absl::string_view kernel_name,
+                              std::optional<LaunchDimensions> launch_dimensions,
                               int32_t shmem_bytes,
                               std::unique_ptr<llvm::Module> local_module) {
     return EmitCollectiveResult{
@@ -235,6 +236,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
                 .debug_options()
                 .xla_gpu_unsupported_use_all_reduce_one_shot_kernel(),
             /*kernel_name=*/kernel_name,
+            /*launch_dimensions=*/launch_dimensions,
             /*shmem_bytes=*/shmem_bytes,
             /*is_multimem_enabled=*/false),
         std::move(local_module)};
@@ -244,6 +246,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   if (!did_set_config) {
     LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false - not using Triton";
     return make_thunk(/*kernel_name=*/"",
+                      /*launch_dimensions=*/std::nullopt,
                       /*shmem_bytes=*/0,
                       /*local_module=*/nullptr);
   }
@@ -261,6 +264,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
                               /*instr_override=*/instr, unmanaged_arguments));
   }
   return make_thunk(result.kernel_thunk->kernel_name(),
+                    result.kernel_thunk->launch_dimensions(),
                     result.kernel_thunk->shmem_bytes(),
                     std::move(result.llvm_module));
 }
@@ -294,6 +298,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   
   // For AllGather, we don't have a reduction, so we create a dummy config
   const auto make_thunk = [&](absl::string_view kernel_name,
+                              std::optional<LaunchDimensions> launch_dimensions,
                               int32_t shmem_bytes,
                               std::unique_ptr<llvm::Module> local_module) {
     // AllGather doesn't have reduction, use a placeholder
@@ -308,6 +313,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
                 .debug_options()
                 .xla_gpu_unsupported_use_all_gather_triton_backend(),
             /*kernel_name=*/kernel_name,
+            /*launch_dimensions=*/launch_dimensions,
             /*shmem_bytes=*/shmem_bytes,
             /*is_multimem_enabled=*/false,
             /*collective_op_kind=*/CollectiveKernelThunk::CollectiveOpKind::kAllGather),
@@ -319,6 +325,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   if (!did_set_config) {
     LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false for AllGather - not using Triton";
     return make_thunk(/*kernel_name=*/"",
+                      /*launch_dimensions=*/std::nullopt,
                       /*shmem_bytes=*/0,
                       /*local_module=*/nullptr);
   }
@@ -341,7 +348,9 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
                               /*instr_override=*/instr, unmanaged_arguments));
   }
   return make_thunk(
-      result.kernel_thunk->kernel_name(), result.kernel_thunk->shmem_bytes(),
+      result.kernel_thunk->kernel_name(),
+      result.kernel_thunk->launch_dimensions(),
+      result.kernel_thunk->shmem_bytes(),
       std::move(result.llvm_module));
 }
 

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -215,8 +215,8 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
     Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
     const HloAllReduceInstruction* instr, const AllReduceConfig& config) {
-  LOG(INFO) << "EmitCollectiveKernelThunk called for AllReduce: "
-            << instr->name();
+  VLOG(3) << "EmitCollectiveKernelThunk called for AllReduce: "
+          << instr->name();
 
   std::unique_ptr<HloModule> fused_module =
       NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
@@ -246,14 +246,14 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
                                                device_info, fusion_instr));
   if (!did_set_config) {
-    LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false - not "
-                 "using Triton";
+    VLOG(3) << "TrySetGpuBackendConfigForCollective returned false - not "
+               "using Triton";
     return make_thunk(/*kernel_name=*/"",
                       /*launch_dimensions=*/std::nullopt,
                       /*shmem_bytes=*/0,
                       /*local_module=*/nullptr);
   }
-  LOG(INFO) << "TrySetGpuBackendConfigForCollective succeeded - using Triton!";
+  VLOG(3) << "TrySetGpuBackendConfigForCollective succeeded - using Triton!";
   const HloFusionAnalysis fusion_analysis =
       HloFusionAnalysis::Create(*fusion_instr, device_info);
   auto emitter = std::make_unique<TritonFusion>(fusion_analysis);
@@ -290,8 +290,8 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
     Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
     const HloAllGatherInstruction* instr) {
-  LOG(INFO) << "EmitCollectiveKernelThunk called for AllGather: "
-            << instr->name();
+  VLOG(3) << "EmitCollectiveKernelThunk called for AllGather: "
+          << instr->name();
 
   std::unique_ptr<HloModule> fused_module =
       NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
@@ -300,17 +300,17 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   const se::DeviceDescription& device_info =
       ir_emitter_context->gpu_device_info();
 
-  // For AllGather, we don't have a reduction, so we create a dummy config
+  // For AllGather, we don't have a reduction, so we use ReductionKind::NONE
   const auto make_thunk = [&](absl::string_view kernel_name,
                               std::optional<LaunchDimensions> launch_dimensions,
                               int32_t shmem_bytes,
                               std::unique_ptr<llvm::Module> local_module) {
-    // AllGather doesn't have reduction, use a placeholder
+    // AllGather doesn't perform reduction, so pass nullopt
     return EmitCollectiveResult{
         std::make_unique<CollectiveKernelThunk>(
             thunk_info,
             GetCollectiveConfig(instr, instr->use_global_device_ids()),
-            ReductionKind::SUM,  // Placeholder, not used for AllGather
+            std::nullopt,  // AllGather doesn't perform reduction
             /*is_async=*/!IsGPUSyncCollective(*instr), std::move(buffers),
             /*is_collective_kernel_enabled=*/
             instr->GetModule()
@@ -329,15 +329,15 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
                                                device_info, fusion_instr));
   if (!did_set_config) {
-    LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false for "
-                 "AllGather - not using Triton";
+    VLOG(3) << "TrySetGpuBackendConfigForCollective returned false for "
+               "AllGather - not using Triton";
     return make_thunk(/*kernel_name=*/"",
                       /*launch_dimensions=*/std::nullopt,
                       /*shmem_bytes=*/0,
                       /*local_module=*/nullptr);
   }
-  LOG(INFO) << "TrySetGpuBackendConfigForCollective succeeded for AllGather - "
-               "using Triton!";
+  VLOG(3) << "TrySetGpuBackendConfigForCollective succeeded for AllGather - "
+             "using Triton!";
   const HloFusionAnalysis fusion_analysis =
       HloFusionAnalysis::Create(*fusion_instr, device_info);
   auto emitter = std::make_unique<TritonFusion>(fusion_analysis);
@@ -346,7 +346,7 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     XLA_SCOPED_LOGGING_TIMER("Emit collective kernel thunk for AllGather");
     TF_ASSIGN_OR_RETURN(std::vector<Shape> unmanaged_arguments,
                         GetCollectiveUnmanagedKernelArguments(fusion_instr));
-    LOG(INFO) << "EmitCollectiveKernelThunk before emit!";
+    VLOG(3) << "EmitCollectiveKernelThunk before emit!";
 
     // For AllGather, use instr_override to get correct buffer assignments.
     // The special KernelArguments::Create overload in fusion.cc handles

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -165,6 +165,7 @@ limitations under the License.
 #include "xla/stream_executor/memory_space.h"
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/dnn.pb.h"
 #include "xla/util.h"
@@ -173,7 +174,6 @@ limitations under the License.
 #include "tsl/platform/casts.h"
 #include "tsl/platform/human_readable_json.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 namespace {
@@ -197,18 +197,27 @@ static constexpr bool kRequiresCollectiveKernelThunk =
                             const HloAllReduceInstruction*,
                             std::vector<CollectiveThunk::Buffer>,
                             std::unique_ptr<CollectiveKernelThunk>,
+                            /*p2p_memcpy_enabled=*/bool> ||
+    std::is_constructible_v<ThunkType, Thunk::ThunkInfo,
+                            const HloAllGatherInstruction*,
+                            std::vector<CollectiveThunk::Buffer>,
+                            std::unique_ptr<CollectiveKernelThunk>,
                             /*p2p_memcpy_enabled=*/bool>;
 
 // The signature of this function would change to absl::Status once we lift the
 // CollectiveKernelThunk out as a top level thunk. It would then become a member
 // function of ThunkEmitter.
 // As it stands now the collective kernel thunk is wrapped inside other
-// collective thunks such as AllReduceStart. So this function is only
-// responsible for emitting the collective kernel thunk and its dependencies.
+// collective thunks such as AllReduceStart and AllGatherStart. So this function
+// is only responsible for emitting the collective kernel thunk and its
+// dependencies.
 absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
     Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
     const HloAllReduceInstruction* instr, const AllReduceConfig& config) {
+  LOG(INFO) << "EmitCollectiveKernelThunk called for AllReduce: "
+            << instr->name();
+
   std::unique_ptr<HloModule> fused_module =
       NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
   HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
@@ -235,8 +244,14 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
                                                device_info, fusion_instr));
   if (!did_set_config) {
-    return make_thunk(/*kernel_name=*/"", 0, nullptr);
+    LOG(INFO) << "TrySetGpuBackendConfigForCollective returned false - not "
+                 "using Triton";
+    return make_thunk(/*kernel_name=*/"",
+                      /*shmem_bytes=*/0,
+                      /*launch_dimensions=*/std::nullopt,
+                      /*local_module=*/nullptr);
   }
+  LOG(INFO) << "TrySetGpuBackendConfigForCollective succeeded - using Triton!";
   const HloFusionAnalysis fusion_analysis =
       HloFusionAnalysis::Create(*fusion_instr, device_info);
   auto emitter = std::make_unique<TritonFusion>(fusion_analysis);
@@ -267,12 +282,81 @@ std::optional<const HloInstruction*> GetCollectiveHeroForDynamicSliceFusion(
       [](const HloInstruction* instr) { return IsCollective(instr); });
 }
 
+// Overload for AllGather
+absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
+    IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
+    Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
+    const HloAllGatherInstruction* instr) {
+  LOG(INFO) << "EmitCollectiveKernelThunk called for AllGather: "
+            << instr->name();
+
+  std::unique_ptr<HloModule> fused_module =
+      NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
+  HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
+      fused_module->entry_computation()->root_instruction());
+  const se::DeviceDescription& device_info =
+      ir_emitter_context->gpu_device_info();
+
+  // For AllGather, we don't have a reduction, so we create a dummy config
+  const auto make_thunk = [&](absl::string_view kernel_name,
+                              int32_t shmem_bytes,
+                              std::optional<LaunchDimensions> launch_dimensions,
+                              std::unique_ptr<llvm::Module> local_module) {
+    // AllGather doesn't have reduction, use a placeholder
+    return EmitCollectiveResult{
+        std::make_unique<CollectiveKernelThunk>(
+            thunk_info,
+            GetCollectiveConfig(instr, instr->use_global_device_ids()),
+            ReductionKind::SUM,  // Placeholder, not used for AllGather
+            /*is_async=*/!IsGPUSyncCollective(*instr), std::move(buffers),
+            /*is_collective_kernel_enabled=*/
+            instr->GetModule()
+                ->config()
+                .debug_options()
+                .xla_gpu_unsupported_use_all_gather_triton_backend(),
+            /*kernel_name=*/kernel_name,
+            /*launch_dimensions=*/launch_dimensions,
+            /*shmem_bytes=*/shmem_bytes,
+            /*is_multimem_enabled=*/false,
+            /*collective_op_kind=*/
+            CollectiveKernelThunk::CollectiveOpKind::kAllGather),
+        std::move(local_module)};
+  };
+
+  TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
+                                               device_info, fusion_instr));
+  if (!did_set_config) {
+    return make_thunk(/*kernel_name=*/"",
+                      /*shmem_bytes=*/0,
+                      /*launch_dimensions=*/std::nullopt,
+                      /*local_module=*/nullptr);
+  }
+  const HloFusionAnalysis fusion_analysis =
+      HloFusionAnalysis::Create(*fusion_instr, device_info);
+  auto emitter = std::make_unique<TritonFusion>(fusion_analysis);
+  TritonFusion::EmitResult result;
+  {
+    XLA_SCOPED_LOGGING_TIMER("Emit collective kernel thunk for AllGather");
+    TF_ASSIGN_OR_RETURN(std::vector<Shape> unmanaged_arguments,
+                        GetCollectiveUnmanagedKernelArguments(fusion_instr));
+
+    // For AllGather, use instr_override to get correct buffer assignments.
+    // The special KernelArguments::Create overload in fusion.cc handles
+    // the tuple unpacking, using fusion for shapes and AllGather for buffers.
+    TF_ASSIGN_OR_RETURN(
+        result, emitter->Emit(*ir_emitter_context, *fusion_instr,
+                              /*instr_override=*/instr, unmanaged_arguments));
+  }
+  return make_thunk(
+      result.kernel_thunk->kernel_name(), result.kernel_thunk->shmem_bytes(),
+      result.kernel_thunk->launch_dimensions(), std::move(result.llvm_module));
+}
+
 }  // namespace
 
-ThunkEmitter::ThunkEmitter(
-    IrEmitterContext* absl_nonnull ir_emitter_context,
-    llvm_ir::LLVMCommandLineOptionsReleasableLock* absl_nonnull
-        llvm_options_lock)
+ThunkEmitter::ThunkEmitter(IrEmitterContext* absl_nonnull ir_emitter_context,
+                           llvm_ir::LLVMCommandLineOptionsReleasableLock*
+                               absl_nonnull llvm_options_lock)
     : ir_emitter_context_(ir_emitter_context),
       send_recv_events_(std::make_shared<HostSendRecvAsyncEvents>()),
       copy_events_(std::make_shared<CopyThunk::AsyncEvents>()),
@@ -1675,18 +1759,35 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectiveThunk(
   // TODO(b/828435206) Remove this constexpr once collective kernel thunk is
   // lifted out of the all reduce thunk.
   if constexpr (kRequiresCollectiveKernelThunk<CollectiveThunkType>) {
-    TF_ASSIGN_OR_RETURN(
-        auto emit_result,
-        EmitCollectiveKernelThunk(
-            ir_emitter_context_, call_graph_.get(), thunk_info, buffers,
-            Cast<HloAllReduceInstruction>(inst), GetAllReduceConfigInst(inst)));
-    if (emit_result.llvm_module != nullptr) {
-      kernel_modules_.push_back(std::move(emit_result.llvm_module));
+    // Check if this is AllReduce or AllGather and call appropriate overload
+    if constexpr (std::is_same_v<HloInstType, HloAllReduceInstruction>) {
+      TF_ASSIGN_OR_RETURN(
+          auto emit_result,
+          EmitCollectiveKernelThunk(ir_emitter_context_, call_graph_.get(),
+                                    thunk_info, buffers, inst,
+                                    GetAllReduceConfigInst(inst)));
+      if (emit_result.llvm_module != nullptr) {
+        kernel_modules_.push_back(std::move(emit_result.llvm_module));
+      }
+      thunk = std::make_unique<CollectiveThunkType>(
+          thunk_info, inst, /*buffers=*/std::move(buffers),
+          std::move(emit_result.thunk),
+          ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p());
+    } else if constexpr (std::is_same_v<HloInstType, HloAllGatherInstruction>) {
+      TF_ASSIGN_OR_RETURN(
+          auto emit_result,
+          EmitCollectiveKernelThunk(ir_emitter_context_, call_graph_.get(),
+                                    thunk_info, buffers, inst));
+      if (emit_result.llvm_module != nullptr) {
+        kernel_modules_.push_back(std::move(emit_result.llvm_module));
+      }
+      thunk = std::make_unique<CollectiveThunkType>(
+          thunk_info, inst, /*buffers=*/std::move(buffers),
+          std::move(emit_result.thunk),
+          ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p());
+    } else {
+      return Internal("Unsupported collective instruction type");
     }
-    thunk = std::make_unique<CollectiveThunkType>(
-        thunk_info, inst, /*buffers=*/std::move(buffers),
-        std::move(emit_result.thunk),
-        ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p());
   } else {
     thunk = std::make_unique<CollectiveThunkType>(
         thunk_info, inst, /*buffers=*/std::move(buffers),

--- a/xla/service/hlo_creation_utils.cc
+++ b/xla/service/hlo_creation_utils.cc
@@ -990,6 +990,21 @@ std::unique_ptr<HloModule> NewModuleWithFusion(
     });
   }
 
+  // For AllGather-start, extract the output element from the tuple.
+  // AllGather-start returns (input, output) tuple, but Triton backend
+  // cannot handle tuple results. We extract element 1 (the output).
+  Shape fusion_output_shape = instruction->shape();
+  if (instruction->opcode() == HloOpcode::kAllGatherStart &&
+      instruction->shape().IsTuple()) {
+    // Extract just the output element (index 1) from the tuple
+    HloInstruction* gte =
+        fusion_builder.AddInstruction(HloInstruction::CreateGetTupleElement(
+            ShapeUtil::GetTupleElementShape(instruction->shape(), 1),
+            fused_root, 1));
+    fused_root = gte;
+    fusion_output_shape = fused_root->shape();
+  }
+
   HloComputation* fused_computation =
       hlo_module->AddEmbeddedComputation(fusion_builder.Build(fused_root));
 
@@ -998,7 +1013,7 @@ std::unique_ptr<HloModule> NewModuleWithFusion(
   std::vector<HloInstruction*> entry_parameters =
       build_parameter_instructions(entry_builder);
   HloInstruction* fusion_instruction = entry_builder.AddInstruction(
-      HloInstruction::CreateFusion(instruction->shape(), fusion_kind,
+      HloInstruction::CreateFusion(fusion_output_shape, fusion_kind,
                                    entry_parameters, fused_computation));
 
   hlo_module->AddEntryComputation(entry_builder.Build(fusion_instruction));

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -4043,3 +4043,41 @@ xla_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+xla_test(
+    name = "all_gather_e2e_test",
+    srcs = ["all_gather_e2e_test.cc"],
+    backend_tags = {
+        "gpu": [
+            "multi_gpu",
+        ],
+    },
+    backends = [
+        "gpu",
+    ],
+    deps = [
+        ":literal_test_util",
+        "//xla:array",
+        "//xla:error_spec",
+        "//xla:literal",
+        "//xla:literal_util",
+        "//xla:shape_util",
+        "//xla:types",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service:collective_ops_utils",
+        "//xla/service/gpu/tests:collective_ops_e2e_test_base",
+        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:test",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/xla/tests/all_gather_e2e_test.cc
+++ b/xla/tests/all_gather_e2e_test.cc
@@ -240,7 +240,7 @@ static absl::StatusOr<InputsOutputs> BuildTestInputsOutputs(
   std::vector<Literal> expected_output_literals;
 
   const std::vector<ReplicaGroup>& replica_groups =
-      instr->device_list()->replica_groups();
+      instr->device_list().replica_groups();
 
   // Map each device to set of replica groups it belongs to.
   std::vector<std::vector<int64_t>> device_to_groups(num_replicas);

--- a/xla/tests/all_gather_e2e_test.cc
+++ b/xla/tests/all_gather_e2e_test.cc
@@ -725,6 +725,147 @@ TEST_P(AllGatherTest, F32_3D_2GPUs_Dim2) {
   }
 }
 
+// Large BF16 test matching the Python test configuration
+// Tests 1024 elements (2KB) with 2 GPUs to verify Triton output correctness
+TEST_P(AllGatherTest, BF16_1024Elements_2GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = bf16[1024] parameter(0)
+    ROOT all-gather = bf16[2048] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+
+  // Build test inputs and expected outputs
+  TF_ASSERT_OK_AND_ASSIGN(InputsOutputs test_io,
+                          (BuildTestInputsOutputs<PrimitiveType::BF16>(
+                              *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+
+  // Execute the all-gather operation
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+
+  // Verify outputs match expected
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-3}))
+        << "ExpectedOutput != Result at replica " << i
+        << "\nThis test verifies that AllGather output matches the expected "
+        << "concatenation of inputs. Failure indicates incorrect Triton "
+           "implementation.";
+  }
+}
+
+// Large BF16 test with 4 GPUs
+// Tests 1024 elements per replica (2KB) -> 4096 elements output (8KB)
+TEST_P(AllGatherTest, BF16_1024Elements_4GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = bf16[1024] parameter(0)
+    ROOT all-gather = bf16[4096] all-gather(param_0),
+      replica_groups={{0,1,2,3}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 4;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+
+  // Build test inputs and expected outputs
+  TF_ASSERT_OK_AND_ASSIGN(InputsOutputs test_io,
+                          (BuildTestInputsOutputs<PrimitiveType::BF16>(
+                              *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+
+  // Execute the all-gather operation
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+
+  // Verify outputs match expected
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-3}))
+        << "ExpectedOutput != Result at replica " << i
+        << "\nThis test verifies that AllGather output matches the expected "
+        << "concatenation of inputs. Failure indicates incorrect Triton "
+           "implementation.";
+  }
+}
+
+// Large BF16 test with 8 GPUs
+// Tests 1024 elements per replica (2KB) -> 8192 elements output (16KB)
+TEST_P(AllGatherTest, BF16_1024Elements_8GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = bf16[1024] parameter(0)
+    ROOT all-gather = bf16[8192] all-gather(param_0),
+      replica_groups={{0,1,2,3,4,5,6,7}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 8;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+
+  // Build test inputs and expected outputs
+  TF_ASSERT_OK_AND_ASSIGN(InputsOutputs test_io,
+                          (BuildTestInputsOutputs<PrimitiveType::BF16>(
+                              *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+
+  // Execute the all-gather operation
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+
+  // Verify outputs match expected
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-3}))
+        << "ExpectedOutput != Result at replica " << i
+        << "\nThis test verifies that AllGather output matches the expected "
+        << "concatenation of inputs. Failure indicates incorrect Triton "
+           "implementation.";
+  }
+}
+
 // FP8 vs FP16 all-gather comparison.
 TEST_F(AllGatherTestNoParams, AsyncAllGather_F8E4M3FN_2GPUs) {
   bool has_fp8_support = false;

--- a/xla/tests/all_gather_e2e_test.cc
+++ b/xla/tests/all_gather_e2e_test.cc
@@ -1,0 +1,801 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/array.h"
+#include "xla/error_spec.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/literal.h"
+#include "xla/literal_util.h"
+#include "xla/primitive_util.h"
+#include "xla/service/collective_ops_utils.h"
+#include "xla/service/gpu/tests/collective_ops_e2e_test_base.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/tests/literal_test_util.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/test.h"
+#include "xla/types.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla {
+namespace {
+
+std::string GetAsyncTestName(bool is_async) {
+  return is_async ? "async" : "sync";
+}
+
+void VerifyAllGatherType(const HloModule* module, PrimitiveType expected_type) {
+  bool found = false;
+  for (auto* comp : module->computations()) {
+    for (auto* instr : comp->instructions()) {
+      if (instr->opcode() == HloOpcode::kAllGather ||
+          instr->opcode() == HloOpcode::kAllGatherStart) {
+        PrimitiveType actual_type = instr->operand(0)->shape().element_type();
+        ASSERT_EQ(actual_type, expected_type)
+            << "Expected AllGather type " << PrimitiveType_Name(expected_type)
+            << " but got " << PrimitiveType_Name(actual_type);
+        found = true;
+      }
+    }
+  }
+  ASSERT_TRUE(found) << "No AllGather found in module";
+}
+
+class AllGatherTestNoParams : public CollectiveOpsWithFlagsBase {
+ public:
+  explicit AllGatherTestNoParams(bool is_async = false)
+      : CollectiveOpsWithFlagsBase(/*enable_async=*/is_async,
+                                   /*enable_p2p_memcpy=*/false,
+                                   /*memory_size=*/32 * kMB,
+                                   /*collectives_memory_size=*/0) {}
+
+  void SetUp() override {
+    CollectiveOpsE2ETestBase::SetUp();
+    // Check for Triton support: Ampere+ for CUDA, any supported GPU for ROCm
+    if (Capability().IsCuda() && !IsAmpereAndHigher()) {
+      GTEST_SKIP() << "Test requires Ampere or newer architecture for CUDA "
+                      "since it's using triton.";
+    }
+  }
+
+  // Receives a required device count and asserts or skips the test if the
+  // device count is less than the required device count.
+  //
+  // Tap presubmits have only 2 GPUs available. This is the minimum required
+  // device count below which we fail the test.
+  // If the required device count is more than 2 and not enough devices are
+  // available, the test is marked as skipped when running on TAP.
+  //
+  // Returns false if the test should be skipped or has failed. Otherwise,
+  // returns true.
+  bool CheckDeviceCount(int32_t required_device_count) {
+    [&]() -> void {
+      const int32_t current_device_count = device_count();
+      if (current_device_count < required_device_count) {
+        ASSERT_GE(current_device_count, 2)
+            << "Test requires at least 2 devices but only "
+            << current_device_count << " available";
+        if (current_device_count < required_device_count) {
+          GTEST_SKIP() << "Test requires at least " << required_device_count
+                       << " devices but only " << current_device_count
+                       << " available.";
+        }
+      }
+    }();
+    return !IsSkipped() && !HasFatalFailure();
+  }
+};
+
+struct AllGatherTestParams {
+  // If true uses the async stream for the collective.
+  bool is_async;
+  // If true, uses the Triton backend for all-gather.
+  // If false, uses the NCCL backend.
+  bool use_all_gather_triton_backend;
+
+  // Returns the shape for the given element type and rank.
+  std::vector<int64_t> GetShape(PrimitiveType element_type,
+                                int32_t rank = 1) const {
+    // Use a reasonable size for testing
+    int64_t total = 1024;
+    if (rank <= 1) {
+      return {total};
+    }
+    std::vector<int64_t> dims;
+    for (int32_t i = 0; i < rank - 1; ++i) {
+      dims.push_back(rank);
+      total /= rank;
+    }
+    dims.push_back(total);
+    return dims;
+  }
+
+  static std::vector<AllGatherTestParams> Generate() {
+    std::vector<AllGatherTestParams> params;
+    for (bool is_async : {true, false}) {
+      for (bool use_all_gather_triton_backend : {true, false}) {
+        params.push_back({is_async, use_all_gather_triton_backend});
+      }
+    }
+    return params;
+  }
+
+  // Convert to string for test naming.
+  [[maybe_unused]] friend void PrintTo(const AllGatherTestParams& params,
+                                       std::ostream* os) {
+    *os << "{ .is_async=" << params.is_async
+        << ", .use_all_gather_triton_backend="
+        << params.use_all_gather_triton_backend << " }";
+  }
+};
+
+struct AllGatherTypesTestParams : public AllGatherTestParams {
+  // The element type of the all-gather.
+  PrimitiveType element_type;
+
+  static std::vector<AllGatherTypesTestParams> Generate() {
+    std::vector<AllGatherTypesTestParams> params;
+    for (auto& all_gather_test_params : AllGatherTestParams::Generate()) {
+      // Test common types used in ML workloads
+      for (const PrimitiveType element_type : {F32, F16, BF16, S32, S8, PRED}) {
+        params.push_back({all_gather_test_params, element_type});
+      }
+    }
+    return params;
+  }
+};
+
+struct InputsOutputs {
+  std::vector<Literal> inputs;
+  std::vector<Literal> expected_outputs;
+
+  [[nodiscard]] std::vector<std::vector<Literal*>> InputLiteralPtrs() {
+    std::vector<std::vector<Literal*>> result;
+    for (auto& input : inputs) {
+      result.push_back(std::vector<Literal*>{&input});
+    }
+    return result;
+  }
+};
+
+template <typename T>
+static void FillRandom(Array<T>& array, int64_t seed) {
+  constexpr PrimitiveType primitive_type =
+      primitive_util::NativeToPrimitiveType<T>();
+  if constexpr (primitive_util::IsFloatingPointType(primitive_type)) {
+    array.FillRandom(T{1.0f}, T{10.0}, seed);
+  } else if constexpr (primitive_type == PRED) {
+    array.FillRandomBool(seed);
+  } else if constexpr (primitive_util::IsIntegralType(primitive_type)) {
+    array.FillRandomUniform(T{0}, T{100}, seed);
+  } else {
+    GTEST_FAIL() << "Unsupported element type: "
+                 << absl::StrFormat("%v",
+                                    primitive_util::NativeToPrimitiveType<T>());
+  }
+}
+
+template <PrimitiveType kElementType>
+static absl::StatusOr<InputsOutputs> BuildTestInputsOutputs(
+    const HloModule& module, int64_t num_replicas,
+    int64_t all_gather_dimension) {
+  using ElementType = primitive_util::NativeTypeOf<kElementType>;
+
+  std::vector<Array<ElementType>> inputs;
+  std::vector<Literal> input_literals;
+  const HloInstruction* const hlo_instr =
+      HloHardwareIndependentTestBase::FindInstruction(&module,
+                                                      HloOpcode::kAllGather);
+  if (hlo_instr == nullptr) {
+    return absl::InvalidArgumentError(
+        "Instruction 'all-gather' not found in module.");
+  }
+  const HloAllGatherInstruction* instr =
+      Cast<HloAllGatherInstruction>(hlo_instr);
+  const Shape& input_shape = instr->operand(0)->shape();
+
+  // Create inputs for each replica
+  for (int i = 0; i < num_replicas; ++i) {
+    auto& input =
+        inputs.emplace_back(Array<ElementType>(input_shape.dimensions()));
+    FillRandom<ElementType>(input, i);
+    input_literals.push_back(LiteralUtil::CreateFromArray(input));
+  }
+
+  std::vector<Literal> expected_output_literals;
+
+  const std::vector<ReplicaGroup>& replica_groups =
+      instr->device_list()->replica_groups();
+
+  // Map each device to set of replica groups it belongs to.
+  std::vector<std::vector<int64_t>> device_to_groups(num_replicas);
+  for (const auto& replica_group : replica_groups) {
+    const auto& replica_ids = replica_group.replica_ids();
+    for (int64_t replica : replica_group.replica_ids()) {
+      CHECK_EQ(device_to_groups[replica].size(), 0);
+      device_to_groups[replica].assign(replica_ids.begin(), replica_ids.end());
+    }
+  }
+
+  // Build expected outputs by concatenating inputs along the all-gather
+  // dimension For all-gather, each replica in a group receives the
+  // concatenation of all inputs from replicas in that group along the specified
+  // dimension.
+  const Shape& output_shape = instr->shape();
+  for (int i = 0; i < num_replicas; ++i) {
+    const std::vector<int64_t>& group = device_to_groups[i];
+
+    // Create output literal with the concatenated shape
+    Literal output(output_shape);
+
+    // Manually concatenate by copying slices from each replica in the group
+    // along the all-gather dimension
+    int64_t offset = 0;
+    for (int64_t replica : group) {
+      const Literal& input = input_literals[replica];
+      const int64_t slice_size = input_shape.dimensions(all_gather_dimension);
+
+      // Set up source and destination bases
+      std::vector<int64_t> src_base(input_shape.dimensions_size(), 0);
+      std::vector<int64_t> dest_base(output_shape.dimensions_size(), 0);
+      dest_base[all_gather_dimension] = offset;
+
+      // Copy data from input to output at the appropriate offset
+      TF_RETURN_IF_ERROR(output.CopySliceFrom(
+          input, src_base, dest_base, /*copy_size=*/input_shape.dimensions()));
+      offset += slice_size;
+    }
+
+    expected_output_literals.push_back(std::move(output));
+  }
+
+  return InputsOutputs{std::move(input_literals),
+                       std::move(expected_output_literals)};
+}
+
+absl::StatusOr<InputsOutputs> BuildTestInputsOutputs(
+    PrimitiveType element_type, const HloModule& module, int64_t num_replicas,
+    int64_t all_gather_dimension) {
+  const auto dispatch = [&](auto type) {
+    return BuildTestInputsOutputs<type>(module, num_replicas,
+                                        all_gather_dimension);
+  };
+  return primitive_util::ArrayTypeSwitch(dispatch, element_type);
+}
+
+class AllGatherTest
+    : public AllGatherTestNoParams,
+      public ::testing::WithParamInterface<AllGatherTestParams> {
+ public:
+  AllGatherTest() : AllGatherTestNoParams(/*is_async=*/GetParam().is_async) {}
+
+ protected:
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions opts = CollectiveOpsWithFlagsBase::GetDebugOptionsForTest();
+    opts.set_xla_gpu_unsupported_use_all_gather_triton_backend(
+        GetParam().use_all_gather_triton_backend);
+    return opts;
+  }
+};
+
+class AllGatherTypesTest
+    : public AllGatherTestNoParams,
+      public ::testing::WithParamInterface<AllGatherTypesTestParams> {
+ public:
+  AllGatherTypesTest()
+      : AllGatherTestNoParams(/*is_async=*/GetParam().is_async) {}
+
+ protected:
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions opts = CollectiveOpsWithFlagsBase::GetDebugOptionsForTest();
+    opts.set_xla_gpu_unsupported_use_all_gather_triton_backend(
+        GetParam().use_all_gather_triton_backend);
+    return opts;
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    AllGatherTest, AllGatherTest,
+    ::testing::ValuesIn(AllGatherTestParams::Generate()),
+    [](const ::testing::TestParamInfo<AllGatherTestParams>& info) {
+      return absl::StrCat(
+          GetAsyncTestName(info.param.is_async), "_",
+          info.param.use_all_gather_triton_backend ? "triton" : "nccl");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    AllGatherTypesTest, AllGatherTypesTest,
+    ::testing::ValuesIn(AllGatherTypesTestParams::Generate()),
+    [](const ::testing::TestParamInfo<AllGatherTypesTestParams>& info) {
+      return absl::StrCat(
+          GetAsyncTestName(info.param.is_async), "_",
+          primitive_util::LowercasePrimitiveTypeName(info.param.element_type),
+          "_", info.param.use_all_gather_triton_backend ? "triton" : "nccl");
+    });
+
+TEST_P(AllGatherTypesTest, SupportedTypes2GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = %1$s[%2$s] parameter(0)
+    ROOT all-gather = %1$s[%3$s] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  const PrimitiveType element_type = GetParam().element_type;
+  const std::vector<int64_t> input_shape = GetParam().GetShape(element_type);
+
+  // Calculate output shape (dimension 0 multiplied by num replicas in group)
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  const std::string module_str = absl::StrFormat(
+      kModuleStr, primitive_util::LowercasePrimitiveTypeName(element_type),
+      absl::StrJoin(input_shape, ","), absl::StrJoin(output_shape, ","));
+  SCOPED_TRACE(::testing::Message() << "module_str: " << module_str);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(module_str, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs(element_type, *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Equal(test_io.expected_outputs[i], results[i]))
+        << "ExpectedOutput != Result at rank " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32_8GPUs_AllReplicasOneGroup) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1,2,3,4,5,6,7}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 8;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  const std::vector<int64_t> input_shape =
+      GetParam().GetShape(PrimitiveType::F32);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32_8GPUs_2ReplicasPerGroup) {
+  const std::vector<int64_t> input_shape =
+      GetParam().GetShape(PrimitiveType::F32);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= 2;  // 2 replicas per group
+
+  const auto kModuleStr = absl::StrFormat(
+      R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,4},{1,5},{2,6},{3,7}}, dimensions={0}
+  }
+  )",
+      absl::StrJoin(input_shape, ","), absl::StrJoin(output_shape, ","));
+
+  constexpr int64_t kNumReplicas = 8;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Equal(test_io.expected_outputs[i], results[i]))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32TwoD4GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1,2,3}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 4;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  const std::vector<int64_t> input_shape =
+      GetParam().GetShape(PrimitiveType::F32, /*rank=*/2);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// This test uses a 3D shape with non-power-of-2 dimensions (e.g., [3,3,113] =
+// 1017 elements) which doesn't meet Triton's alignment requirements (must be
+// divisible by 4). The test verifies that the system correctly falls back to
+// NCCL/RCCL when Triton is not supported.
+TEST_P(AllGatherTest, F32_3D_2GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+  const std::vector<int64_t> input_shape =
+      GetParam().GetShape(PrimitiveType::F32, /*rank=*/3);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// 3D test with power-of-2 dimensions that work with Triton tiling
+TEST_P(AllGatherTest, F32_3D_2GPUs_PowerOf2) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+  // Use power-of-2 dimensions: [8, 8, 16] = 1024 elements (aligned)
+  const std::vector<int64_t> input_shape = {8, 8, 16};
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// Test gathering on dimension 1 for 2D data
+TEST_P(AllGatherTest, F32TwoD4GPUs_Dim1) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[32,32] parameter(0)
+    ROOT all-gather = f32[32,128] all-gather(param_0),
+      replica_groups={{0,1,2,3}}, dimensions={1}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 4;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/1)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// Test gathering on dimension 1 for 3D data
+TEST_P(AllGatherTest, F32_3D_2GPUs_Dim1) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[8,8,16] parameter(0)
+    ROOT all-gather = f32[8,16,16] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={1}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/1)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// Test gathering on dimension 2 for 3D data
+TEST_P(AllGatherTest, F32_3D_2GPUs_Dim2) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[8,8,16] parameter(0)
+    ROOT all-gather = f32[8,8,32] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={2}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/2)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// FP8 vs FP16 all-gather comparison.
+TEST_F(AllGatherTestNoParams, AsyncAllGather_F8E4M3FN_2GPUs) {
+  bool has_fp8_support = false;
+  if (Capability().IsCuda()) {
+    has_fp8_support = Capability().cuda_compute_capability()->IsAtLeast(9, 0);
+  } else if (Capability().IsRocm()) {
+    has_fp8_support =
+        Capability().rocm_compute_capability()->has_ocp_fp8_support();
+  }
+
+  if (!has_fp8_support) {
+    GTEST_SKIP() << "FP8 requires GPU with OCP FP8 support (CUDA Hopper+ or "
+                    "ROCm MI350/gfx12xx with ROCm 7.0+).";
+  }
+
+  // FP16 baseline
+  constexpr absl::string_view kF16ModuleStr = R"(
+  HloModule f16_allgather
+  ENTRY test {
+    param = f16[32,64] parameter(0)
+    ROOT all-gather = f16[64,64] all-gather(param), replica_groups={{0,1}}, dimensions={0}
+  })";
+
+  // FP8 version
+  constexpr absl::string_view kF8ModuleStr = R"(
+  HloModule fp8_allgather
+  ENTRY test {
+    param = f16[32,64] parameter(0)
+    param_f8 = f8e4m3fn[32,64] convert(param)
+    all-gather_f8 = f8e4m3fn[64,64] all-gather(param_f8), replica_groups={{0,1}}, dimensions={0}
+    ROOT result = f16[64,64] convert(all-gather_f8)
+  })";
+
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  Array<Eigen::half> input1({32, 64}), input2({32, 64});
+  input1.FillRandom(Eigen::half(0.1f), 0.5f, /*seed=*/0);
+  input2.FillRandom(Eigen::half(0.1f), 0.5f, /*seed=*/1);
+
+  Literal input_lit1 = LiteralUtil::CreateFromArray(input1);
+  Literal input_lit2 = LiteralUtil::CreateFromArray(input2);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto f16_module, ParseAndReturnVerifiedModule(
+                                               kF16ModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult f16_result,
+                          ExecuteReplicated(std::move(f16_module),
+                                            std::vector<std::vector<Literal*>>{
+                                                {&input_lit1}, {&input_lit2}}));
+  // Verify FP16 all-gather type in optimized module
+  VerifyAllGatherType(f16_result.optimized_module, F16);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto f8_module, ParseAndReturnVerifiedModule(kF8ModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult f8_result,
+                          ExecuteReplicated(std::move(f8_module),
+                                            std::vector<std::vector<Literal*>>{
+                                                {&input_lit1}, {&input_lit2}}));
+  // Verify FP8 all-gather type in optimized module
+  VerifyAllGatherType(f8_result.optimized_module, F8E4M3FN);
+
+  ASSERT_EQ(f16_result.results.size(), kNumReplicas);
+  ASSERT_EQ(f8_result.results.size(), kNumReplicas);
+
+  // FP8 vs FP16 comparison: should be close but not identical
+  // Note: Using 6% tolerance due to cumulative FP16 and FP8 precision loss
+  EXPECT_TRUE(LiteralTestUtil::Near(f16_result.results[0], f8_result.results[0],
+                                    ErrorSpec{6e-2, 6e-2}));
+}
+
+}  // namespace
+}  // namespace xla

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -286,8 +286,8 @@ TEST_P(AsyncCollectiveOps, AsyncAllGatherTritonBackend) {
   config.mutable_debug_options()
       .set_xla_gpu_unsupported_use_all_gather_triton_backend(true);
 
-  TF_ASSERT_OK_AND_ASSIGN(
-      auto module, ParseAndReturnVerifiedModule(kModuleStr, config));
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr, config));
 
   TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
                           ExecuteReplicated(std::move(module)));
@@ -304,7 +304,8 @@ TEST_P(AsyncCollectiveOps, AsyncAllGatherTritonBackend) {
   const std::vector<Literal>& results = execution_result.results;
   ASSERT_EQ(results.size(), kNumReplicas);
   for (const Literal& result : results) {
-    LiteralTestUtil::ExpectR1Equal<float>({10.0, 15.0, 20.0, 25.0, 11.0, 16.0, 21.0, 26.0}, result);
+    LiteralTestUtil::ExpectR1Equal<float>(
+        {10.0, 15.0, 20.0, 25.0, 11.0, 16.0, 21.0, 26.0}, result);
   }
 }
 
@@ -2428,7 +2429,8 @@ TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim0OutputIsCorrect) {
   }
 }
 
-TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim0OutputIsCorrectTritonBackend) {
+TEST_F(CollectiveOpsTestE2E,
+       OptimizedSubByteAllGatherOnDim0OutputIsCorrectTritonBackend) {
   constexpr int kNumReplicas = 2;
   ASSERT_GE(device_count(), kNumReplicas)
       << "Test requires at least " << kNumReplicas << " devices ("
@@ -2510,7 +2512,8 @@ TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim1OutputIsCorrect) {
   }
 }
 
-TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim1OutputIsCorrectTritonBackend) {
+TEST_F(CollectiveOpsTestE2E,
+       OptimizedSubByteAllGatherOnDim1OutputIsCorrectTritonBackend) {
   constexpr int kNumReplicas = 2;
   ASSERT_GE(device_count(), kNumReplicas)
       << "Test requires at least " << kNumReplicas << " devices ("
@@ -2591,7 +2594,8 @@ TEST_F(CollectiveOpsTestE2E, AllGatherOnChangedDimensionIsCorrect) {
   }
 }
 
-TEST_F(CollectiveOpsTestE2E, AllGatherOnChangedDimensionIsCorrectTritonBackend) {
+TEST_F(CollectiveOpsTestE2E,
+       AllGatherOnChangedDimensionIsCorrectTritonBackend) {
   const int64_t kNumReplicas = 2;
   ASSERT_GE(device_count(), kNumReplicas)
       << "The test requires at least " << kNumReplicas << " devices";

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -261,6 +261,53 @@ TEST_P(AsyncCollectiveOps, AsyncAllGather) {
   }
 }
 
+TEST_P(AsyncCollectiveOps, AsyncAllGatherTritonBackend) {
+  const absl::string_view kModuleStr = R"(
+  HloModule test
+  ENTRY test_computation {
+    id = u32[] replica-id()
+    id_f32 = f32[] convert(id)
+    id2 = f32[1, 4] broadcast(id_f32), dimensions={}
+    a0 = f32[1, 4] constant({{10, 15, 20, 25}})
+    a1 = f32[1, 4] add(id2, a0)
+    allgather = f32[2, 4] all-gather(a1), replica_groups={{0,1}}, dimensions={0}
+    ROOT out = f32[8] reshape(allgather)
+  }
+  )";
+  const int64_t kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "Test requires at least " << kNumReplicas << " devices ("
+      << device_count() << " available)";
+
+  const bool enable_async_all_gather = GetParam();
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  config.mutable_debug_options()
+      .set_xla_gpu_unsupported_use_all_gather_triton_backend(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, config));
+
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
+                          ExecuteReplicated(std::move(module)));
+
+  const HloModule* hlo_module = execution_result.optimized_module;
+  HloInstruction* all_gather_start =
+      FindInstruction(hlo_module, HloOpcode::kAllGatherStart);
+  HloInstruction* all_gather_done =
+      FindInstruction(hlo_module, HloOpcode::kAllGatherDone);
+  EXPECT_THAT(all_gather_start, NotNull());
+  EXPECT_THAT(all_gather_done, NotNull());
+  EXPECT_EQ(IsAsync(all_gather_start), enable_async_all_gather);
+
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (const Literal& result : results) {
+    LiteralTestUtil::ExpectR1Equal<float>({10.0, 15.0, 20.0, 25.0, 11.0, 16.0, 21.0, 26.0}, result);
+  }
+}
+
 TEST_P(AsyncCollectiveOps, AsyncAllGatherMixedTypes) {
   const absl::string_view kModuleStr = R"(
   HloModule test
@@ -2381,6 +2428,48 @@ TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim0OutputIsCorrect) {
   }
 }
 
+TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim0OutputIsCorrectTritonBackend) {
+  constexpr int kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "Test requires at least " << kNumReplicas << " devices ("
+      << device_count() << " available)";
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  config.mutable_debug_options()
+      .set_xla_gpu_unsupported_use_all_gather_triton_backend(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto unoptimized_module,
+                          ParseAndReturnVerifiedModule(R"(
+    HloModule m, replica_count=2
+
+    e {
+      a = s4[2,4]{1,0:E(4)} constant({{0,1,2,3},{4,5,5,4}})
+      b = s4[4,4]{1,0:E(4)} all-gather(a), replica_groups={{0,1}}, dimensions={0}
+    })",
+                                                       config));
+
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
+                          ExecuteReplicated(std::move(unoptimized_module)));
+
+  const HloModule* module = execution_result.optimized_module;
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              GmockMatch(m::Bitcast(m::AllGatherDone().WithShape(S8, {4, 2}))));
+
+  const Literal expected_result =
+      LiteralUtil::CreateR2<s4>({{s4(0), s4(1), s4(2), s4(3)},
+                                 {s4(4), s4(5), s4(5), s4(4)},
+                                 {s4(0), s4(1), s4(2), s4(3)},
+                                 {s4(4), s4(5), s4(5), s4(4)}});
+
+  const std::vector<Literal>& result = execution_result.results;
+  ASSERT_EQ(result.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    EXPECT_TRUE(LiteralTestUtil::Equal(expected_result, result[i]))
+        << "Results differ at replica " << i;
+  }
+}
+
 TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim1OutputIsCorrect) {
   constexpr int kNumReplicas = 2;
   ASSERT_GE(device_count(), kNumReplicas)
@@ -2418,6 +2507,128 @@ TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim1OutputIsCorrect) {
   for (int i = 0; i < kNumReplicas; ++i) {
     EXPECT_TRUE(LiteralTestUtil::Equal(expected_result, result[i]))
         << "Results differ at replica " << i;
+  }
+}
+
+TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim1OutputIsCorrectTritonBackend) {
+  constexpr int kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "Test requires at least " << kNumReplicas << " devices ("
+      << device_count() << " available)";
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  config.mutable_debug_options()
+      .set_xla_gpu_unsupported_use_all_gather_triton_backend(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto unoptimized_module,
+                          ParseAndReturnVerifiedModule(R"(
+    HloModule m, replica_count=2
+
+    e {
+      a = s4[4,2]{1,0:E(4)} constant({{0,1},{2,3},{4,5},{5,4}})
+      b = s4[4,4]{1,0:E(4)} all-gather(a), replica_groups={{0,1}}, dimensions={1}
+    })",
+                                                       config));
+
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
+                          ExecuteReplicated(std::move(unoptimized_module)));
+
+  const HloModule* module = execution_result.optimized_module;
+  const HloInstruction* root = module->entry_computation()->root_instruction();
+  EXPECT_THAT(root, GmockMatch(m::Fusion(
+                        m::Bitcast(m::AllGatherDone().WithShape(S8, {2, 4})))));
+  EXPECT_THAT(root->fused_expression_root(),
+              GmockMatch(m::Transpose(m::Parameter())));
+
+  const Literal expected_result =
+      LiteralUtil::CreateR2<s4>({{s4(0), s4(1), s4(0), s4(1)},
+                                 {s4(2), s4(3), s4(2), s4(3)},
+                                 {s4(4), s4(5), s4(4), s4(5)},
+                                 {s4(5), s4(4), s4(5), s4(4)}});
+
+  const std::vector<Literal>& result = execution_result.results;
+  ASSERT_EQ(result.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    EXPECT_TRUE(LiteralTestUtil::Equal(expected_result, result[i]))
+        << "Results differ at replica " << i;
+  }
+}
+
+TEST_F(CollectiveOpsTestE2E, AllGatherOnChangedDimensionIsCorrect) {
+  const int64_t kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "The test requires at least " << kNumReplicas << " devices";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto unoptimized_module,
+                          ParseAndReturnVerifiedModule(R"(
+  HloModule m, replica_count=2
+  e {
+    a = u32[2,2,3] constant({{{0,1,2},{3,4,5}},{{6,7,8},{9,10,11}}})
+    g = u32[2,4,3] all-gather(a), dimensions={1}
+  })",
+                                                       kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(auto executable,
+                          CreateExecutable(std::move(unoptimized_module),
+                                           /*run_hlo_passes=*/true));
+  TF_ASSERT_OK_AND_ASSIGN(const HloModule* module,
+                          test_runner().HloModuleFromWrapped(executable.get()));
+  const HloInstruction* root = module->entry_computation()->root_instruction();
+
+  EXPECT_THAT(root, GmockMatch(m::Fusion(m::AllGatherDone(
+                        m::AllGatherStart(m::Bitcast(m::Constant()))))));
+  EXPECT_THAT(root->fused_expression_root(),
+              GmockMatch(m::Transpose(m::Bitcast(m::Parameter()))));
+
+  TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
+                          ExecuteReplicated(executable.get(), {{}, {}}));
+  ASSERT_EQ(results.size(), kNumReplicas);
+  Literal expected = LiteralUtil::CreateR3<uint32_t>(
+      {{{0, 1, 2}, {3, 4, 5}, {0, 1, 2}, {3, 4, 5}},
+       {{6, 7, 8}, {9, 10, 11}, {6, 7, 8}, {9, 10, 11}}});
+  for (const Literal& result : results) {
+    EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
+  }
+}
+
+TEST_F(CollectiveOpsTestE2E, AllGatherOnChangedDimensionIsCorrectTritonBackend) {
+  const int64_t kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "The test requires at least " << kNumReplicas << " devices";
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  config.mutable_debug_options()
+      .set_xla_gpu_unsupported_use_all_gather_triton_backend(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto unoptimized_module,
+                          ParseAndReturnVerifiedModule(R"(
+  HloModule m, replica_count=2
+  e {
+    a = f32[2,2,3] constant({{{0,1,2},{3,4,5}},{{6,7,8},{9,10,11}}})
+    g = f32[2,4,3] all-gather(a), replica_groups={{0,1}}, dimensions={1}
+  })",
+                                                       config));
+  TF_ASSERT_OK_AND_ASSIGN(auto executable,
+                          CreateExecutable(std::move(unoptimized_module),
+                                           /*run_hlo_passes=*/true));
+  TF_ASSERT_OK_AND_ASSIGN(const HloModule* module,
+                          test_runner().HloModuleFromWrapped(executable.get()));
+  const HloInstruction* root = module->entry_computation()->root_instruction();
+
+  EXPECT_THAT(root, GmockMatch(m::Fusion(m::AllGatherDone(
+                        m::AllGatherStart(m::Bitcast(m::Constant()))))));
+  EXPECT_THAT(root->fused_expression_root(),
+              GmockMatch(m::Transpose(m::Bitcast(m::Parameter()))));
+
+  TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
+                          ExecuteReplicated(executable.get(), {{}, {}}));
+  ASSERT_EQ(results.size(), kNumReplicas);
+  Literal expected = LiteralUtil::CreateR3<float>(
+      {{{0, 1, 2}, {3, 4, 5}, {0, 1, 2}, {3, 4, 5}},
+       {{6, 7, 8}, {9, 10, 11}, {6, 7, 8}, {9, 10, 11}}});
+  for (const Literal& result : results) {
+    EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
   }
 }
 

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1018,6 +1018,9 @@ message DebugOptions {
   // all-reduce operations.
   optional bool xla_gpu_unsupported_use_all_reduce_one_shot_kernel = 387;
 
+  // Internal testing flag to enable Triton backend for all-gather operations.
+  optional bool xla_gpu_unsupported_use_all_gather_triton_backend = 462;
+
   // Internal testing flag to enable one-shot kernel for single-host
   // ragged-all-to-all operations.
   optional bool xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel = 375;


### PR DESCRIPTION
This PR enables AllGather triton backend:
- Enhances the common collective-emitter to handle the `AllGather` op (that returns a tuple)
- Adds 2 tritons kernel implementations: one default implementation and one using swizzled for loading data
- Adds e2e tests.
(This support needed the triton-xla atomics operations to be implemented. That's why it is based on top of the branch `ci_maxime_allreduce_triton_rocm_elementwise_rocm`) 