### PR TITLE
Fix LoadKernel to use refcounted module path for proper cleanup

### DIFF
--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -660,12 +660,8 @@ absl::StatusOr<std::unique_ptr<Kernel>> RocmExecutor::LoadKernel(
     const char* hsaco = reinterpret_cast<const char*>(
         spec.cuda_cubin_in_memory()->cubin_bytes.data());
     absl::MutexLock lock{in_memory_modules_mu_};
-    ModuleHandle module_handle{hsaco};
-    hipModule_t& module = in_memory_modules_[module_handle];
-
-    if (module == nullptr) {
-      TF_ASSIGN_OR_RETURN(module, LoadHsaco(&rocm_context_, hsaco));
-    }
+    TF_ASSIGN_OR_RETURN(ModuleHandle module_handle, LoadModuleFromHsaco(hsaco));
+    hipModule_t module = gpu_binary_to_module_.at(module_handle).first;
     kernel_to_gpu_binary_[rocm_kernel.get()] = module_handle;
 
     VLOG(2) << "getting function " << kernel_name << " from module " << module;


### PR DESCRIPTION
## Summary

Cherry-pick of upstream PR https://github.com/openxla/xla/pull/40847 (first commit only).

ROCm's RocmExecutor has two kernel/module loading paths with
different caching behavior:

  1. LoadModule → LoadModuleFromHsaco → populates both
     gpu_binary_to_module_ (refcounted) and in_memory_modules_
  2. LoadKernel → directly inserts into in_memory_modules_ only,
     bypassing gpu_binary_to_module_ entirely

When UnloadKernel calls UnloadGpuBinary, it only looks in
gpu_binary_to_module_ for cleanup. Since LoadKernel never populated
that map, the cleanup was a no-op: in_memory_modules_ entries and
loaded hipModule_t objects were never removed, leaking until
executor destruction.

This caused stale module cache entries when CustomKernelThunk's
owned HSACO buffers were freed and reallocated at the same address.
The cache returned old modules that didn't contain the expected
kernels, producing flaky hipErrorNotFound failures in sort and
LuSolve tests under xdist parallelism.

Fix by routing LoadKernel through LoadModuleFromHsaco, so every
loaded module participates in the refcount mechanism and is properly
cleaned up when the last kernel referencing it is destroyed.

## Kind of Contribution

🐛 Bug Fix