### PR TITLE
Fix roctracer (v1) profiler build for rocm-jaxlib-v0.9.0

### DIFF
--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -187,7 +187,13 @@ absl::Status GpuTracer::DoStart() {
       GetRocmTraceCollectorOptions(rocm_tracer_->NumGpus());
   rocm_trace_collector_ = CreateRocmCollector(
       trace_collector_options, start_walltime_ns, start_gputime_ns);
+#if XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V3
+  // GpuAgents() is only available on the rocprofiler-sdk (v3) backend.
+  // The v1 (roctracer) tracer does not expose agent data; SetGpuAgents() on
+  // the base RocmTraceCollector is a no-op by default, so skipping the call
+  // in the v1 path preserves prior behavior.
   rocm_trace_collector_->SetGpuAgents(rocm_tracer_->GpuAgents());
+#endif
 
   rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get());
 

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -15,6 +15,13 @@ limitations under the License.
 
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 
+// These tests exercise the rocprofiler-sdk (v3) tracer API (GpuAgents(),
+// RocmTracerOptions{max_annotation_strings=...}, RocmTracer::collector()).
+// The roctracer-based v1 backend exposes a different RocmTracerOptions layout
+// and does not provide GpuAgents(), so the tests are compiled out when the
+// v1 backend is selected.
+#if XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V3
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -235,3 +242,5 @@ TEST(RocmTracerTest, CapturesHipEvents) {
 }  // namespace
 }  // namespace profiler
 }  // namespace xla
+
+#endif  // XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V3


### PR DESCRIPTION
Cherry-pick b3248ad1 added RocmTracer::GpuAgents() and a matching test,
both of which only exist on the rocprofiler-sdk (v3) tracer backend.
The roctracer (v1) backend (--define=xla_rocm_profiler=v1) does not
expose these APIs, breaking //pjrt/tools:build_gpu_plugin_wheel.

Guard the v3-only call in device_tracer_rocm.cc and the v3-only tests
in rocm_tracer_test.cc with the XLA_GPU_ROCM_TRACER_BACKEND macro.
SetGpuAgents() is a no-op on the base collector, so the v1 path
preserves pre-cherrypick behavior.