### PR TITLE
Cherry-pick roctracer fixes

### DIFF
--- a/build_tools/lint/tags.py
+++ b/build_tools/lint/tags.py
@@ -104,6 +104,7 @@ _TAGS_TO_DOCUMENTATION_MAP = {
         "Tags the target as a PJRT migration candidate."
     ),
     "multi_gpu": "Used by `xla_test` to signal that multiple GPUs are needed.",
+    "skip_rocprofiler_sdk": "used to skip rocmtracer test as it calls rocprofiler-sdk via rocprofiler_force_configure",
 }
 
 

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -69,10 +69,18 @@ cc_library(
         "//xla:debug_options_flags",
         "//xla/stream_executor/rocm:roctracer_wrapper",
         "//xla/tsl/platform:env_time",
+        "//xla/tsl/platform:errors",
         "//xla/tsl/profiler/backends/cpu:annotation_stack",
+        "//xla/tsl/profiler/utils:parse_annotation",
+        "//xla/tsl/profiler/utils:trace_utils",
+        "//xla/tsl/profiler/utils:xplane_builder",
+        "//xla/tsl/profiler/utils:xplane_schema",
+        "//xla/tsl/profiler/utils:xplane_utils",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@local_config_rocm//rocm:rocm_headers",
         "@tsl//tsl/profiler/lib:profiler_factory",
         "@tsl//tsl/profiler/lib:profiler_interface",
         "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc",
@@ -426,19 +434,52 @@ cc_library(
     ],
 )
 
+config_setting(
+    name = "use_v1",
+    values = {"define": "xla_rocm_profiler=v1"},
+)
+
+config_setting(
+    name = "use_rocprofiler_sdk",
+    values = {"define": "xla_rocm_profiler=v3"},
+)
+
 cc_library(
-    name = "rocm_tracer_utils",
-    srcs = ["rocm_tracer_utils.cc"],
-    hdrs = ["rocm_tracer_utils.h"],
+    name = "rocm_profiler_backend_cfg",
+    defines = select({
+        ":use_v1": ["XLA_GPU_ROCM_TRACER_BACKEND=1"],
+        ":use_rocprofiler_sdk": ["XLA_GPU_ROCM_TRACER_BACKEND=3"],
+        "//conditions:default": ["XLA_GPU_ROCM_TRACER_BACKEND=3"],
+    }),
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/container:node_hash_set",
-        "@com_google_absl//absl/log",
-        "@com_google_absl//absl/log:check",
-        "@com_google_absl//absl/strings:string_view",
-        "@com_google_absl//absl/synchronization",
+)
+
+cc_library(
+  name = "rocm_tracer_utils",
+  srcs = ["rocm_tracer_utils.cc"],
+  hdrs = ["rocm_tracer_utils.h"],
+  tags = [
+        "gpu",
+        "manual",
+        "rocm-only",
     ],
+  deps = [
+    "//xla/tsl/profiler/backends/cpu:annotation_stack",
+    "//xla/tsl/profiler/utils:time_utils",
+    "//xla/tsl/profiler/utils:math_utils",
+    "@com_google_absl//absl/strings:string_view",
+    "@com_google_absl//absl/container:flat_hash_map",
+    "@com_google_absl//absl/container:flat_hash_set",
+    "@com_google_absl//absl/container:node_hash_map",
+    "@com_google_absl//absl/container:node_hash_set",
+    "@tsl//tsl/platform:env_time",
+    "@tsl//tsl/platform:env",
+    "@tsl//tsl/platform:errors",
+    "@tsl//tsl/platform:logging",
+    "@tsl//tsl/platform:macros",
+    "@local_config_rocm//rocm:rocprofiler-sdk",
+  ],
+  visibility = ["//visibility:public"],
 )
 
 cc_library(
@@ -454,82 +495,132 @@ cc_library(
     ]),
     deps = [
         ":rocm_tracer_utils",
+        ":rocm_profiler_backend_cfg",
         "//xla/stream_executor/rocm:roctracer_wrapper",
-        "//xla/tsl/platform:status",
+        "//xla/tsl/profiler/backends/cpu:annotation_stack",
         "//xla/tsl/profiler/utils:parse_annotation",
-        "//xla/tsl/profiler/utils:trace_utils",
         "//xla/tsl/profiler/utils:xplane_builder",
         "//xla/tsl/profiler/utils:xplane_schema",
         "//xla/tsl/profiler/utils:xplane_utils",
-        "@com_google_absl//absl/base:core_headers",
+        "//xla/tsl/util:env_var",
+        "@com_google_absl//absl/container:fixed_array",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:node_hash_map",
-        "@com_google_absl//absl/log",
-        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/container:node_hash_set",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
-        "@local_config_rocm//rocm:rocm_headers",  # buildcleaner: keep
-        "@local_config_rocm//rocm:rocprofiler-sdk",  # buildcleaner: keep
         "@tsl//tsl/platform:abi",
-        "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+        "@tsl//tsl/platform:env_time",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:macros",
+        "@tsl//tsl/platform:status",
+        "@tsl//tsl/platform:thread_annotations",
+        "@tsl//tsl/platform:types",
+        "@tsl//tsl/profiler/lib:profiler_factory",
+        "@tsl//tsl/profiler/lib:profiler_interface",
+        "@local_config_rocm//rocm:rocprofiler-sdk",
+    ],
+)
+
+cc_library(
+    name = "rocm_tracer_headers",
+    hdrs = [
+        "rocm_tracer.h",
+        "rocm_profiler_sdk.h",
+        "rocm_tracer_v1.h",
+    ],
+    tags = [
+        "gpu",
+        "manual",
+        "rocm-only",
+    ],
+    # PROPAGATE the layout macro to every dependent TU:
+    defines = select({
+        ":use_v1": ["XLA_GPU_ROCM_TRACER_BACKEND=1"],
+        ":use_rocprofiler_sdk": ["XLA_GPU_ROCM_TRACER_BACKEND=3"],
+        "//conditions:default": ["XLA_GPU_ROCM_TRACER_BACKEND=3"],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "rocm_tracer_impl",
+    srcs = select({
+        ":use_v1": ["rocm_tracer_v1.cc"],
+        ":use_rocprofiler_sdk": ["rocm_profiler_sdk.cc"],
+        "//conditions:default": ["rocm_profiler_sdk.cc"],
+    }),
+    tags = [
+        "gpu",
+        "manual",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_tracer_headers",
+        ":rocm_collector",
+        "//xla/stream_executor/rocm:roctracer_wrapper",
+        "//xla/tsl/profiler/backends/cpu:annotation_stack",
+        "//xla/tsl/profiler/utils:time_utils",
+        "//xla/tsl/profiler/utils:xplane_builder",
+        "//xla/tsl/profiler/utils:xplane_schema",
+        "//xla/tsl/profiler/utils:xplane_utils",
+        "//xla/tsl/util:env_var",
+        "//xla:debug_options_flags",
+        "@com_google_absl//absl/container:fixed_array",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/container:node_hash_set",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/synchronization",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:env",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:logging",
+        "@tsl//tsl/platform:macros",
+        "@tsl//tsl/platform:platform_port",
+        "@tsl//tsl/platform:status",
+        "@tsl//tsl/platform:thread_annotations",
+        "@tsl//tsl/platform:types",
+        "@tsl//tsl/profiler/lib:profiler_factory",
+        "@tsl//tsl/profiler/lib:profiler_interface",
     ],
 )
 
 cc_library(
     name = "rocm_tracer",
-    srcs = ["rocm_tracer.cc"],
-    hdrs = ["rocm_tracer.h"],
     tags = [
         "gpu",
-        "rocm-only",
-    ] + if_google([
-        # TODO(b/360374983): Remove this tag once the target can be built without --config=rocm.
         "manual",
-    ]),
-    deps = [
-        ":rocm_collector",
-        ":rocm_tracer_utils",
-        "//xla/stream_executor/rocm:roctracer_wrapper",
-        "//xla/tsl/profiler/backends/cpu:annotation_stack",
-        "@com_google_absl//absl/container:fixed_array",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/container:flat_hash_set",
-        "@com_google_absl//absl/container:node_hash_set",
-        "@com_google_absl//absl/log",
-        "@com_google_absl//absl/strings:str_format",
-        "@com_google_absl//absl/synchronization",
-        "@com_google_absl//absl/types:optional",
-        "@local_config_rocm//rocm:rocm_headers",  # buildcleaner: keep
-        "@local_config_rocm//rocm:rocprofiler-sdk",  # buildcleaner: keep
-        "@tsl//tsl/platform:abi",
-        "@tsl//tsl/platform:errors",
-        "@tsl//tsl/platform:macros",
-        "@tsl//tsl/platform:status",
-        "@tsl//tsl/platform:types",
+        "rocm-only",
     ],
+    deps = [":rocm_tracer_headers", ":rocm_tracer_impl"],
+    visibility = ["//visibility:public"],
 )
 
-xla_cc_test(
+# upstream it's called xla_cc_test as no GPU involved.
+xla_test(
     name = "rocm_tracer_test",
     size = "small",
     srcs = ["rocm_tracer_test.cc"],
     tags = [
         "gpu",
         "rocm-only",
+        "skip_rocprofiler_sdk",   # due to rocprofiler-sdk's rocprofiler_force_configure
     ] + if_google([
         # Optional: only run internally if ROCm config is enabled
         "manual",
     ]),
     deps = [
-        ":rocm_collector",
         ":rocm_tracer",
         ":rocm_tracer_utils",
-        "@com_google_absl//absl/log",
-        "@com_google_absl//absl/strings:string_view",
+        "//xla/tsl/profiler/utils:xplane_builder",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_googletest//:gtest_main",
-        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
-        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:status_matchers",
+        "@tsl//tsl/platform:test",
         "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
     ],
 )
@@ -545,7 +636,6 @@ xla_cc_test(
         "manual",
     ]),
     deps = [
-        # ":rocm_tracer",
         ":rocm_collector",
         ":rocm_tracer_utils",
         "@com_google_googletest//:gtest_main",

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -190,6 +190,10 @@ absl::Status GpuTracer::DoStart() {
   rocm_trace_collector_ = CreateRocmCollector(
       trace_collector_options, start_walltime_ns, start_gputime_ns);
 #if XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V3
+  // GpuAgents() is only available on the rocprofiler-sdk (v3) backend.
+  // The v1 (roctracer) tracer does not expose agent data; SetGpuAgents() on
+  // the base RocmTraceCollector is a no-op by default, so skipping the call
+  // in the v1 path preserves prior behavior.
   rocm_trace_collector_->SetGpuAgents(rocm_tracer_->GpuAgents());
 #endif
 

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -15,15 +15,21 @@ limitations under the License.
 
 #include <cstdint>
 #include <memory>
+#include <set>
+#include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
+#include "rocm/include/hip/amd_detail/hip_prof_str.h"
+#include "rocm/include/roctracer/ext/prof_protocol.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/debug_options_flags.h"
 #include "xla/tsl/platform/env_time.h"
+#include "xla/tsl/platform/errors.h"
 #include "xla/tsl/profiler/backends/cpu/annotation_stack.h"
 #include "tsl/profiler/lib/profiler_factory.h"
 #include "tsl/profiler/lib/profiler_interface.h"
@@ -73,7 +79,80 @@ class GpuTracer : public profiler::ProfilerInterface {
 
 RocmTracerOptions GpuTracer::GetRocmTracerOptions() {
   RocmTracerOptions options;
+#if XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V1
+  std::vector<uint32_t> empty_vec;
+  // clang formatting does not preserve one entry per line
+  // clang-format off
+  std::vector<uint32_t> hip_api_domain_ops{
+      // KERNEL
+      HIP_API_ID_hipExtModuleLaunchKernel,
+      HIP_API_ID_hipModuleLaunchKernel,
+      HIP_API_ID_hipHccModuleLaunchKernel,
+      HIP_API_ID_hipLaunchKernel,
+      HIP_API_ID_hipExtLaunchKernel,
+      // MEMCPY
+      HIP_API_ID_hipMemcpy,
+      HIP_API_ID_hipMemcpyAsync,
+      HIP_API_ID_hipMemcpyDtoD,
+      HIP_API_ID_hipMemcpyDtoDAsync,
+      HIP_API_ID_hipMemcpyDtoH,
+      HIP_API_ID_hipMemcpyDtoHAsync,
+      HIP_API_ID_hipMemcpyHtoD,
+      HIP_API_ID_hipMemcpyHtoDAsync,
+      HIP_API_ID_hipMemcpyPeer,
+      HIP_API_ID_hipMemcpyPeerAsync,
+
+      // MEMSet
+      HIP_API_ID_hipMemsetD32,
+      HIP_API_ID_hipMemsetD32Async,
+      HIP_API_ID_hipMemsetD16,
+      HIP_API_ID_hipMemsetD16Async,
+      HIP_API_ID_hipMemsetD8,
+      HIP_API_ID_hipMemsetD8Async,
+      HIP_API_ID_hipMemset,
+      HIP_API_ID_hipMemsetAsync,
+
+      // MEMAlloc
+      HIP_API_ID_hipMalloc,
+      HIP_API_ID_hipMallocPitch,
+      // MEMFree
+      HIP_API_ID_hipFree,
+      // GENERIC
+      HIP_API_ID_hipStreamSynchronize,
+  };
+  // clang-format on
+
+  options.api_tracking_set =
+      std::set<uint32_t>(hip_api_domain_ops.begin(), hip_api_domain_ops.end());
+
+  // These are the list of APIs we track since roctracer activity
+  // does not provide all the information necessary to fully populate the
+  // TF events. We need to track the APIs for those activities in API domain but
+  // we only use them for filling the missing items in their corresponding
+  // activity (using correlation id).
+  // clang-format off
+  std::vector<uint32_t> hip_api_aux_ops{
+    HIP_API_ID_hipStreamWaitEvent,
+    // TODO(rocm-profiler): finding device ID from hipEventSynchronize need some
+    // extra work, we ignore it for now.
+    // HIP_API_ID_hipEventSynchronize,
+    HIP_API_ID_hipHostFree,
+    HIP_API_ID_hipHostMalloc,
+    HIP_API_ID_hipSetDevice  //  added to track default device
+  };
+
+  // clang-format on
+
+  hip_api_domain_ops.insert(hip_api_domain_ops.end(), hip_api_aux_ops.begin(),
+                            hip_api_aux_ops.end());
+
+  // options.api_callbacks.emplace(ACTIVITY_DOMAIN_HIP_API, hip_api_domain_ops);
+  options.api_callbacks.emplace(ACTIVITY_DOMAIN_HIP_API, empty_vec);
+
+  options.activity_tracing.emplace(ACTIVITY_DOMAIN_HIP_OPS, empty_vec);
+#else
   options.max_annotation_strings = 4 * 1024 * 1024;
+#endif
   return options;
 }
 
@@ -91,6 +170,7 @@ RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
   if (max_events > 1'000'000'000LL) {
     max_events = 1'000'000'000LL;
   }
+
   VLOG(3) << "maximum number of events to be traced = " << max_events;
 
   options.max_callback_api_events = max_events;
@@ -109,7 +189,9 @@ absl::Status GpuTracer::DoStart() {
       GetRocmTraceCollectorOptions(rocm_tracer_->NumGpus());
   rocm_trace_collector_ = CreateRocmCollector(
       trace_collector_options, start_walltime_ns, start_gputime_ns);
+#if XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V3
   rocm_trace_collector_->SetGpuAgents(rocm_tracer_->GpuAgents());
+#endif
 
   rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get());
 
@@ -121,10 +203,9 @@ absl::Status GpuTracer::Start() {
   if (status.ok()) {
     profiling_state_ = State::kStartedOk;
     return absl::OkStatus();
-  } else {
-    profiling_state_ = State::kStartedError;
-    return status;
   }
+  profiling_state_ = State::kStartedError;
+  return status;
 }
 
 absl::Status GpuTracer::DoStop() {
@@ -147,7 +228,7 @@ absl::Status GpuTracer::CollectData(XSpace* space) {
       VLOG(3) << "No trace data collected, session wasn't started";
       return absl::OkStatus();
     case State::kStartedOk:
-      return absl::FailedPreconditionError(
+      return tsl::errors::FailedPrecondition(
           "Cannot collect trace before stopping");
     case State::kStartedError:
       LOG(ERROR) << "Cannot collect, roctracer failed to start";
@@ -156,7 +237,9 @@ absl::Status GpuTracer::CollectData(XSpace* space) {
       VLOG(3) << "No trace data collected";
       return absl::OkStatus();
     case State::kStoppedOk: {
-      if (rocm_trace_collector_) rocm_trace_collector_->Export(space);
+      if (rocm_trace_collector_) {
+        rocm_trace_collector_->Export(space);
+      }
       return absl::OkStatus();
     }
   }
@@ -168,8 +251,10 @@ absl::Status GpuTracer::CollectData(XSpace* space) {
 std::unique_ptr<profiler::ProfilerInterface> CreateGpuTracer(
     const ProfileOptions& options) {
   if (options.device_type() != ProfileOptions::GPU &&
-      options.device_type() != ProfileOptions::UNSPECIFIED)
+      options.device_type() != ProfileOptions::UNSPECIFIED) {
     return nullptr;
+  }
+
   auto& rocm_tracer = profiler::RocmTracer::GetRocmTracerSingleton();
   if (!rocm_tracer.IsAvailable()) return nullptr;
   return std::make_unique<profiler::GpuTracer>(&rocm_tracer);

--- a/xla/backends/profiler/gpu/rocm_profiler_sdk.cc
+++ b/xla/backends/profiler/gpu/rocm_profiler_sdk.cc
@@ -1,4 +1,4 @@
-/* Copyright 2024 The OpenXLA Authors. All Rights Reserved.
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,38 +19,34 @@ limitations under the License.
 // keep the compiler and linker happy.  Once real logging is implemented, you
 // can replace the stubs with the actual logic.
 
-#include "xla/backends/profiler/gpu/rocm_tracer.h"
+#include "xla/backends/profiler/gpu/rocm_profiler_sdk.h"
 
-#include <time.h>
-#include <unistd.h>
-
-#include <atomic>
-#include <cassert>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <map>
+#include <mutex>
+#include <sstream>
 #include <string>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
-#include "absl/log/log.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/node_hash_map.h"
 #include "absl/strings/str_format.h"
-#include "absl/synchronization/mutex.h"
-#include "rocm/include/rocprofiler-sdk/agent.h"
-#include "rocm/include/rocprofiler-sdk/buffer.h"
-#include "rocm/include/rocprofiler-sdk/buffer_tracing.h"
-#include "rocm/include/rocprofiler-sdk/callback_tracing.h"
-#include "rocm/include/rocprofiler-sdk/context.h"
-#include "rocm/include/rocprofiler-sdk/cxx/details/name_info.hpp"
-#include "rocm/include/rocprofiler-sdk/fwd.h"
-#include "rocm/include/rocprofiler-sdk/hip/runtime_api_id.h"
-#include "rocm/include/rocprofiler-sdk/internal_threading.h"
-#include "rocm/include/rocprofiler-sdk/registration.h"
-#include "rocm/include/rocprofiler-sdk/rocprofiler.h"
+#include <time.h>
+#include <unistd.h>
+#include <unistd.h>  // For standard sysconf
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/backends/cpu/annotation_stack.h"
-#include "tsl/platform/abi.h"
+#include "xla/tsl/profiler/utils/time_utils.h"
+#include "tsl/platform/env.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/logging.h"
+#include "tsl/platform/macros.h"
+#include "tsl/platform/mem.h"
+#include "tsl/platform/stacktrace.h"
 
 // for rocprofiler-sdk
 namespace xla {
@@ -61,15 +57,69 @@ using tsl::profiler::AnnotationStack;
 // represents an invalid or uninitialized device ID used in RocmTracer events.
 constexpr uint32_t RocmTracerEvent::kInvalidDeviceId;
 
-inline auto GetCallbackTracingNames() {
-  return rocprofiler::sdk::get_callback_tracing_names();
+namespace {
+static int toolInitStatic(rocprofiler_client_finalize_t finalize_func,
+                          void* tool_data) {
+  return RocmTracer::GetRocmTracerSingleton().toolInit(finalize_func,
+                                                       tool_data);
 }
 
-std::vector<rocprofiler_agent_v0_t> GetGpuDeviceAgents();
+static void code_object_callback(rocprofiler_callback_tracing_record_t record,
+                                 rocprofiler_user_data_t* user_data,
+                                 void* callback_data) {
+  RocmTracer::GetRocmTracerSingleton().CodeObjectCallback(record,
+                                                          callback_data);
+}
+
+static void tool_tracing_callback(rocprofiler_context_id_t context,
+                                  rocprofiler_buffer_id_t buffer_id,
+                                  rocprofiler_record_header_t** headers,
+                                  size_t num_headers, void* user_data,
+                                  uint64_t drop_count) {
+  RocmTracer::GetRocmTracerSingleton().TracingCallback(
+      context, buffer_id, headers, num_headers, drop_count);
+}
+
+// ----------------------------------------------------------------------------
+// Buffer tracing helpers
+inline auto GetBufferTracingNames() {
+  return rocprofiler::sdk::get_buffer_tracing_names();
+}
+
+// ----------------------------------------------------------------------------
+// Helper that returns all device agents (GPU + CPU for now).
+// ----------------------------------------------------------------------------
+std::vector<rocprofiler_agent_v0_t> GetGpuDeviceAgents() {
+  std::vector<rocprofiler_agent_v0_t> agents;
+
+  rocprofiler_query_available_agents_cb_t iterate_cb =
+      [](rocprofiler_agent_version_t agents_ver, const void** agents_arr,
+         size_t num_agents, void* udata) {
+        if (agents_ver != ROCPROFILER_AGENT_INFO_VERSION_0) {
+          LOG(ERROR) << "unexpected rocprofiler agent version: " << agents_ver;
+          return ROCPROFILER_STATUS_ERROR;
+        }
+        // `udata` is an opaque pointer provided by us to rocprofiler-sdk
+        // it got passed as `&agents`
+        auto* agents_vec =
+            static_cast<std::vector<rocprofiler_agent_v0_t>*>(udata);
+        for (size_t i = 0; i < num_agents; ++i) {
+          const auto* agent =
+              static_cast<const rocprofiler_agent_v0_t*>(agents_arr[i]);
+          agents_vec->push_back(*agent);
+        }
+        return ROCPROFILER_STATUS_SUCCESS;
+      };
+
+  rocprofiler_query_available_agents(ROCPROFILER_AGENT_INFO_VERSION_0,
+                                     iterate_cb, sizeof(rocprofiler_agent_t),
+                                     static_cast<void*>(&agents));
+  return agents;
+}
 
 //-----------------------------------------------------------------------------
 // copy api calls
-bool isCopyApi(uint32_t id) {
+constexpr bool IsCopyApi(uint32_t id) {
   switch (id) {
     case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy:
     case ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy2D:
@@ -106,6 +156,7 @@ bool isCopyApi(uint32_t id) {
   }
   return false;
 }
+}  // namespace
 
 // ----------------------------------------------------------------------------
 // Stub implementations for RocmTracer static functions expected by
@@ -131,17 +182,18 @@ bool RocmTracer::IsAvailable() const {
 
 void RocmTracer::Enable(const RocmTracerOptions& options,
                         RocmTraceCollector* collector) {
-  absl::MutexLock lock(collector_mutex_);
+  absl::MutexLock lock(&collector_mutex_);
   if (collector_ != nullptr) {
     LOG(WARNING) << "ROCM tracer is already running!";
     return;
   }
   options_ = options;
   collector_ = collector;
+  AnnotationMap(options_->max_annotation_strings);
   api_tracing_enabled_ = true;
   activity_tracing_enabled_ = true;
   rocprofiler_start_context(context_);
-  LOG(INFO) << "GpuTracer started with number of GPUs = " << NumGpus();
+  VLOG(1) << "GpuTracer started with number of GPUs = " << NumGpus();
 }
 
 void RocmTracer::HipApiEvent(const rocprofiler_record_header_t* hdr,
@@ -166,7 +218,7 @@ void RocmTracer::HipApiEvent(const rocprofiler_record_header_t* hdr,
 
   {
     // bounds-check name table: kind and operation
-    absl::MutexLock lock(kernel_lock_);
+    absl::MutexLock lock(&kernel_lock_);
     const size_t kind = static_cast<size_t>(rec.kind);
     if (kind < name_info_.size()) {
       const auto& vec = name_info_[kind];
@@ -191,7 +243,7 @@ void RocmTracer::HipApiEvent(const rocprofiler_record_header_t* hdr,
     }
   }
 
-  if (isCopyApi(rec.operation)) {
+  if (IsCopyApi(rec.operation)) {
     // actually one needs to set the real type
     trace_event->type = RocmTracerEventType::MemcpyOther;
   }
@@ -283,7 +335,7 @@ void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
   trace_event->name = "??";
   trace_event->start_time_ns = rec.start_timestamp;
   trace_event->end_time_ns = rec.end_timestamp;
-  trace_event->device_id = agents_[kinfo.agent_id.handle].id.handle;
+  trace_event->device_id = kinfo.agent_id.handle;
   trace_event->correlation_id = rec.correlation_id.internal;
   trace_event->annotation =
       annotation_map()->LookUp(trace_event->correlation_id);
@@ -309,13 +361,14 @@ void RocmTracer::TracingCallback(rocprofiler_context_id_t context,
                                  rocprofiler_buffer_id_t buffer_id,
                                  rocprofiler_record_header_t** headers,
                                  size_t num_headers, uint64_t drop_count) {
-  if (collector() == nullptr) {
-    return;
+  if (collector() == nullptr) return;
+  if (num_headers == 0) return;
+  if (drop_count != 0) {
+    LOG(WARNING) << "rocprofiler buffer callback reported drop_count="
+                 << drop_count
+                 << " despite using a lossless buffer policy. Some GPU events "
+                    "may be missing from the trace.";
   }
-  if (num_headers == 0) {
-    return;
-  }
-  assert(drop_count == 0 && "drop count should be zero for lossless policy");
 
   if (headers == nullptr) {
     LOG(ERROR)
@@ -347,7 +400,7 @@ void RocmTracer::TracingCallback(rocprofiler_context_id_t context,
         continue;
     }  // switch
 
-    absl::MutexLock lock(collector_mutex_);
+    absl::MutexLock lock(&collector_mutex_);
     if (collector()) {
       collector()->AddEvent(std::move(event), false);
     }
@@ -368,48 +421,31 @@ void RocmTracer::CodeObjectCallback(
                  ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER) {
     auto* data = static_cast<kernel_symbol_data_t*>(record.payload);
     if (record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD) {
-      absl::MutexLock lock(kernel_lock_);
+      absl::MutexLock lock(&kernel_lock_);
       kernel_info_.emplace(
           data->kernel_id,
           ProfilerKernelInfo{tsl::port::MaybeAbiDemangle(data->kernel_name),
                              *data});
     } else if (record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD) {
-      // FIXME: clear these?  At minimum need kernel names at shutdown, async
-      // completion We don't erase it just in case a buffer callback still needs
-      // this kernel_info_.erase(data->kernel_id);
+      // FIXME (cj401-amd): clear these?  At minimum need kernel names at
+      // shutdown, async completion We don't erase it just in case a buffer
+      // callback still needs this kernel_info_.erase(data->kernel_id);
     }
   }
 }
 
-static void code_object_callback(rocprofiler_callback_tracing_record_t record,
-                                 rocprofiler_user_data_t* user_data,
-                                 void* callback_data) {
-  RocmTracer::GetRocmTracerSingleton().CodeObjectCallback(record,
-                                                          callback_data);
-}
-
-static void tool_tracing_callback(rocprofiler_context_id_t context,
-                                  rocprofiler_buffer_id_t buffer_id,
-                                  rocprofiler_record_header_t** headers,
-                                  size_t num_headers, void* user_data,
-                                  uint64_t drop_count) {
-  RocmTracer::GetRocmTracerSingleton().TracingCallback(
-      context, buffer_id, headers, num_headers, drop_count);
-}
-
 int RocmTracer::toolInit(rocprofiler_client_finalize_t fini_func,
                          void* tool_data) {
-  // Gather API names
-  name_info_ = GetCallbackTracingNames();
+  // Gather API names with rocprofiler-sdk api call
+  name_info_ = GetBufferTracingNames();
 
   // Gather agent info.  Build an ordered list of GPU agents for use by the
   // profiler collector (e.g. GetDeviceCapabilities).
   num_gpus_ = 0;
   gpu_agents_.clear();
   for (const auto& agent : GetGpuDeviceAgents()) {
-    LOG(INFO) << "agent id = " << agent.id.handle
-              << ", dev = " << agent.device_id
-              << ", name = " << (agent.name ? agent.name : "null");
+    VLOG(1) << "agent id = " << agent.id.handle << ", dev = " << agent.device_id
+            << ", name = " << (agent.name ? agent.name : "null");
     agents_[agent.id.handle] = agent;
     if (agent.type == ROCPROFILER_AGENT_TYPE_GPU) {
       gpu_agents_.push_back(agent);
@@ -420,26 +456,25 @@ int RocmTracer::toolInit(rocprofiler_client_finalize_t fini_func,
   // Utility context to gather code‑object info
   rocprofiler_create_context(&utility_context_);
 
-  // buffered tracing
   auto code_object_ops = std::vector<rocprofiler_tracing_operation_t>{
       ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER};
-
+  // rocprofiler-sdk api call for code_object callbacks
   rocprofiler_configure_callback_tracing_service(
       utility_context_, ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT,
       code_object_ops.data(), code_object_ops.size(), code_object_callback,
       nullptr);
 
   rocprofiler_start_context(utility_context_);
-  LOG(INFO) << "rocprofiler start utilityContext";
+  VLOG(1) << "rocprofiler start utilityContext";
 
   // a multiple of the page size, and the gap allows the buffer to absorb bursts
   // of GPU events
   constexpr auto buffer_size_bytes = 100 * 4096;
-  constexpr auto buffer_watermark_bytes = 40 * 4096;
+  constexpr auto buffer_watermark_bytes = 20 * 4096;
 
   // Utility context to gather code‑object info
   rocprofiler_create_context(&context_);
-
+  // rocprofiler-sdk api call for buffer tracing
   rocprofiler_create_buffer(context_, buffer_size_bytes, buffer_watermark_bytes,
                             ROCPROFILER_BUFFER_POLICY_LOSSLESS,
                             tool_tracing_callback, tool_data, &buffer_);
@@ -459,7 +494,7 @@ int RocmTracer::toolInit(rocprofiler_client_finalize_t fini_func,
     // for annotations
     const rocprofiler_tracing_operation_t* hip_ops = nullptr;
     size_t hip_ops_count = 0;
-
+    // rocprofiler-sdk api callbacks
     rocprofiler_configure_callback_tracing_service(
         context_, ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API, hip_ops,
         hip_ops_count,
@@ -484,7 +519,8 @@ int RocmTracer::toolInit(rocprofiler_client_finalize_t fini_func,
   int isValid = 0;
   rocprofiler_context_is_valid(context_, &isValid);
   if (isValid == 0) {
-    context_.handle = 0;  // Leak on failure.
+    LOG(ERROR) << "rocprofiler context is invalid; tearing down.";
+    context_.handle = 0;
     return -1;
   }
 
@@ -497,7 +533,6 @@ void RocmTracer::toolFinalize(void* tool_data) {
   rocprofiler_stop_context(obj.utility_context_);
   obj.utility_context_.handle = 0;
   rocprofiler_stop_context(obj.context_);
-  // flush buffer here or in disable?
   obj.context_.handle = 0;
 }
 
@@ -506,47 +541,12 @@ void RocmTracer::Disable() {
   if (status != ROCPROFILER_STATUS_SUCCESS) {
     LOG(WARNING) << "rocprofiler_flush_buffer failed with error " << status;
   }
-  absl::MutexLock lock(collector_mutex_);
+  absl::MutexLock lock(&collector_mutex_);
   collector_->Flush();
   collector_ = nullptr;
   api_tracing_enabled_ = false;
   activity_tracing_enabled_ = false;
-  LOG(INFO) << "GpuTracer stopped";
-}
-
-// ----------------------------------------------------------------------------
-// Helper that returns all device agents (GPU + CPU for now).
-// ----------------------------------------------------------------------------
-std::vector<rocprofiler_agent_v0_t> GetGpuDeviceAgents() {
-  std::vector<rocprofiler_agent_v0_t> agents;
-
-  rocprofiler_query_available_agents_cb_t iterate_cb =
-      [](rocprofiler_agent_version_t agents_ver, const void** agents_arr,
-         size_t num_agents, void* udata) {
-        if (agents_ver != ROCPROFILER_AGENT_INFO_VERSION_0) {
-          LOG(ERROR) << "unexpected rocprofiler agent version: " << agents_ver;
-          return ROCPROFILER_STATUS_ERROR;
-        }
-        auto* agents_vec =
-            static_cast<std::vector<rocprofiler_agent_v0_t>*>(udata);
-        for (size_t i = 0; i < num_agents; ++i) {
-          const auto* agent =
-              static_cast<const rocprofiler_agent_v0_t*>(agents_arr[i]);
-          agents_vec->push_back(*agent);
-        }
-        return ROCPROFILER_STATUS_SUCCESS;
-      };
-
-  rocprofiler_query_available_agents(ROCPROFILER_AGENT_INFO_VERSION_0,
-                                     iterate_cb, sizeof(rocprofiler_agent_t),
-                                     static_cast<void*>(&agents));
-  return agents;
-}
-
-static int toolInitStatic(rocprofiler_client_finalize_t finalize_func,
-                          void* tool_data) {
-  return RocmTracer::GetRocmTracerSingleton().toolInit(finalize_func,
-                                                       tool_data);
+  VLOG(1) << "GpuTracer stopped";
 }
 
 // ----------------------------------------------------------------------------
@@ -555,24 +555,46 @@ static int toolInitStatic(rocprofiler_client_finalize_t finalize_func,
 extern "C" rocprofiler_tool_configure_result_t* rocprofiler_configure(
     uint32_t version, const char* runtime_version, uint32_t priority,
     rocprofiler_client_id_t* id) {
-  auto& obj = RocmTracer::GetRocmTracerSingleton();  // Ensure constructed,
-                                                     // critical for tracing.
+  auto& obj = RocmTracer::GetRocmTracerSingleton();  // Ensure constructed
 
   id->name = "XLA-with-rocprofiler-sdk";
   obj.client_id_ = id;
 
-  LOG(INFO) << "Configure rocprofiler-sdk...";
+  static bool configured = false;
+  static uint32_t initial_version = 0;
+  static uint32_t initial_priority = 0;
 
-  const uint32_t major = version / 10000;
-  const uint32_t minor = (version % 10000) / 100;
-  const uint32_t patch = version % 100;
+  if (!configured) {
+    configured = true;
+    initial_version = version;
+    initial_priority = priority;
 
-  LOG(INFO) << absl::StrFormat(
-      "%s Configure XLA with rocprofv3... (priority=%u) is using "
-      "rocprofiler-sdk v%u.%u.%u (%s)",
-      id->name, static_cast<unsigned>(priority), static_cast<unsigned>(major),
-      static_cast<unsigned>(minor), static_cast<unsigned>(patch),
-      runtime_version ? runtime_version : "unknown");
+    const uint32_t major = version / 10000;
+    const uint32_t minor = (version % 10000) / 100;
+    const uint32_t patch = version % 100;
+
+    VLOG(1) << absl::StrFormat(
+        "%s registered with rocprofiler-sdk (priority=%u), "
+        "runtime reports rocprofiler-sdk v%u.%u.%u (%s). "
+        "Current XLA integration does not vary behavior based on "
+        "version/priority; this is logged for diagnostics only.",
+        id->name, static_cast<unsigned>(priority), static_cast<unsigned>(major),
+        static_cast<unsigned>(minor), static_cast<unsigned>(patch),
+        runtime_version ? runtime_version : "unknown");
+  } else {
+    if (version != initial_version || priority != initial_priority) {
+      LOG(WARNING)
+          << "rocprofiler_configure() called more than once with different "
+             "arguments. XLA keeps the initial configuration "
+             "(version="
+          << initial_version << ", priority=" << initial_priority
+          << ") and ignores subsequent values (version=" << version
+          << ", priority=" << priority << ").";
+    } else {
+      VLOG(1) << "rocprofiler_configure() called multiple times with "
+                 "identical arguments; reusing initial configuration.";
+    }
+  }
 
   static rocprofiler_tool_configure_result_t cfg{
       sizeof(rocprofiler_tool_configure_result_t), &toolInitStatic,
@@ -580,10 +602,13 @@ extern "C" rocprofiler_tool_configure_result_t* rocprofiler_configure(
 
   return &cfg;
 }
-
 }  // namespace profiler
 }  // namespace xla
 
+// force to initialize the hooks before hipInit, if we don't use this
+// some high-level framwork, e.g., maxtext, calls hipInit before
+// rocprofiler_configure, then no tracing callbacks will be triggered,
+// as a result, there is no gpu trace events.
 void __attribute__((constructor)) init_rocm_lib() {
   rocprofiler_force_configure(xla::profiler::rocprofiler_configure);
 }

--- a/xla/backends/profiler/gpu/rocm_profiler_sdk.h
+++ b/xla/backends/profiler/gpu/rocm_profiler_sdk.h
@@ -1,0 +1,144 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_PROFILER_SDK_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_PROFILER_SDK_H_
+
+#include <vector>
+
+#include "absl/container/fixed_array.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/container/node_hash_set.h"
+#include "absl/types/optional.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "xla/stream_executor/rocm/roctracer_wrapper.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/macros.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/types.h"
+
+namespace xla {
+namespace profiler {
+// forward declare (interface)
+class RocmTraceCollector;
+
+struct RocmTracerOptions {
+  // maximum number of annotation strings that AnnotationMap in RocmTracer can
+  // store. e.g. 1M
+  uint64_t max_annotation_strings;
+};
+
+// The class use to enable rocprofiler-sdk buffered callback/activity tracing
+// and forward the collected trace events to RocmTraceCollector. There should be
+// only one RocmTracer per process.
+class RocmTracer {
+ public:
+  // Returns a reference to the singleton instance of RocmTracer.
+  // This ensures that only one global instance exists throughout the process
+  // lifetime. The first call to this function lazily constructs the instance in
+  // a thread-safe manner. Subsequent calls return the same instance, enabling
+  // centralized tracer state management.
+  static RocmTracer& GetRocmTracerSingleton();
+
+  // Only one profile session can be live in the same time.
+  bool IsAvailable() const;
+
+  void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector_);
+  void Disable();
+
+  static uint64_t GetTimestamp();
+  uint32_t NumGpus() const { return num_gpus_; };
+  const std::vector<rocprofiler_agent_v0_t>& GpuAgents() const {
+    return gpu_agents_;
+  }
+  RocmTraceCollector* collector() { return collector_; }
+
+  int toolInit(rocprofiler_client_finalize_t finalize_func, void* tool_data);
+  static void toolFinalize(void* tool_data);
+
+  void TracingCallback(rocprofiler_context_id_t context,
+                       rocprofiler_buffer_id_t buffer_id,
+                       rocprofiler_record_header_t** headers,
+                       size_t num_headers, uint64_t drop_count);
+
+  void CodeObjectCallback(rocprofiler_callback_tracing_record_t record,
+                          void* callback_data);
+
+  AnnotationMap* annotation_map() { return &annotation_map_; }
+
+ protected:
+  // protected constructor for injecting mock cupti interface for testing.
+  RocmTracer() = default;
+
+  void HipApiEvent(const rocprofiler_record_header_t* hdr, RocmTracerEvent* ev);
+  void KernelEvent(const rocprofiler_record_header_t* hdr, RocmTracerEvent* ev);
+  void MemcpyEvent(const rocprofiler_record_header_t* hdr, RocmTracerEvent* ev);
+
+ private:
+  uint32_t num_gpus_{0};
+  std::optional<RocmTracerOptions> options_;
+  RocmTraceCollector* collector_{nullptr};
+  absl::Mutex collector_mutex_;
+
+  bool api_tracing_enabled_{false};
+  bool activity_tracing_enabled_{false};
+
+  AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
+
+ public:
+  // Type alias for rocprofiler-sdk kernel symbol registration callback data
+  // structure
+  using kernel_symbol_data_t =
+      rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;
+
+  struct ProfilerKernelInfo {
+    std::string name;
+    kernel_symbol_data_t data;
+  };
+
+  using kernel_info_map_t =
+      std::unordered_map<rocprofiler_kernel_id_t, ProfilerKernelInfo>;
+
+  using agent_info_map_t = std::unordered_map<uint64_t, rocprofiler_agent_v0_t>;
+
+  using buffer_name_info = rocprofiler::sdk::buffer_name_info;
+
+  rocprofiler_client_id_t* client_id_{nullptr};
+  // Contexts ----------------------------------------------------------
+  // for registering kernel names
+  rocprofiler_context_id_t utility_context_{};
+  // for buffered callback services
+  rocprofiler_context_id_t context_{};
+  rocprofiler_buffer_id_t buffer_{};
+
+  // Maps & misc -------------------------------------------------------
+  kernel_info_map_t kernel_info_{};
+  absl::Mutex kernel_lock_;
+
+  buffer_name_info name_info_;
+  agent_info_map_t agents_;
+  std::vector<rocprofiler_agent_v0_t> gpu_agents_;
+
+ public:
+  // Disable copy and move.
+  RocmTracer(const RocmTracer&) = delete;
+  RocmTracer& operator=(const RocmTracer&) = delete;
+};
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_PROFILER_SDK_H_

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -1,4 +1,4 @@
-/* Copyright 2024 The OpenXLA Authors. All Rights Reserved.
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,129 +13,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
-#define XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_FACADE_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_FACADE_H_
 
-#include "absl/container/fixed_array.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
-#include "absl/container/node_hash_set.h"
-#include "absl/synchronization/mutex.h"
-#include "absl/types/optional.h"
-#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
-#include "xla/stream_executor/rocm/roctracer_wrapper.h"
-#include "tsl/platform/errors.h"
-#include "tsl/platform/macros.h"
-#include "tsl/platform/status.h"
-#include "tsl/platform/types.h"
+// Backend: 3=v3 (rocprofiler-sdk), 1=v1 (roctracer). Default to v3.
+#define XLA_GPU_ROCM_TRACER_BACKEND_V3 3
+#define XLA_GPU_ROCM_TRACER_BACKEND_V1 1
 
-namespace xla {
-namespace profiler {
-// forward declare (interface)
-class RocmTraceCollector;
+#ifndef XLA_GPU_ROCM_TRACER_BACKEND
+#define XLA_GPU_ROCM_TRACER_BACKEND XLA_GPU_ROCM_TRACER_BACKEND_V3
+#endif
 
-struct RocmTracerOptions {
-  // maximum number of annotation strings that AnnotationMap in RocmTracer can
-  // store. e.g. 1M
-  uint64_t max_annotation_strings;
-};
+#if XLA_GPU_ROCM_TRACER_BACKEND == 3
+#include "xla/backends/profiler/gpu/rocm_profiler_sdk.h"
+#else
+#include "xla/backends/profiler/gpu/rocm_tracer_v1.h"
+#endif
 
-// The class use to enable rocprofiler-sdk buffered callback/activity tracing
-// and forward the collected trace events to RocmTraceCollector. There should be
-// only one RocmTracer per process.
-class RocmTracer {
- public:
-  // Returns a reference to the singleton instance of RocmTracer.
-  // This ensures that only one global instance exists throughout the process
-  // lifetime. The first call to this function lazily constructs the instance in
-  // a thread-safe manner. Subsequent calls return the same instance, enabling
-  // centralized tracer state management.
-  static RocmTracer& GetRocmTracerSingleton();
-
-  // Only one profile session can be live in the same time.
-  bool IsAvailable() const;
-
-  void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector_);
-  void Disable();
-
-  static uint64_t GetTimestamp();
-  uint32_t NumGpus() const { return num_gpus_; }
-  const std::vector<rocprofiler_agent_v0_t>& GpuAgents() const {
-    return gpu_agents_;
-  }
-  RocmTraceCollector* collector() { return collector_; }
-
-  int toolInit(rocprofiler_client_finalize_t finalize_func, void* tool_data);
-  static void toolFinalize(void* tool_data);
-
-  void TracingCallback(rocprofiler_context_id_t context,
-                       rocprofiler_buffer_id_t buffer_id,
-                       rocprofiler_record_header_t** headers,
-                       size_t num_headers, uint64_t drop_count);
-
-  void CodeObjectCallback(rocprofiler_callback_tracing_record_t record,
-                          void* callback_data);
-
-  AnnotationMap* annotation_map() { return &annotation_map_; }
-
- protected:
-  // protected constructor for injecting mock cupti interface for testing.
-  RocmTracer() = default;
-
-  void HipApiEvent(const rocprofiler_record_header_t* hdr, RocmTracerEvent* ev);
-  void KernelEvent(const rocprofiler_record_header_t* hdr, RocmTracerEvent* ev);
-  void MemcpyEvent(const rocprofiler_record_header_t* hdr, RocmTracerEvent* ev);
-
- private:
-  uint32_t num_gpus_{0};
-  std::optional<RocmTracerOptions> options_;
-  RocmTraceCollector* collector_{nullptr};
-  absl::Mutex collector_mutex_;
-
-  bool api_tracing_enabled_{false};
-  bool activity_tracing_enabled_{false};
-
-  AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
-
- public:
-  using kernel_symbol_data_t =
-      rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;
-
-  struct ProfilerKernelInfo {
-    std::string name;
-    kernel_symbol_data_t data;
-  };
-
-  using kernel_info_map_t =
-      std::unordered_map<rocprofiler_kernel_id_t, ProfilerKernelInfo>;
-
-  using agent_info_map_t = std::unordered_map<uint64_t, rocprofiler_agent_v0_t>;
-
-  using callback_name_info = rocprofiler::sdk::callback_name_info;
-
-  rocprofiler_client_id_t* client_id_{nullptr};
-  // Contexts ----------------------------------------------------------
-  // for registering kernel names
-  rocprofiler_context_id_t utility_context_{};
-  // for buffered callback services
-  rocprofiler_context_id_t context_{};
-  rocprofiler_buffer_id_t buffer_{};
-
-  // Maps & misc -------------------------------------------------------
-  kernel_info_map_t kernel_info_{};
-  absl::Mutex kernel_lock_;
-
-  callback_name_info name_info_;
-  agent_info_map_t agents_;
-  std::vector<rocprofiler_agent_v0_t> gpu_agents_;
-
- public:
-  // Disable copy and move.
-  RocmTracer(const RocmTracer&) = delete;
-  RocmTracer& operator=(const RocmTracer&) = delete;
-};
-
-}  // namespace profiler
-}  // namespace xla
-
-#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_FACADE_H_

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -15,6 +15,13 @@ limitations under the License.
 
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 
+// These tests exercise the rocprofiler-sdk (v3) tracer API (GpuAgents(),
+// RocmTracerOptions{max_annotation_strings=...}, RocmTracer::collector()).
+// The roctracer-based v1 backend exposes a different RocmTracerOptions layout
+// and does not provide GpuAgents(), so the tests are compiled out when the
+// v1 backend is selected.
+#if XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V3
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -235,3 +242,5 @@ TEST(RocmTracerTest, CapturesHipEvents) {
 }  // namespace
 }  // namespace profiler
 }  // namespace xla
+
+#endif  // XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V3

--- a/xla/backends/profiler/gpu/rocm_tracer_v1.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_v1.cc
@@ -1,0 +1,1562 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/rocm_tracer_v1.h"
+
+#include <cstdint>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/node_hash_map.h"
+#include "absl/status/status.h"
+#include "rocm/rocm_config.h"
+#include "xla/tsl/profiler/backends/cpu/annotation_stack.h"
+#include "xla/tsl/profiler/utils/time_utils.h"
+#include "tsl/platform/env.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/logging.h"
+#include "tsl/platform/macros.h"
+#include "tsl/platform/mem.h"
+
+namespace xla {
+namespace profiler {
+
+namespace se = ::stream_executor;
+using absl::MutexLock;
+using tsl::profiler::AnnotationStack;
+
+constexpr uint32_t RocmTracerEvent::kInvalidDeviceId;
+
+#define RETURN_IF_ROCTRACER_ERROR(expr)                                     \
+  do {                                                                      \
+    roctracer_status_t status = expr;                                       \
+    if (status != ROCTRACER_STATUS_SUCCESS) {                               \
+      const char* errstr = se::wrap::roctracer_error_string();              \
+      LOG(ERROR) << "function " << #expr << "failed with error " << errstr; \
+      return tsl::errors::Internal(                                         \
+          absl::StrCat("roctracer call error", errstr));                    \
+    }                                                                       \
+  } while (false)
+
+namespace {
+
+// GetCachedTID() caches the thread ID in thread-local storage (which is a
+// userspace construct) to avoid unnecessary system calls. Without this caching,
+// it can take roughly 98ns, while it takes roughly 1ns with this caching.
+int64_t GetCachedTID() {
+  static thread_local int64_t current_thread_id =
+      tsl::Env::Default()->GetCurrentThreadId();
+  return current_thread_id;
+}
+
+const char* GetActivityDomainName(uint32_t domain) {
+  switch (domain) {
+    case ACTIVITY_DOMAIN_HSA_API:
+      return "HSA API";
+    case ACTIVITY_DOMAIN_HSA_OPS:
+      return "HSA OPS";
+    case ACTIVITY_DOMAIN_HIP_OPS:
+      return "HIP OPS/HCC/VDI";
+    case ACTIVITY_DOMAIN_HIP_API:
+      return "HIP API";
+    case ACTIVITY_DOMAIN_KFD_API:
+      return "KFD API";
+    case ACTIVITY_DOMAIN_EXT_API:
+      return "EXT API";
+    case ACTIVITY_DOMAIN_ROCTX:
+      return "ROCTX";
+    case ACTIVITY_DOMAIN_HSA_EVT:
+      return "HSA envents";
+    default:
+      DCHECK(false);
+      return "";
+  }
+  return "";
+}
+
+std::string GetActivityDomainOpName(uint32_t domain, uint32_t op) {
+  std::ostringstream oss;
+  oss << GetActivityDomainName(domain) << " - ";
+  switch (domain) {
+    case ACTIVITY_DOMAIN_HIP_API:
+      oss << hip_api_name(op);
+      break;
+    default:
+      oss << op;
+      break;
+  }
+  return oss.str();
+}
+
+const char* GetActivityPhaseName(uint32_t phase) {
+  switch (phase) {
+    case ACTIVITY_API_PHASE_ENTER:
+      return "ENTER";
+    case ACTIVITY_API_PHASE_EXIT:
+      return "EXIT";
+    default:
+      DCHECK(false);
+      return "";
+  }
+  return "";
+}
+
+inline void DumpApiCallbackData(uint32_t domain, uint32_t cbid,
+                                const void* cbdata) {
+  std::ostringstream oss;
+  oss << "API callback for " << GetActivityDomainName(domain);
+  if (domain == ACTIVITY_DOMAIN_HIP_API) {
+    const hip_api_data_t* data =
+        reinterpret_cast<const hip_api_data_t*>(cbdata);
+    oss << " - " << hip_api_name(cbid);
+    oss << ", correlation_id=" << data->correlation_id;
+    oss << ", phase=" << GetActivityPhaseName(data->phase);
+    switch (cbid) {
+      case HIP_API_ID_hipModuleLaunchKernel:
+      case HIP_API_ID_hipExtModuleLaunchKernel:
+      case HIP_API_ID_hipHccModuleLaunchKernel:
+      case HIP_API_ID_hipLaunchKernel:
+      case HIP_API_ID_hipExtLaunchKernel:
+        break;
+      case HIP_API_ID_hipMemcpyDtoH:
+        oss << ", sizeBytes=" << data->args.hipMemcpyDtoH.sizeBytes;
+        break;
+      case HIP_API_ID_hipMemcpyDtoHAsync:
+        oss << ", sizeBytes=" << data->args.hipMemcpyDtoHAsync.sizeBytes;
+        break;
+      case HIP_API_ID_hipMemcpyHtoD:
+        oss << ", sizeBytes=" << data->args.hipMemcpyHtoD.sizeBytes;
+        break;
+      case HIP_API_ID_hipMemcpyHtoDAsync:
+        oss << ", sizeBytes=" << data->args.hipMemcpyHtoDAsync.sizeBytes;
+        break;
+      case HIP_API_ID_hipMemcpyDtoD:
+        oss << ", sizeBytes=" << data->args.hipMemcpyDtoD.sizeBytes;
+        break;
+      case HIP_API_ID_hipMemcpyDtoDAsync:
+        oss << ", sizeBytes=" << data->args.hipMemcpyDtoDAsync.sizeBytes;
+        break;
+      case HIP_API_ID_hipMemcpyAsync:
+        oss << ", sizeBytes=" << data->args.hipMemcpyAsync.sizeBytes;
+        break;
+      case HIP_API_ID_hipMemsetD32:
+        oss << ", value=" << data->args.hipMemsetD32.value;
+        oss << ", count=" << data->args.hipMemsetD32.count;
+        break;
+      case HIP_API_ID_hipMemsetD32Async:
+        oss << ", value=" << data->args.hipMemsetD32Async.value;
+        oss << ", count=" << data->args.hipMemsetD32Async.count;
+        break;
+      case HIP_API_ID_hipMemsetD8:
+        oss << ", value=" << data->args.hipMemsetD8.value;
+        oss << ", count=" << data->args.hipMemsetD8.count;
+        break;
+      case HIP_API_ID_hipMemsetD8Async:
+        oss << ", value=" << data->args.hipMemsetD8Async.value;
+        oss << ", count=" << data->args.hipMemsetD8Async.count;
+        break;
+      case HIP_API_ID_hipMalloc:
+        oss << ", size=" << data->args.hipMalloc.size;
+        break;
+      case HIP_API_ID_hipFree:
+        oss << ", ptr=" << data->args.hipFree.ptr;
+        break;
+      case HIP_API_ID_hipStreamSynchronize:
+        break;
+      case HIP_API_ID_hipStreamWaitEvent:  // ignore all aux HIP API Events
+      case HIP_API_ID_hipHostFree:
+      case HIP_API_ID_hipHostMalloc:
+      case HIP_API_ID_hipSetDevice:
+        break;
+      default:
+        VLOG(3) << "Warning: HIP API is not handled: HIP_API_ID_"
+                << hip_api_name(cbid);
+        break;
+    }
+  } else {
+    oss << ": " << cbid;
+  }
+  VLOG(3) << oss.str();
+}
+
+void DumpActivityRecord(const roctracer_record_t* record,
+                        std::string extra_info) {
+  std::ostringstream oss;
+  oss << "Activity callback for " << GetActivityDomainName(record->domain);
+  oss << ", op name= "
+      << se::wrap::roctracer_op_string(record->domain, record->op,
+                                       record->kind);
+  oss << ", correlation_id=" << record->correlation_id;
+  oss << ", begin_ns=" << record->begin_ns;
+  oss << ", end_ns=" << record->end_ns;
+  oss << ", duration=" << record->end_ns - record->begin_ns;
+  oss << ", device_id=" << record->device_id;
+  oss << ", queue_id=" << record->queue_id;
+  oss << ", process_id=" << record->process_id;
+  oss << ", thread_id=" << record->thread_id;
+  oss << ", external_id=" << record->external_id;
+  oss << ", bytes=" << record->bytes;
+  oss << ", domain=" << record->domain;
+  oss << ", op=" << record->op;
+  oss << ", kind=" << record->kind;
+  oss << ", extra_info=" << extra_info;
+  VLOG(3) << oss.str();
+}
+
+}  // namespace
+
+absl::Status RocmApiCallbackImpl::operator()(uint32_t domain, uint32_t cbid,
+                                             const void* cbdata) {
+  /* Some APIs such as hipMalloc, implicitly work on th devices set by the
+    user using APIs such as hipSetDevice. API callbacks and activity records
+    for functions like hipMalloc does not return the device id (CUDA does). To
+    solve this we need to track the APIs that select the device (such as
+    hipSetDevice) for each thread.
+    */
+
+  thread_local uint32_t default_device = hipGetStreamDeviceId(nullptr);
+
+  // DumpApiCallbackData(domain, cbid, cbdata);
+
+  if (domain != ACTIVITY_DOMAIN_HIP_API) return absl::OkStatus();
+
+  const hip_api_data_t* data = reinterpret_cast<const hip_api_data_t*>(cbdata);
+
+  if (data->phase == ACTIVITY_API_PHASE_ENTER) {
+    if (options_.api_tracking_set.find(cbid) !=
+        options_.api_tracking_set.end()) {
+      MutexLock lock(api_call_start_mutex_);
+      api_call_start_time_.emplace(data->correlation_id,
+                                   RocmTracer::GetTimestamp());
+    }
+
+    if (cbid == HIP_API_ID_hipSetDevice) {
+      default_device = hipGetStreamDeviceId(nullptr);
+    }
+  } else if (data->phase == ACTIVITY_API_PHASE_EXIT) {
+    uint64_t enter_time = 0, exit_time = 0;
+
+    if (options_.api_tracking_set.find(cbid) !=
+        options_.api_tracking_set.end()) {
+      MutexLock lock(api_call_start_mutex_);
+      if (api_call_start_time_.find(data->correlation_id) !=
+          api_call_start_time_.end()) {
+        enter_time = api_call_start_time_.at(data->correlation_id);
+        api_call_start_time_.erase(data->correlation_id);
+      } else {
+        LOG(WARNING) << "An API exit callback received without API enter "
+                        "with same correlation id. Event droped!";
+        return absl::OkStatus();  // This API does not belong to us.
+      }
+      exit_time = RocmTracer::GetTimestamp();
+    }
+    // Set up the map from correlation id to annotation string.
+    const std::string& annotation = AnnotationStack::Get();
+    if (!annotation.empty()) {
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->Add(
+          data->correlation_id, annotation);
+    }
+
+    if (options_.api_tracking_set.find(cbid) ==
+        options_.api_tracking_set.end()) {
+      VLOG(3) << "API callback is from the auxilarity list. Corr. id="
+              << data->correlation_id;
+    }
+    DumpApiCallbackData(domain, cbid, cbdata);
+
+    switch (cbid) {
+      // star in comments means it does not exist in the driver wrapper
+      case HIP_API_ID_hipModuleLaunchKernel:
+      case HIP_API_ID_hipExtModuleLaunchKernel:  // *
+      case HIP_API_ID_hipHccModuleLaunchKernel:  // *
+      case HIP_API_ID_hipLaunchKernel:           // *
+      case HIP_API_ID_hipExtLaunchKernel:
+
+        this->AddKernelEventUponApiExit(cbid, data, enter_time, exit_time);
+
+        // Add the correlation_ids for these events to the pending set
+        // so that we can explicitly wait for their corresponding
+        // HIP runtime activity records, before exporting the trace data
+        tracer_->AddToPendingActivityRecords(data->correlation_id);
+        break;
+      case HIP_API_ID_hipMemcpy:
+      case HIP_API_ID_hipMemcpyDtoH:
+      case HIP_API_ID_hipMemcpyDtoHAsync:
+      case HIP_API_ID_hipMemcpyHtoD:
+      case HIP_API_ID_hipMemcpyHtoDAsync:
+      case HIP_API_ID_hipMemcpyDtoD:
+      case HIP_API_ID_hipMemcpyDtoDAsync:
+      case HIP_API_ID_hipMemcpyAsync:
+        this->AddNormalMemcpyEventUponApiExit(cbid, data, enter_time,
+                                              exit_time);
+        tracer_->AddToPendingActivityRecords(data->correlation_id);
+        break;
+      case HIP_API_ID_hipMemset:
+      case HIP_API_ID_hipMemsetAsync:
+      case HIP_API_ID_hipMemsetD32:
+      case HIP_API_ID_hipMemsetD32Async:
+      case HIP_API_ID_hipMemsetD16:
+      case HIP_API_ID_hipMemsetD16Async:
+      case HIP_API_ID_hipMemsetD8:
+      case HIP_API_ID_hipMemsetD8Async:
+        this->AddMemsetEventUponApiExit(cbid, data, enter_time, exit_time);
+        break;
+      case HIP_API_ID_hipMalloc:
+      case HIP_API_ID_hipMallocPitch:
+      case HIP_API_ID_hipHostMalloc:
+      case HIP_API_ID_hipFree:
+      case HIP_API_ID_hipHostFree:
+        this->AddMallocFreeEventUponApiExit(cbid, data, default_device,
+                                            enter_time, exit_time);
+        break;
+      case HIP_API_ID_hipStreamSynchronize:
+      case HIP_API_ID_hipStreamWaitEvent:
+        // case HIP_API_ID_hipEventSynchronize:
+        this->AddSynchronizeEventUponApiExit(cbid, data, enter_time, exit_time);
+        break;
+      case HIP_API_ID_hipSetDevice:
+        // we track this ID only to find the device ID
+        //  for the current thread.
+        break;
+      default:
+        //
+        LOG(WARNING) << "API call "
+                     << se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API,
+                                                      cbid, 0)
+                     << ", corr. id=" << data->correlation_id
+                     << " dropped. No capturing function was found!";
+        // AddGenericEventUponApiExit(cbid, data);
+        break;
+    }
+  }
+  return absl::OkStatus();
+}
+
+void RocmApiCallbackImpl::AddKernelEventUponApiExit(uint32_t cbid,
+                                                    const hip_api_data_t* data,
+                                                    const uint64_t enter_time,
+                                                    const uint64_t exit_time) {
+  /*
+  extra fields:
+    kernel_info, domain
+
+  missing fields:
+    context_id
+  */
+  RocmTracerEvent event;
+
+  event.domain = RocmTracerEventDomain::HIP_API;
+  event.type = RocmTracerEventType::Kernel;
+  event.source = RocmTracerEventSource::ApiCallback;
+  event.thread_id = GetCachedTID();
+  event.correlation_id = data->correlation_id;
+  event.start_time_ns = enter_time;
+  event.end_time_ns = exit_time;
+
+  switch (cbid) {
+    case HIP_API_ID_hipModuleLaunchKernel: {
+      const hipFunction_t kernelFunc = data->args.hipModuleLaunchKernel.f;
+      if (kernelFunc != nullptr) event.name = hipKernelNameRef(kernelFunc);
+
+      event.kernel_info.group_segment_size =
+          data->args.hipModuleLaunchKernel.sharedMemBytes;
+      event.kernel_info.workgroup_x =
+          data->args.hipModuleLaunchKernel.blockDimX;
+      event.kernel_info.workgroup_y =
+          data->args.hipModuleLaunchKernel.blockDimY;
+      event.kernel_info.workgroup_z =
+          data->args.hipModuleLaunchKernel.blockDimZ;
+      event.kernel_info.grid_x = data->args.hipModuleLaunchKernel.gridDimX;
+      event.kernel_info.grid_y = data->args.hipModuleLaunchKernel.gridDimY;
+      event.kernel_info.grid_z = data->args.hipModuleLaunchKernel.gridDimZ;
+      event.kernel_info.func_ptr = kernelFunc;
+      const hipStream_t& stream = data->args.hipModuleLaunchKernel.stream;
+      // TODO(rocm-profiler): wrap this API if possible.
+      event.device_id = hipGetStreamDeviceId(stream);
+    } break;
+    case HIP_API_ID_hipExtModuleLaunchKernel: {
+      const hipFunction_t kernelFunc = data->args.hipExtModuleLaunchKernel.f;
+      if (kernelFunc != nullptr) event.name = hipKernelNameRef(kernelFunc);
+
+      event.kernel_info.group_segment_size =
+          data->args.hipExtModuleLaunchKernel.sharedMemBytes;
+      unsigned int blockDimX =
+          data->args.hipExtModuleLaunchKernel.localWorkSizeX;
+      unsigned int blockDimY =
+          data->args.hipExtModuleLaunchKernel.localWorkSizeY;
+      unsigned int blockDimZ =
+          data->args.hipExtModuleLaunchKernel.localWorkSizeZ;
+
+      event.kernel_info.workgroup_x = blockDimX;
+      event.kernel_info.workgroup_y = blockDimY;
+      event.kernel_info.workgroup_z = blockDimZ;
+      event.kernel_info.grid_x =
+          data->args.hipExtModuleLaunchKernel.globalWorkSizeX / blockDimX;
+      event.kernel_info.grid_y =
+          data->args.hipExtModuleLaunchKernel.globalWorkSizeY / blockDimY;
+      event.kernel_info.grid_z =
+          data->args.hipExtModuleLaunchKernel.globalWorkSizeZ / blockDimZ;
+      event.kernel_info.func_ptr = kernelFunc;
+      const hipStream_t& stream = data->args.hipExtModuleLaunchKernel.hStream;
+      event.device_id = hipGetStreamDeviceId(stream);
+    } break;
+    case HIP_API_ID_hipHccModuleLaunchKernel: {
+      const hipFunction_t kernelFunc = data->args.hipHccModuleLaunchKernel.f;
+      if (kernelFunc != nullptr) event.name = hipKernelNameRef(kernelFunc);
+
+      event.kernel_info.group_segment_size =
+          data->args.hipHccModuleLaunchKernel.sharedMemBytes;
+      event.kernel_info.workgroup_x =
+          data->args.hipHccModuleLaunchKernel.blockDimX;
+      event.kernel_info.workgroup_y =
+          data->args.hipHccModuleLaunchKernel.blockDimY;
+      event.kernel_info.workgroup_z =
+          data->args.hipHccModuleLaunchKernel.blockDimZ;
+      event.kernel_info.grid_x =
+          data->args.hipHccModuleLaunchKernel.globalWorkSizeX /
+          event.kernel_info.workgroup_x;
+      event.kernel_info.grid_y =
+          data->args.hipHccModuleLaunchKernel.globalWorkSizeY /
+          event.kernel_info.workgroup_y;
+      event.kernel_info.grid_z =
+          data->args.hipHccModuleLaunchKernel.globalWorkSizeZ /
+          event.kernel_info.workgroup_z;
+      event.kernel_info.func_ptr = kernelFunc;
+      const hipStream_t& stream = data->args.hipHccModuleLaunchKernel.hStream;
+      event.device_id = hipGetStreamDeviceId(stream);
+      event.kernel_info.group_segment_size =
+          data->args.hipHccModuleLaunchKernel.sharedMemBytes;
+    } break;
+    case HIP_API_ID_hipLaunchKernel: {
+      const void* func_addr = data->args.hipLaunchKernel.function_address;
+      hipStream_t stream = data->args.hipLaunchKernel.stream;
+      if (func_addr != nullptr)
+        event.name = hipKernelNameRefByPtr(func_addr, stream);
+
+      event.kernel_info.group_segment_size =
+          data->args.hipLaunchKernel.sharedMemBytes;
+      event.kernel_info.workgroup_x = data->args.hipLaunchKernel.dimBlocks.x;
+      event.kernel_info.workgroup_y = data->args.hipLaunchKernel.dimBlocks.y;
+      event.kernel_info.workgroup_z = data->args.hipLaunchKernel.dimBlocks.z;
+      event.kernel_info.grid_x = data->args.hipLaunchKernel.numBlocks.x;
+      event.kernel_info.grid_y = data->args.hipLaunchKernel.numBlocks.y;
+      event.kernel_info.grid_z = data->args.hipLaunchKernel.numBlocks.z;
+      event.kernel_info.func_ptr = (void*)func_addr;
+      event.device_id = hipGetStreamDeviceId(stream);
+    } break;
+    case HIP_API_ID_hipExtLaunchKernel: {
+      const void* func_addr = data->args.hipExtLaunchKernel.function_address;
+      hipStream_t stream = data->args.hipExtLaunchKernel.stream;
+      if (func_addr != nullptr)
+        event.name = hipKernelNameRefByPtr(func_addr, stream);
+
+      event.kernel_info.group_segment_size =
+          data->args.hipExtLaunchKernel.sharedMemBytes;
+      event.kernel_info.workgroup_x = data->args.hipExtLaunchKernel.dimBlocks.x;
+      event.kernel_info.workgroup_y = data->args.hipExtLaunchKernel.dimBlocks.y;
+      event.kernel_info.workgroup_z = data->args.hipExtLaunchKernel.dimBlocks.z;
+      event.kernel_info.grid_x = data->args.hipExtLaunchKernel.numBlocks.x;
+      event.kernel_info.grid_y = data->args.hipExtLaunchKernel.numBlocks.y;
+      event.kernel_info.grid_z = data->args.hipExtLaunchKernel.numBlocks.z;
+      event.kernel_info.func_ptr = const_cast<void*>(func_addr);
+      event.device_id = hipGetStreamDeviceId(stream);
+    } break;
+  }
+  bool is_auxiliary =
+      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
+  collector_->AddEvent(std::move(event), is_auxiliary);
+}
+
+void RocmApiCallbackImpl::AddNormalMemcpyEventUponApiExit(
+    uint32_t cbid, const hip_api_data_t* data, uint64_t enter_time,
+    uint64_t exit_time) {
+  /*
+    missing:
+      device_id(partially, have only for async), context_id,
+    memcpy_info.kind(CUPTI puts CUPTI_ACTIVITY_MEMCPY_KIND_UNKNOWN),
+      memcpy_info.destination(partially, only for async)( CUPTI puts device_id),
+
+    extra:
+      domain, name,
+  */
+  // for CUDA, it does NOT capture stream id for these types
+
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_API;
+  event.name = se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid, 0);
+  event.source = RocmTracerEventSource::ApiCallback;
+  event.thread_id = GetCachedTID();
+  event.correlation_id = data->correlation_id;
+  event.start_time_ns = enter_time;
+  event.end_time_ns = exit_time;
+
+  /* The general hipMemcpy or hipMemcpyAsync can support any kind of memory
+  copy operation, such as H2D, D2D, P2P, and D2H. Here we use MemcpyOther for
+  all api calls with HipMemcpy(+Async) to carry-on this generality.
+  We also assume that if we want to copy data BETWEEN devices, we do not use
+  hipMemcpy(+Async) or hipMemcpyDtoD(+Async) as we explicitly always set the
+  destenation as the source device id). Ultimately, to figure out the actual
+  device we can use hipPointerGetAttributes but we do not do that now .In the
+  other words, we assume we use hipMemcpyPeer to achieve the copy between
+  devices.
+  */
+
+  switch (cbid) {
+    case HIP_API_ID_hipMemcpyDtoH: {
+      event.type = RocmTracerEventType::MemcpyD2H;
+      event.memcpy_info.num_bytes = data->args.hipMemcpyDtoH.sizeBytes;
+      event.memcpy_info.async = false;
+    } break;
+    case HIP_API_ID_hipMemcpyDtoHAsync: {
+      event.type = RocmTracerEventType::MemcpyD2H;
+      const hipStream_t& stream = data->args.hipMemcpyDtoHAsync.stream;
+      event.device_id = hipGetStreamDeviceId(stream);
+      event.memcpy_info.num_bytes = data->args.hipMemcpyDtoHAsync.sizeBytes;
+      event.memcpy_info.async = true;
+      event.memcpy_info.destination = event.device_id;
+    } break;
+    case HIP_API_ID_hipMemcpyHtoD: {
+      event.type = RocmTracerEventType::MemcpyH2D;
+      event.memcpy_info.num_bytes = data->args.hipMemcpyHtoD.sizeBytes;
+      event.memcpy_info.async = false;
+      // we set the destenattion device id for it using the device id we get
+      // from activities when they exchange information before flushing
+    } break;
+    case HIP_API_ID_hipMemcpyHtoDAsync: {
+      event.type = RocmTracerEventType::MemcpyH2D;
+      const hipStream_t& stream = data->args.hipMemcpyHtoDAsync.stream;
+      event.device_id = hipGetStreamDeviceId(stream);
+      event.memcpy_info.num_bytes = data->args.hipMemcpyHtoDAsync.sizeBytes;
+      event.memcpy_info.async = true;
+      event.memcpy_info.destination = event.device_id;
+    } break;
+    case HIP_API_ID_hipMemcpyDtoD: {
+      event.type = RocmTracerEventType::MemcpyD2D;
+      event.memcpy_info.num_bytes = data->args.hipMemcpyDtoD.sizeBytes;
+      event.memcpy_info.async = false;
+    } break;
+    case HIP_API_ID_hipMemcpyDtoDAsync: {
+      event.type = RocmTracerEventType::MemcpyD2D;
+      const hipStream_t& stream = data->args.hipMemcpyDtoDAsync.stream;
+      event.device_id = hipGetStreamDeviceId(stream);
+      event.memcpy_info.num_bytes = data->args.hipMemcpyDtoDAsync.sizeBytes;
+      event.memcpy_info.async = true;
+      event.memcpy_info.destination = event.device_id;
+    } break;
+    case HIP_API_ID_hipMemcpy: {
+      event.type = RocmTracerEventType::MemcpyOther;
+      event.memcpy_info.num_bytes = data->args.hipMemcpy.sizeBytes;
+      event.memcpy_info.async = false;
+    } break;
+    case HIP_API_ID_hipMemcpyAsync: {
+      event.type = RocmTracerEventType::MemcpyOther;
+      const hipStream_t& stream = data->args.hipMemcpyAsync.stream;
+      event.device_id = hipGetStreamDeviceId(stream);
+      event.memcpy_info.num_bytes = data->args.hipMemcpyAsync.sizeBytes;
+      event.memcpy_info.async = true;
+      event.memcpy_info.destination = event.device_id;
+    } break;
+    default:
+      LOG(WARNING) << "Unsupported Memcpy API for profiling observed for cbid="
+                   << cbid << ". Event dropped!";
+      return;
+      break;
+  }
+
+  bool is_auxiliary =
+      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
+  collector_->AddEvent(std::move(event), is_auxiliary);
+}
+void RocmApiCallbackImpl::AddMemcpyPeerEventUponApiExit(
+    uint32_t cbid, const hip_api_data_t* data, uint64_t enter_time,
+    uint64_t exit_time) {
+  /*
+    missing: context_id, memcpy_info.kind
+
+    extra: domain, name,
+  */
+
+  RocmTracerEvent event;
+  event.type = RocmTracerEventType::MemcpyP2P;
+  event.domain = RocmTracerEventDomain::HIP_API;
+  event.name = se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid, 0);
+  event.source = RocmTracerEventSource::ApiCallback;
+  event.thread_id = GetCachedTID();
+  event.correlation_id = data->correlation_id;
+  event.start_time_ns = enter_time;
+  event.end_time_ns = exit_time;
+
+  switch (cbid) {
+    case HIP_API_ID_hipMemcpyPeer:
+      event.device_id = data->args.hipMemcpyPeer.srcDeviceId;
+      event.memcpy_info.destination = data->args.hipMemcpyPeer.dstDeviceId;
+      event.memcpy_info.num_bytes = data->args.hipMemcpyPeer.sizeBytes;
+      event.memcpy_info.async = false;
+      break;
+    case HIP_API_ID_hipMemcpyPeerAsync:
+      event.device_id = data->args.hipMemcpyPeerAsync.srcDevice;
+      event.memcpy_info.destination = data->args.hipMemcpyPeerAsync.dstDeviceId;
+      event.memcpy_info.num_bytes = data->args.hipMemcpyPeerAsync.sizeBytes;
+      event.memcpy_info.async = true;
+      break;
+    default:
+      LOG(WARNING)
+          << "Unsupported MemcpyPeer API for profiling observed for cbid="
+          << cbid << ". Event dropped!";
+      return;
+      break;
+  }
+
+  bool is_auxiliary =
+      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
+  collector_->AddEvent(std::move(event), is_auxiliary);
+}
+void RocmApiCallbackImpl::AddMemsetEventUponApiExit(uint32_t cbid,
+                                                    const hip_api_data_t* data,
+                                                    uint64_t enter_time,
+                                                    uint64_t exit_time) {
+  /*
+    misses:
+      device_id(only avail. for async), context_id
+
+    extras:
+      domain, name
+  */
+
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_API;
+  event.name = se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid, 0);
+  event.source = RocmTracerEventSource::ApiCallback;
+  event.thread_id = GetCachedTID();
+  event.correlation_id = data->correlation_id;
+  event.start_time_ns = enter_time;
+  event.end_time_ns = exit_time;
+
+  switch (cbid) {
+    case HIP_API_ID_hipMemsetD8:
+      event.type = RocmTracerEventType::Memset;
+      event.memset_info.num_bytes = data->args.hipMemsetD8.count;
+      event.memset_info.async = false;
+      break;
+    case HIP_API_ID_hipMemsetD8Async: {
+      event.type = RocmTracerEventType::Memset;
+      event.memset_info.num_bytes = data->args.hipMemsetD8Async.count;
+      event.memset_info.async = true;
+      const hipStream_t& stream = data->args.hipMemsetD8Async.stream;
+      event.device_id = hipGetStreamDeviceId(stream);
+    } break;
+    case HIP_API_ID_hipMemsetD16:
+      event.type = RocmTracerEventType::Memset;
+      event.memset_info.num_bytes = 2 * data->args.hipMemsetD16.count;
+      event.memset_info.async = false;
+      break;
+    case HIP_API_ID_hipMemsetD16Async: {
+      event.type = RocmTracerEventType::Memset;
+      event.memset_info.num_bytes = 2 * data->args.hipMemsetD16Async.count;
+      event.memset_info.async = true;
+      const hipStream_t& stream = data->args.hipMemsetD16Async.stream;
+      event.device_id = hipGetStreamDeviceId(stream);
+    } break;
+    case HIP_API_ID_hipMemsetD32:
+      event.type = RocmTracerEventType::Memset;
+      event.memset_info.num_bytes = 4 * data->args.hipMemsetD32.count;
+      event.memset_info.async = false;
+      break;
+    case HIP_API_ID_hipMemsetD32Async: {
+      event.type = RocmTracerEventType::Memset;
+      event.memset_info.num_bytes = 4 * data->args.hipMemsetD32Async.count;
+      event.memset_info.async = true;
+      const hipStream_t& stream = data->args.hipMemsetD32Async.stream;
+      event.device_id = hipGetStreamDeviceId(stream);
+    } break;
+    case HIP_API_ID_hipMemset:
+      event.type = RocmTracerEventType::Memset;
+      event.memset_info.num_bytes = data->args.hipMemset.sizeBytes;
+      event.memset_info.async = false;
+      break;
+    case HIP_API_ID_hipMemsetAsync: {
+      event.type = RocmTracerEventType::Memset;
+      event.memset_info.num_bytes = data->args.hipMemsetAsync.sizeBytes;
+      event.memset_info.async = true;
+      const hipStream_t& stream = data->args.hipMemsetAsync.stream;
+      event.device_id = hipGetStreamDeviceId(stream);
+    } break;
+    default:
+      LOG(WARNING) << "Unsupported Memset API for profiling observed for cbid="
+                   << cbid << ". Event dropped!";
+      return;
+      break;
+  }
+
+  bool is_auxiliary =
+      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
+  collector_->AddEvent(std::move(event), is_auxiliary);
+}
+
+void RocmApiCallbackImpl::AddMallocFreeEventUponApiExit(
+    uint32_t cbid, const hip_api_data_t* data, uint32_t device_id,
+    uint64_t enter_time, uint64_t exit_time) {
+  /*
+    misses: context_id
+
+    extras: domain
+  */
+
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_API;
+  event.type = (cbid == HIP_API_ID_hipFree || cbid == HIP_API_ID_hipHostFree)
+                   ? RocmTracerEventType::MemoryFree
+                   : RocmTracerEventType::MemoryAlloc;
+  event.source = RocmTracerEventSource::ApiCallback;
+  event.name = se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid, 0);
+  event.device_id = device_id;
+  event.thread_id = GetCachedTID();
+  // We do not set stream_id (probably to zero as Malloc etc. commands seems
+  // to run on  default stream). Later we use the unassigned stream_id as a
+  // feature to assign events to host or device.
+  event.correlation_id = data->correlation_id;
+  event.start_time_ns = enter_time;
+  event.end_time_ns = exit_time;
+
+  switch (cbid) {
+    case HIP_API_ID_hipMalloc:
+      event.memalloc_info.num_bytes = data->args.hipMalloc.size;
+      break;
+    case HIP_API_ID_hipMallocPitch:
+      event.memalloc_info.num_bytes = data->args.hipMallocPitch.pitch__val *
+                                      data->args.hipMallocPitch.height;
+      break;
+    case HIP_API_ID_hipHostMalloc:
+      event.memalloc_info.num_bytes = data->args.hipHostMalloc.size;
+      break;
+    case HIP_API_ID_hipFree:
+    case HIP_API_ID_hipHostFree:
+      event.memalloc_info.num_bytes = 0;
+      break;
+    default:
+      LOG(WARNING)
+          << "Unsupported Malloc/Free API for profiling observed for cbid="
+          << cbid << ". Event dropped!";
+      return;
+      break;
+  }
+
+  bool is_auxiliary =
+      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
+  collector_->AddEvent(std::move(event), is_auxiliary);
+}
+
+void RocmApiCallbackImpl::AddSynchronizeEventUponApiExit(
+    uint32_t cbid, const hip_api_data_t* data, uint64_t enter_time,
+    uint64_t exit_time) {
+  // TODO(rocm-profiler): neither CUDA and nor we capture annotaint for this
+  // event
+  /*
+    misses: context_id
+
+    extras: domain,
+  */
+
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_API;
+  event.type = RocmTracerEventType::Synchronization;
+  event.source = RocmTracerEventSource::ApiCallback;
+  event.name = se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid, 0);
+  event.thread_id = GetCachedTID();
+  event.correlation_id = data->correlation_id;
+  event.start_time_ns = enter_time;
+  event.end_time_ns = exit_time;
+
+  switch (cbid) {
+    case HIP_API_ID_hipStreamSynchronize: {
+      event.synchronization_info.sync_type =
+          RocmTracerSyncTypes::StreamSynchronize;
+      const hipStream_t& stream = data->args.hipStreamSynchronize.stream;
+      event.device_id = hipGetStreamDeviceId(stream);
+    } break;
+    case HIP_API_ID_hipStreamWaitEvent: {
+      event.synchronization_info.sync_type = RocmTracerSyncTypes::StreamWait;
+      const hipStream_t& stream = data->args.hipStreamWaitEvent.stream;
+      event.device_id = hipGetStreamDeviceId(stream);
+    } break;
+    default:
+      LOG(WARNING)
+          << "Unsupported Synchronization API for profiling observed for cbid="
+          << cbid << ". Event dropped!";
+      return;
+      break;
+  }
+  bool is_auxiliary =
+      options_.api_tracking_set.find(cbid) == options_.api_tracking_set.end();
+  collector_->AddEvent(std::move(event), is_auxiliary);
+}
+
+absl::Status RocmActivityCallbackImpl::operator()(const char* begin,
+                                                  const char* end) {
+  // we do not dump activities in this set in logger
+
+  static std::set<activity_op_t> dump_excluded_activities = {
+      HIP_API_ID_hipGetDevice,
+      HIP_API_ID_hipSetDevice,
+      HIP_API_ID___hipPushCallConfiguration,
+      HIP_API_ID___hipPopCallConfiguration,
+      HIP_API_ID_hipEventQuery,
+      HIP_API_ID_hipCtxSetCurrent,
+      HIP_API_ID_hipEventRecord,
+      HIP_API_ID_hipEventQuery,
+      HIP_API_ID_hipGetDeviceProperties,
+      HIP_API_ID_hipPeekAtLastError,
+      HIP_API_ID_hipModuleGetFunction,
+      HIP_API_ID_hipEventCreateWithFlags};
+
+  const roctracer_record_t* record =
+      reinterpret_cast<const roctracer_record_t*>(begin);
+  const roctracer_record_t* end_record =
+      reinterpret_cast<const roctracer_record_t*>(end);
+
+  while (record < end_record) {
+    // DumpActivityRecord(record);
+
+    switch (record->domain) {
+      // HIP API activities.
+      case ACTIVITY_DOMAIN_HIP_API:
+        switch (record->op) {
+          case HIP_API_ID_hipModuleLaunchKernel:
+          case HIP_API_ID_hipExtModuleLaunchKernel:
+          case HIP_API_ID_hipHccModuleLaunchKernel:
+          case HIP_API_ID_hipLaunchKernel:
+          case HIP_API_ID_hipExtLaunchKernel:
+            DumpActivityRecord(record, std::to_string(__LINE__));
+            AddHipKernelActivityEvent(record);
+            break;
+          case HIP_API_ID_hipMemcpyDtoH:
+          case HIP_API_ID_hipMemcpyHtoD:
+          case HIP_API_ID_hipMemcpyDtoD:
+          case HIP_API_ID_hipMemcpyDtoHAsync:
+          case HIP_API_ID_hipMemcpyHtoDAsync:
+          case HIP_API_ID_hipMemcpyDtoDAsync:
+          case HIP_API_ID_hipMemcpyAsync:
+          case HIP_API_ID_hipMemcpy:
+            DumpActivityRecord(record, std::to_string(__LINE__));
+            AddNormalHipMemcpyActivityEvent(record);
+            break;
+          case HIP_API_ID_hipMemset:
+          case HIP_API_ID_hipMemsetAsync:
+          case HIP_API_ID_hipMemsetD32:
+          case HIP_API_ID_hipMemsetD32Async:
+          case HIP_API_ID_hipMemsetD16:
+          case HIP_API_ID_hipMemsetD16Async:
+          case HIP_API_ID_hipMemsetD8:
+          case HIP_API_ID_hipMemsetD8Async:
+            DumpActivityRecord(record, std::to_string(__LINE__));
+            AddHipMemsetActivityEvent(record);
+            break;
+
+          case HIP_API_ID_hipMalloc:
+          case HIP_API_ID_hipMallocPitch:
+          case HIP_API_ID_hipHostMalloc:
+          case HIP_API_ID_hipFree:
+          case HIP_API_ID_hipHostFree:
+            DumpActivityRecord(record, std::to_string(__LINE__));
+            AddHipMallocActivityEvent(record);
+            break;
+          case HIP_API_ID_hipStreamSynchronize:
+          case HIP_API_ID_hipStreamWaitEvent:
+            // case HIP_API_ID_hipStreamWaitEvent:
+            DumpActivityRecord(record, std::to_string(__LINE__));
+            AddHipStreamSynchronizeActivityEvent(record);
+            break;
+
+          default:
+            if (dump_excluded_activities.find(record->op) ==
+                dump_excluded_activities.end()) {
+              std::string drop_message(
+                  "\nNot in the API tracked activities. Dropped!");
+              DumpActivityRecord(record, drop_message);
+            }
+            break;
+        }  // switch (record->op).
+        break;
+
+      // HCC ops activities.
+      case ACTIVITY_DOMAIN_HIP_OPS:
+
+        switch (record->op) {
+          case HIP_OP_ID_DISPATCH:
+            DumpActivityRecord(record, std::to_string(__LINE__));
+            AddHccKernelActivityEvent(record);
+            tracer_->RemoveFromPendingActivityRecords(record->correlation_id);
+            break;
+          case HIP_OP_ID_COPY:
+            switch (record->kind) {
+              // TODO(rocm-profiler): use enum instead.
+              case 4595:   /*CopyDeviceToHost*/
+              case 4596:   /*CopyDeviceToDevice*/
+              case 4597: { /*CopyHostToDevice*/
+                /*MEMCPY*/
+                // roctracer returns CopyHostToDevice for hipMemcpyDtoD API
+                //  Please look at the issue #53 in roctracer GitHub repo.
+                DumpActivityRecord(record, "");
+                AddNormalHipOpsMemcpyActivityEvent(record);
+                tracer_->RemoveFromPendingActivityRecords(
+                    record->correlation_id);
+              } break;
+              case 4615: /*FillBuffer*/
+                /*MEMSET*/
+                DumpActivityRecord(record, "");
+                AddHipOpsMemsetActivityEvent(record);
+                break;
+              case 4606: /*MARKER*/
+                // making the log shorter.
+                // markers are with 0ns duration.
+                break;
+              default:
+                std::string drop_message(
+                    "\nNot in the HIP-OPS-COPY tracked activities. Dropeed!");
+                DumpActivityRecord(record, drop_message);
+                break;
+            }  // switch (record->kind)
+            break;
+          default:
+            std::string drop_message(
+                "\nNot in the HIP-OPS tracked activities. Dropped!");
+            DumpActivityRecord(record, drop_message);
+            break;
+        }  // switch (record->op).
+        break;
+      default:
+        std::string drop_message(
+            "\nNot in the tracked domain activities. Dropped!");
+        DumpActivityRecord(record, drop_message);
+        break;
+    }
+
+    RETURN_IF_ROCTRACER_ERROR(static_cast<roctracer_status_t>(
+#if TF_ROCM_VERSION >= 50300
+        se::wrap::roctracer_next_record(record, &record)
+#else
+        roctracer_next_record(record, &record)
+#endif
+            ));
+  }
+
+  return absl::OkStatus();
+}
+
+void RocmActivityCallbackImpl::AddHipKernelActivityEvent(
+    const roctracer_record_t* record) {
+  /*
+  missing:
+   name, device_id(got from hcc), context_id, stream_id(got from hcc),
+ nvtx_range, kernel_info
+
+  extra:
+   domain
+ activity record contains process/thread ID
+ */
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_API;
+  event.type = RocmTracerEventType::Kernel;
+  event.source = RocmTracerEventSource::Activity;
+  event.name = /* we use the API name instead*/
+      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
+  event.correlation_id = record->correlation_id;
+  // TODO(rocm-profiler): CUDA uses device id and correlation ID for finding
+  // annotations.
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
+
+  event.start_time_ns = record->begin_ns;
+  event.end_time_ns = record->end_ns;
+
+  collector_->AddEvent(std::move(event), false);
+}
+
+void RocmActivityCallbackImpl::AddNormalHipMemcpyActivityEvent(
+    const roctracer_record_t* record) {
+  /*
+  ---------------NormalMemcpy-------------------
+    misses:context_id, memcpy_info.kind, memcpy_info.srckind,
+  memcpy_info.dstkind, memcpy_info.num_bytes, memcpy_info.destenation,
+  device_id, stream_id,
+
+    extras: domain
+  ---------------PeerMemcpy---------------------
+    misses: device_id, context_id, stream_id, memcpy_info.kind,
+      memcpy_info.num_bytes, memcpy_info.destination,
+    extras:
+      domain,
+  */
+
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_API;
+  event.source = RocmTracerEventSource::Activity;
+  event.start_time_ns = record->begin_ns;
+  event.end_time_ns = record->end_ns;
+  event.correlation_id = record->correlation_id;
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  // TODO(roc-profiler): record->bytes is not a valid value
+  // event.memcpy_info.num_bytes = record->bytes;
+  event.name =
+      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
+  switch (record->op) {
+    case HIP_API_ID_hipMemcpyDtoH:
+    case HIP_API_ID_hipMemcpyDtoHAsync:
+      event.type = RocmTracerEventType::MemcpyD2H;
+      event.memcpy_info.async =
+          (record->op == HIP_API_ID_hipMemcpyDtoHAsync) ? true : false;
+      break;
+    case HIP_API_ID_hipMemcpyHtoD:
+    case HIP_API_ID_hipMemcpyHtoDAsync:
+      event.type = RocmTracerEventType::MemcpyH2D;
+      event.memcpy_info.async =
+          (record->op == HIP_API_ID_hipMemcpyHtoDAsync) ? true : false;
+      break;
+    case HIP_API_ID_hipMemcpyDtoD:
+    case HIP_API_ID_hipMemcpyDtoDAsync:
+      event.type = RocmTracerEventType::MemcpyD2D;
+      event.memcpy_info.async =
+          (record->op == HIP_API_ID_hipMemcpyDtoDAsync) ? true : false;
+      break;
+    case HIP_API_ID_hipMemcpy:
+    case HIP_API_ID_hipMemcpyAsync:
+      event.type = RocmTracerEventType::MemcpyOther;
+      event.memcpy_info.async =
+          (record->op == HIP_API_ID_hipMemcpyAsync) ? true : false;
+      break;
+    case HIP_API_ID_hipMemcpyPeer:
+    case HIP_API_ID_hipMemcpyPeerAsync:
+      event.type = RocmTracerEventType::MemcpyP2P;
+      event.memcpy_info.async =
+          (record->op == HIP_API_ID_hipMemcpyPeerAsync) ? true : false;
+      break;
+    default:
+      LOG(WARNING) << "Unsupported Memcpy/MemcpyPeer activity for profiling "
+                      "observed for cbid="
+                   << record->op << ". Event dropped!";
+      return;
+      break;
+  }
+
+  collector_->AddEvent(std::move(event), false);
+}
+
+void RocmActivityCallbackImpl::AddHipMemsetActivityEvent(
+    const roctracer_record_t* record) {
+  /*
+    misses:
+      device_id, context_id, stram_id, memset_info.num_bytes
+      memset_info.kind
+
+    extras:
+      domain, annotation
+  */
+
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_API;
+  event.source = RocmTracerEventSource::Activity;
+  event.name =
+      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
+  event.correlation_id = record->correlation_id;
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
+
+  event.type = RocmTracerEventType::Memset;
+
+  switch (record->op) {
+    case HIP_API_ID_hipMemset:
+      event.memset_info.async = false;
+      break;
+    case HIP_API_ID_hipMemsetAsync:
+      event.memset_info.async = true;
+      break;
+    case HIP_API_ID_hipMemsetD8:
+      event.memset_info.async = false;
+      break;
+    case HIP_API_ID_hipMemsetD8Async:
+      event.memset_info.async = true;
+      break;
+    case HIP_API_ID_hipMemsetD16:
+      event.memset_info.async = false;
+      break;
+    case HIP_API_ID_hipMemsetD16Async:
+      event.memset_info.async = true;
+      break;
+    case HIP_API_ID_hipMemsetD32:
+      event.memset_info.async = false;
+      break;
+    case HIP_API_ID_hipMemsetD32Async:
+      event.memset_info.async = true;
+      break;
+  }
+
+  event.start_time_ns = record->begin_ns;
+  event.end_time_ns = record->end_ns;
+
+  collector_->AddEvent(std::move(event), false);
+}
+
+void RocmActivityCallbackImpl::AddHipMallocActivityEvent(
+    const roctracer_record_t* record) {
+  /*
+    misses: device_id, context_id, memory_residency_info (num_byts, kind,
+    address)
+
+    extras:
+      annotation, domain,
+  */
+
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_API;
+  event.type = RocmTracerEventType::MemoryAlloc;
+  event.source = RocmTracerEventSource::Activity;
+  event.name =
+      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
+  event.correlation_id = record->correlation_id;
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
+  // similar to CUDA we set this to the default stream
+  event.stream_id = 0;
+  event.start_time_ns = record->begin_ns;
+  // making sure it does not have 0ns duration. Otherwise, it may not show up in
+  // the trace view
+  event.end_time_ns = std::max(record->end_ns, record->begin_ns + 1);
+
+  collector_->AddEvent(std::move(event), false);
+}
+
+void RocmActivityCallbackImpl::AddHipStreamSynchronizeActivityEvent(
+    const roctracer_record_t* record) {
+  /*
+  misses: context_id, device_id (cuda also does not provide but we can get from
+  API-CB)
+
+  extras: domain, synchronization_info.sync_type, annotation
+  */
+
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_API;
+  event.type = RocmTracerEventType::Synchronization;
+  event.source = RocmTracerEventSource::Activity;
+  event.name =
+      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
+  event.correlation_id = record->correlation_id;
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
+  event.start_time_ns = record->begin_ns;
+
+  // making sure it does not have 0ns duration. Otherwise, it may not show up in
+  // the trace view
+  event.end_time_ns = std::max(record->end_ns, record->begin_ns + 1);
+
+  switch (record->op) {
+    case HIP_API_ID_hipStreamSynchronize:
+      event.synchronization_info.sync_type =
+          RocmTracerSyncTypes::StreamSynchronize;
+      break;
+    case HIP_API_ID_hipStreamWaitEvent:
+      event.synchronization_info.sync_type = RocmTracerSyncTypes::StreamWait;
+      break;
+    default:
+      event.synchronization_info.sync_type = RocmTracerSyncTypes::InvalidSync;
+      break;
+  }
+  collector_->AddEvent(std::move(event), false);
+}
+
+// TODO(rocm-profiler): rename this function. this is HIP-OP
+void RocmActivityCallbackImpl::AddHccKernelActivityEvent(
+    const roctracer_record_t* record) {
+  /*
+   missing:
+     name, context_id, nvtx_range, kernel_info
+
+   extra:
+     domain (thread id from the HIP activity)
+
+   activity record contains device/stream ID
+ */
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_OPS;
+  event.type = RocmTracerEventType::Kernel;
+  event.source = RocmTracerEventSource::Activity;
+  event.correlation_id = record->correlation_id;
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
+  event.start_time_ns = record->begin_ns;
+  event.end_time_ns = record->end_ns;
+  event.device_id = record->device_id;
+  event.stream_id = record->queue_id;
+
+  collector_->AddEvent(std::move(event), false);
+}
+
+void RocmActivityCallbackImpl::AddNormalHipOpsMemcpyActivityEvent(
+    const roctracer_record_t* record) {
+  /*
+    misses:
+      type, name(the name set here is not clear enough but we keep it for
+    debug), context_id, memcpy_info.kind, memcpy_info.num_bytes,
+    memcpy_info.async, memcpy_info.src_mem_kind, memcpy_info.dst_mem_kind
+
+    extras:
+      domain,
+
+  */
+
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_OPS;
+  event.source = RocmTracerEventSource::Activity;
+  event.name =  // name is stored for debug
+      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
+  event.correlation_id = record->correlation_id;
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
+
+  event.start_time_ns = record->begin_ns;
+  event.end_time_ns = record->end_ns;
+  event.device_id = record->device_id;
+  event.memcpy_info.destination = event.device_id;
+  event.stream_id = record->queue_id;
+
+  // we set the type as MemcpyOther as HIP-OPS activity record does not carry
+  // this information
+  event.type = RocmTracerEventType::MemcpyOther;
+
+  collector_->AddEvent(std::move(event), false);
+}
+
+void RocmActivityCallbackImpl::AddHipOpsMemsetActivityEvent(
+    const roctracer_record_t* record) {
+  /*
+    misses:
+      name (name recorder here is not clear enough for Memset. We only capture
+    it for debug), context_id, memset_info.kind, memset_info.num_bytes,
+    memset_info.async
+
+    extras:
+      dommain, annotation,
+
+  */
+
+  RocmTracerEvent event;
+  event.domain = RocmTracerEventDomain::HIP_OPS;
+  event.source = RocmTracerEventSource::Activity;
+  event.name =  // name is stored for debug
+      se::wrap::roctracer_op_string(record->domain, record->op, record->kind);
+  event.correlation_id = record->correlation_id;
+  // event.annotation =
+  // collector_->RocmTracer::annotation_map()->LookUp(event.correlation_id);
+  event.annotation =
+      RocmTracer::GetRocmTracerSingleton().annotation_map()->LookUp(
+          event.correlation_id);
+
+  event.start_time_ns = record->begin_ns;
+  event.end_time_ns = record->end_ns;
+  event.device_id = record->device_id;
+  event.stream_id = record->queue_id;
+
+  event.type = RocmTracerEventType::Memset;
+
+  collector_->AddEvent(std::move(event), false);
+}
+
+RocmTracer& RocmTracer::GetRocmTracerSingleton() {
+  static RocmTracer singleton;
+  return singleton;
+}
+
+// FIXME(rocm-profiler): we should also check if we have AMD GPUs
+bool RocmTracer::IsAvailable() const {
+  return !activity_tracing_enabled_ && !api_tracing_enabled_;  // &&NumGpus()
+}
+
+int RocmTracer::NumGpus() {
+  static int num_gpus = []() -> int {
+    if (hipInit(0) != hipSuccess) {
+      return 0;
+    }
+    int gpu_count;
+    if (hipGetDeviceCount(&gpu_count) != hipSuccess) {
+      return 0;
+    }
+    LOG(INFO) << "Profiler found " << gpu_count << " GPUs";
+    return gpu_count;
+  }();
+  return num_gpus;
+}
+
+void RocmTracer::Enable(const RocmTracerOptions& options,
+                        RocmTraceCollector* collector) {
+  options_ = options;
+  collector_ = collector;
+  api_cb_impl_ = new RocmApiCallbackImpl(options, this, collector);
+  activity_cb_impl_ = new RocmActivityCallbackImpl(options, this, collector);
+
+  // From ROCm 3.5 onwards, the following call is required.
+  // don't quite know what it does (no documentation!), only that without it
+  // the call to enable api/activity tracing will run into a segfault
+  se::wrap::roctracer_set_properties(ACTIVITY_DOMAIN_HIP_API, nullptr);
+
+  EnableApiTracing().IgnoreError();
+  EnableActivityTracing().IgnoreError();
+  LOG(INFO) << "GpuTracer started";
+}
+
+void RocmTracer::Disable() {
+  // TODO(rocm-profiler): TF has a SyncAndFlush() function
+  // to be called before disabling. It makes sure all the contexts
+  // has finished all the tasks before shutting down the profiler
+  DisableApiTracing().IgnoreError();
+  DisableActivityTracing().IgnoreError();
+  delete api_cb_impl_;
+  delete activity_cb_impl_;
+  collector_->Flush();
+  collector_ = nullptr;
+  options_.reset();
+  LOG(INFO) << "GpuTracer stopped";
+}
+
+void ApiCallback(uint32_t domain, uint32_t cbid, const void* cbdata,
+                 void* user_data) {
+  RocmTracer* tracer = reinterpret_cast<RocmTracer*>(user_data);
+  tracer->ApiCallbackHandler(domain, cbid, cbdata).IgnoreError();
+}
+
+absl::Status RocmTracer::ApiCallbackHandler(uint32_t domain, uint32_t cbid,
+                                            const void* cbdata) {
+  if (api_tracing_enabled_)
+    TF_RETURN_IF_ERROR((*api_cb_impl_)(domain, cbid, cbdata));
+  return absl::OkStatus();
+}
+
+absl::Status RocmTracer::EnableApiTracing() {
+  if (api_tracing_enabled_) return absl::OkStatus();
+  api_tracing_enabled_ = true;
+
+  for (auto& iter : options_->api_callbacks) {
+    activity_domain_t domain = iter.first;
+    std::vector<uint32_t>& ops = iter.second;
+    if (ops.size() == 0) {
+      VLOG(3) << "Enabling API tracing for domain "
+              << GetActivityDomainName(domain);
+      RETURN_IF_ROCTRACER_ERROR(se::wrap::roctracer_enable_domain_callback(
+          domain, ApiCallback, this));
+    } else {
+      VLOG(3) << "Enabling API tracing for " << ops.size() << " ops in domain "
+              << GetActivityDomainName(domain);
+      for (auto& op : ops) {
+        VLOG(3) << "Enabling API tracing for "
+                << GetActivityDomainOpName(domain, op);
+        RETURN_IF_ROCTRACER_ERROR(se::wrap::roctracer_enable_op_callback(
+            domain, op, ApiCallback, this));
+      }
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status RocmTracer::DisableApiTracing() {
+  if (!api_tracing_enabled_) return absl::OkStatus();
+  api_tracing_enabled_ = false;
+
+  for (auto& iter : options_->api_callbacks) {
+    activity_domain_t domain = iter.first;
+    std::vector<uint32_t>& ops = iter.second;
+    if (ops.size() == 0) {
+      VLOG(3) << "Disabling API tracing for domain "
+              << GetActivityDomainName(domain);
+      RETURN_IF_ROCTRACER_ERROR(
+          se::wrap::roctracer_disable_domain_callback(domain));
+    } else {
+      VLOG(3) << "Disabling API tracing for " << ops.size() << " ops in domain "
+              << GetActivityDomainName(domain);
+      for (auto& op : ops) {
+        VLOG(3) << "Disabling API tracing for "
+                << GetActivityDomainOpName(domain, op);
+        RETURN_IF_ROCTRACER_ERROR(
+            se::wrap::roctracer_disable_op_callback(domain, op));
+      }
+    }
+  }
+  return absl::OkStatus();
+}
+
+void ActivityCallback(const char* begin, const char* end, void* user_data) {
+  RocmTracer* tracer = reinterpret_cast<RocmTracer*>(user_data);
+  tracer->ActivityCallbackHandler(begin, end).IgnoreError();
+}
+
+absl::Status RocmTracer::ActivityCallbackHandler(const char* begin,
+                                                 const char* end) {
+  if (activity_tracing_enabled_) {
+    TF_RETURN_IF_ERROR((*activity_cb_impl_)(begin, end));
+  } else {
+    LOG(WARNING) << "ActivityCallbackHandler called when "
+                    "activity_tracing_enabled_ is false";
+
+    VLOG(3) << "Dropped Activity Records Start";
+    const roctracer_record_t* record =
+        reinterpret_cast<const roctracer_record_t*>(begin);
+    const roctracer_record_t* end_record =
+        reinterpret_cast<const roctracer_record_t*>(end);
+    while (record < end_record) {
+      DumpActivityRecord(record,
+                         "activity_tracing_enabled_ is false. Dropped!");
+#if TF_ROCM_VERSION >= 50300
+      RETURN_IF_ROCTRACER_ERROR(static_cast<roctracer_status_t>(
+          se::wrap::roctracer_next_record(record, &record)));
+#else
+      RETURN_IF_ROCTRACER_ERROR(static_cast<roctracer_status_t>(
+          roctracer_next_record(record, &record)));
+#endif
+    }
+    VLOG(3) << "Dropped Activity Records End";
+  }
+  return absl::OkStatus();
+}
+
+absl::Status RocmTracer::EnableActivityTracing() {
+  if (activity_tracing_enabled_) return absl::OkStatus();
+  activity_tracing_enabled_ = true;
+
+  if (!options_->activity_tracing.empty()) {
+    // Create the memory pool to store activity records in
+    if (se::wrap::roctracer_default_pool_expl(nullptr) == NULL) {
+      roctracer_properties_t properties{};
+      properties.buffer_size = 0x1000;
+      properties.buffer_callback_fun = ActivityCallback;
+      properties.buffer_callback_arg = this;
+      VLOG(3) << "Creating roctracer activity buffer: buff-size="
+              << properties.buffer_size;
+      RETURN_IF_ROCTRACER_ERROR(
+          se::wrap::roctracer_open_pool_expl(&properties, nullptr));
+    }
+  }
+
+  for (auto& iter : options_->activity_tracing) {
+    activity_domain_t domain = iter.first;
+    std::vector<uint32_t>& ops = iter.second;
+    if (ops.size() == 0) {
+      VLOG(3) << "Enabling Activity tracing for domain "
+              << GetActivityDomainName(domain);
+      RETURN_IF_ROCTRACER_ERROR(
+          se::wrap::roctracer_enable_domain_activity_expl(domain, nullptr));
+    } else {
+      VLOG(3) << "Enabling Activity tracing for " << ops.size()
+              << " ops in domain " << GetActivityDomainName(domain);
+      for (auto& op : ops) {
+        VLOG(3) << "Enabling Activity tracing for "
+                << GetActivityDomainOpName(domain, op);
+        // roctracer library has not exported "roctracer_enable_op_activity"
+        RETURN_IF_ROCTRACER_ERROR(
+            se::wrap::roctracer_enable_op_activity_expl(domain, op, nullptr));
+      }
+    }
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status RocmTracer::DisableActivityTracing() {
+  if (!activity_tracing_enabled_) return absl::OkStatus();
+
+  for (auto& iter : options_->activity_tracing) {
+    activity_domain_t domain = iter.first;
+    std::vector<uint32_t>& ops = iter.second;
+    if (ops.size() == 0) {
+      VLOG(3) << "Disabling Activity tracing for domain "
+              << GetActivityDomainName(domain);
+      RETURN_IF_ROCTRACER_ERROR(
+          se::wrap::roctracer_disable_domain_activity(domain));
+    } else {
+      VLOG(3) << "Disabling Activity tracing for " << ops.size()
+              << " ops in domain " << GetActivityDomainName(domain);
+      for (auto& op : ops) {
+        VLOG(3) << "Disabling Activity tracing for "
+                << GetActivityDomainOpName(domain, op);
+        RETURN_IF_ROCTRACER_ERROR(
+            se::wrap::roctracer_disable_op_activity(domain, op));
+      }
+    }
+  }
+
+  // TODO(rocm-profiler): this stopping mechanism needs improvement.
+  // Flush the activity buffer BEFORE setting the activity_tracing_enable_
+  // flag to FALSE. This is because the activity record callback routine is
+  // gated by the same flag
+  VLOG(3) << "Flushing roctracer activity buffer";
+  RETURN_IF_ROCTRACER_ERROR(se::wrap::roctracer_flush_activity_expl(nullptr));
+  // roctracer_flush_buf();
+
+  // Explicitly wait for (almost) all pending activity records
+  // The choice of all of the following is based what seemed to work
+  // best when enabling tracing on a large testcase (BERT)
+  // * 100 ms as the initial sleep duration AND
+  // * 1 as the initial threshold value
+  // * 6 as the maximum number of iterations
+  int duration_ms = 100;
+  size_t threshold = 1;
+  for (int i = 0; i < 6; i++, duration_ms *= 2, threshold *= 2) {
+    if (GetPendingActivityRecordsCount() < threshold) break;
+    VLOG(3) << "Wait for pending activity records :"
+            << " Pending count = " << GetPendingActivityRecordsCount()
+            << ", Threshold = " << threshold;
+    VLOG(3) << "Wait for pending activity records : sleep for " << duration_ms
+            << " ms";
+    tsl::profiler::SleepForMillis(duration_ms);
+  }
+  ClearPendingActivityRecordsCount();
+
+  activity_tracing_enabled_ = false;
+
+  return absl::OkStatus();
+}
+
+/*static*/ uint64_t RocmTracer::GetTimestamp() {
+  uint64_t ts;
+  if (se::wrap::roctracer_get_timestamp(&ts) != ROCTRACER_STATUS_SUCCESS) {
+    const char* errstr = se::wrap::roctracer_error_string();
+    LOG(ERROR) << "function roctracer_get_timestamp failed with error "
+               << errstr;
+    // Return 0 on error.
+    return 0;
+  }
+  return ts;
+}
+
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_tracer_v1.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_v1.h
@@ -1,0 +1,222 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_V1_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_V1_H_
+
+#include <optional>
+
+#include "absl/container/fixed_array.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/container/node_hash_set.h"
+#include "xla/backends/profiler/gpu/rocm_collector.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "xla/stream_executor/rocm/roctracer_wrapper.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/macros.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/types.h"
+
+namespace xla {
+namespace profiler {
+
+enum class RocmTracerSyncTypes {
+  InvalidSync = 0,
+  StreamSynchronize,  // caller thread wait stream to become empty
+  EventSynchronize,   // caller thread will block until event happens
+  StreamWait          // compute stream will wait for event to happen
+};
+
+struct RocmTracerOptions {
+  std::set<uint32_t> api_tracking_set;  // actual api set we want to profile
+
+  // map of domain --> ops for which we need to enable the API callbacks
+  // If the ops vector is empty, then enable API callbacks for entire domain
+  absl::flat_hash_map<activity_domain_t, std::vector<uint32_t> > api_callbacks;
+
+  // map of domain --> ops for which we need to enable the Activity records
+  // If the ops vector is empty, then enable Activity records for entire domain
+  absl::flat_hash_map<activity_domain_t, std::vector<uint32_t> >
+      activity_tracing;
+};
+
+class RocmTracer;
+
+class RocmApiCallbackImpl {
+ public:
+  RocmApiCallbackImpl(const RocmTracerOptions& options, RocmTracer* tracer,
+                      RocmTraceCollector* collector)
+      : options_(options), tracer_(tracer), collector_(collector) {}
+
+  absl::Status operator()(uint32_t domain, uint32_t cbid, const void* cbdata);
+
+ private:
+  void AddKernelEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
+                                 uint64_t enter_time, uint64_t exit_time);
+  void AddNormalMemcpyEventUponApiExit(uint32_t cbid,
+                                       const hip_api_data_t* data,
+                                       uint64_t enter_time, uint64_t exit_time);
+  void AddMemcpyPeerEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
+                                     uint64_t enter_time, uint64_t exit_time);
+  void AddMemsetEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
+                                 uint64_t enter_time, uint64_t exit_time);
+  void AddMallocFreeEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
+                                     uint32_t device_id, uint64_t enter_time,
+                                     uint64_t exit_time);
+  void AddStreamSynchronizeEventUponApiExit(uint32_t cbid,
+                                            const hip_api_data_t* data,
+                                            uint64_t enter_time,
+                                            uint64_t exit_time);
+  void AddSynchronizeEventUponApiExit(uint32_t cbid, const hip_api_data_t* data,
+                                      uint64_t enter_time, uint64_t exit_time);
+
+  RocmTracerOptions options_;
+  RocmTracer* tracer_ = nullptr;
+  RocmTraceCollector* collector_ = nullptr;
+  // tsl::mutex api_call_start_mutex_;
+  absl::Mutex api_call_start_mutex_;
+  // TODO(rocm-profiler): replace this with absl hashmap
+  // keep a map from the corr. id to enter time for API callbacks.
+  // std::map<uint32_t, uint64_t> api_call_start_time_
+  // TF_GUARDED_BY(api_call_start_mutex_);
+  std::map<uint32_t, uint64_t> api_call_start_time_
+      ABSL_GUARDED_BY(api_call_start_mutex_);
+};
+
+class RocmActivityCallbackImpl {
+ public:
+  RocmActivityCallbackImpl(const RocmTracerOptions& options, RocmTracer* tracer,
+                           RocmTraceCollector* collector)
+      : options_(options), tracer_(tracer), collector_(collector) {}
+
+  absl::Status operator()(const char* begin, const char* end);
+
+ private:
+  void AddHipKernelActivityEvent(const roctracer_record_t* record);
+  void AddNormalHipMemcpyActivityEvent(const roctracer_record_t* record);
+  void AddHipMemsetActivityEvent(const roctracer_record_t* record);
+  void AddHipMallocActivityEvent(const roctracer_record_t* record);
+  void AddHipStreamSynchronizeActivityEvent(const roctracer_record_t* record);
+  void AddHccKernelActivityEvent(const roctracer_record_t* record);
+  void AddNormalHipOpsMemcpyActivityEvent(const roctracer_record_t* record);
+  void AddHipOpsMemsetActivityEvent(const roctracer_record_t* record);
+  RocmTracerOptions options_;
+  RocmTracer* tracer_ = nullptr;
+  RocmTraceCollector* collector_ = nullptr;
+};
+
+// The class uses roctracer callback/activity API and forward the collected
+// trace events to RocmTraceCollector. There should be only one RocmTracer
+// per process.
+class RocmTracer {
+ public:
+  // Returns a pointer to singleton RocmTracer.
+  static RocmTracer& GetRocmTracerSingleton();
+
+  // Only one profile session can be live in the same time.
+  bool IsAvailable() const;
+
+  void Enable(const RocmTracerOptions& options, RocmTraceCollector* collector);
+  void Disable();
+
+  absl::Status ApiCallbackHandler(uint32_t domain, uint32_t cbid,
+                                  const void* cbdata);
+  absl::Status ActivityCallbackHandler(const char* begin, const char* end);
+
+  static uint64_t GetTimestamp();
+  static int NumGpus();
+
+  void AddToPendingActivityRecords(uint32_t correlation_id) {
+    pending_activity_records_.Add(correlation_id);
+  }
+
+  void RemoveFromPendingActivityRecords(uint32_t correlation_id) {
+    pending_activity_records_.Remove(correlation_id);
+  }
+
+  void ClearPendingActivityRecordsCount() { pending_activity_records_.Clear(); }
+
+  size_t GetPendingActivityRecordsCount() {
+    return pending_activity_records_.Count();
+  }
+
+  profiler::AnnotationMap* annotation_map() { return &annotation_map_; }
+
+ protected:
+  // protected constructor for injecting mock cupti interface for testing.
+  explicit RocmTracer() : num_gpus_(NumGpus()) {}
+
+ private:
+  absl::Status EnableApiTracing();
+  absl::Status DisableApiTracing();
+
+  absl::Status EnableActivityTracing();
+  absl::Status DisableActivityTracing();
+
+  int num_gpus_;
+  std::optional<RocmTracerOptions> options_;
+  RocmTraceCollector* collector_ = nullptr;
+
+  bool api_tracing_enabled_ = false;
+  bool activity_tracing_enabled_ = false;
+
+  RocmApiCallbackImpl* api_cb_impl_;
+  RocmActivityCallbackImpl* activity_cb_impl_;
+
+  profiler::AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
+
+  class PendingActivityRecords {
+   public:
+    // add a correlation id to the pending set
+    void Add(uint32_t correlation_id) {
+      absl::MutexLock lock(&mutex);
+      pending_set.insert(correlation_id);
+    }
+    // remove a correlation id from the pending set
+    void Remove(uint32_t correlation_id) {
+      absl::MutexLock lock(&mutex);
+      pending_set.erase(correlation_id);
+    }
+    // clear the pending set
+    void Clear() {
+      absl::MutexLock lock(&mutex);
+      pending_set.clear();
+    }
+    // count the number of correlation ids in the pending set
+    size_t Count() {
+      absl::MutexLock lock(&mutex);
+      return pending_set.size();
+    }
+
+   private:
+    // set of co-relation ids for which the hcc activity record is pending
+    absl::flat_hash_set<uint32_t> pending_set;
+    // the callback which processes the activity records (and consequently
+    // removes items from the pending set) is called in a separate thread
+    // from the one that adds item to the list.
+    absl::Mutex mutex;
+  };
+  PendingActivityRecords pending_activity_records_;
+
+ public:
+  // Disable copy and move.
+  RocmTracer(const RocmTracer&) = delete;
+  RocmTracer& operator=(const RocmTracer&) = delete;
+};
+
+}  // namespace profiler
+}  // namespace xla
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_V1_H_

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -105,7 +105,8 @@ absl::StatusOr<std::vector<RepeatedFlagModifier>> ParseRepeatedEnumModifiers(
 namespace {
 
 template <typename T>
-static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list, T value) {
+static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list,
+                                   T value) {
   for (auto it = list->begin(); it != list->end(); ++it) {
     if (*it == value) {
       return it;
@@ -329,7 +330,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
       DebugOptions::PARTITIONING_ALGORITHM_NOOP);
 
   opts.set_xla_gpu_enable_triton_gemm(true);
-  opts.set_xla_gpu_unsupported_enable_triton_multi_output_fusion(true);
+  opts.set_xla_gpu_unsupported_enable_triton_multi_output_fusion(false);
   opts.set_xla_gpu_enable_cudnn_int8x32_convolution_reordering(true);
   opts.set_xla_gpu_triton_gemm_any(true);
   opts.set_xla_gpu_verify_triton_fusion_numerics(false);
@@ -2841,6 +2842,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                 debug_options->xla_enable_hlo_sharding_v3(),
                 "If true, use HloShardingV3 which is a mesh and axis based "
                 "sharding representation."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_rocm_max_trace_events",
+      int64_setter_for(&DebugOptions::set_xla_gpu_rocm_max_trace_events),
+      debug_options->xla_gpu_rocm_max_trace_events(),
+      "Maximum number of ROCm trace events (applies to callback/activity/"
+      "annotation). Set as high as memory allows; up to 1e9."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_enable_checksum_tracing_on_thunks",
       bool_setter_for(

--- a/xla/stream_executor/rocm/roctracer_wrapper.h
+++ b/xla/stream_executor/rocm/roctracer_wrapper.h
@@ -21,14 +21,101 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_ROCM_ROCTRACER_WRAPPER_H_
 #define XLA_STREAM_EXECUTOR_ROCM_ROCTRACER_WRAPPER_H_
 
-#include "rocm/include/rocprofiler-sdk/buffer.h"  // IWYU pragma: export
-#include "rocm/include/rocprofiler-sdk/buffer_tracing.h"  // IWYU pragma: export
-#include "rocm/include/rocprofiler-sdk/callback_tracing.h"  // IWYU pragma: export
-#include "rocm/include/rocprofiler-sdk/cxx/name_info.hpp"  // IWYU pragma: export
-#include "rocm/include/rocprofiler-sdk/external_correlation.h"  // IWYU pragma: export
-#include "rocm/include/rocprofiler-sdk/fwd.h"  // IWYU pragma: export
-#include "rocm/include/rocprofiler-sdk/internal_threading.h"  // IWYU pragma: export
-#include "rocm/include/rocprofiler-sdk/registration.h"  // IWYU pragma: export
-#include "rocm/include/rocprofiler-sdk/rocprofiler.h"  // IWYU pragma: export
+#include "rocm/rocm_config.h"
+
+// ROCm >=6.3
+#include <rocm/include/rocprofiler-sdk/buffer.h>
+#include <rocm/include/rocprofiler-sdk/buffer_tracing.h>
+#include <rocm/include/rocprofiler-sdk/callback_tracing.h>
+#include <rocm/include/rocprofiler-sdk/cxx/name_info.hpp>
+#include <rocm/include/rocprofiler-sdk/external_correlation.h>
+#include <rocm/include/rocprofiler-sdk/fwd.h>
+#include <rocm/include/rocprofiler-sdk/internal_threading.h>
+#include <rocm/include/rocprofiler-sdk/registration.h>
+#include <rocm/include/rocprofiler-sdk/rocprofiler.h>
+
+// ROCm < 6.3
+#include "rocm/include/roctracer/roctracer.h"
+#include "rocm/include/roctracer/roctracer_hip.h"
+#include "rocm/include/roctracer/roctracer_roctx.h"
+#include "tsl/platform/dso_loader.h"
+#include "tsl/platform/env.h"
+#include "tsl/platform/platform.h"
+
+namespace stream_executor {
+namespace wrap {
+
+#ifdef PLATFORM_GOOGLE
+
+#define ROCTRACER_API_WRAPPER(API_NAME)                            \
+  template <typename... Args>                                      \
+  auto API_NAME(Args... args) -> decltype((::API_NAME)(args...)) { \
+    return (::API_NAME)(args...);                                  \
+  }
+
+#else
+
+#define ROCTRACER_API_WRAPPER(API_NAME)                                    \
+  template <typename... Args>                                              \
+  auto API_NAME(Args... args) -> decltype(::API_NAME(args...)) {           \
+    using FuncPtrT = std::add_pointer<decltype(::API_NAME)>::type;         \
+    static FuncPtrT loaded = []() -> FuncPtrT {                            \
+      static const char* kName = #API_NAME;                                \
+      void* f;                                                             \
+      auto s = tsl::Env::Default() -> GetSymbolFromLibrary(                \
+          tsl::internal::CachedDsoLoader::GetRoctracerDsoHandle().value(), \
+          kName, &f);                                                      \
+      CHECK(s.ok()) << "could not find " << kName                          \
+                    << " in roctracer DSO; dlerror: " << s.message();      \
+      return reinterpret_cast<FuncPtrT>(f);                                \
+    }();                                                                   \
+    return loaded(args...);                                                \
+  }
+
+#endif  // PLATFORM_GOOGLE
+
+#if TF_ROCM_VERSION >= 50300
+#define FOREACH_ROCTRACER_API(DO_FUNC)           \
+  DO_FUNC(roctracer_default_pool_expl)           \
+  DO_FUNC(roctracer_disable_domain_activity)     \
+  DO_FUNC(roctracer_disable_domain_callback)     \
+  DO_FUNC(roctracer_disable_op_activity)         \
+  DO_FUNC(roctracer_disable_op_callback)         \
+  DO_FUNC(roctracer_enable_domain_activity_expl) \
+  DO_FUNC(roctracer_enable_domain_callback)      \
+  DO_FUNC(roctracer_enable_op_activity_expl)     \
+  DO_FUNC(roctracer_enable_op_callback)          \
+  DO_FUNC(roctracer_error_string)                \
+  DO_FUNC(roctracer_flush_activity_expl)         \
+  DO_FUNC(roctracer_get_timestamp)               \
+  DO_FUNC(roctracer_op_string)                   \
+  DO_FUNC(roctracer_open_pool_expl)              \
+  DO_FUNC(roctracer_set_properties)              \
+  DO_FUNC(roctracer_next_record)
+#else
+#define FOREACH_ROCTRACER_API(DO_FUNC)           \
+  DO_FUNC(roctracer_default_pool_expl)           \
+  DO_FUNC(roctracer_disable_domain_activity)     \
+  DO_FUNC(roctracer_disable_domain_callback)     \
+  DO_FUNC(roctracer_disable_op_activity)         \
+  DO_FUNC(roctracer_disable_op_callback)         \
+  DO_FUNC(roctracer_enable_domain_activity_expl) \
+  DO_FUNC(roctracer_enable_domain_callback)      \
+  DO_FUNC(roctracer_enable_op_activity_expl)     \
+  DO_FUNC(roctracer_enable_op_callback)          \
+  DO_FUNC(roctracer_error_string)                \
+  DO_FUNC(roctracer_flush_activity_expl)         \
+  DO_FUNC(roctracer_get_timestamp)               \
+  DO_FUNC(roctracer_op_string)                   \
+  DO_FUNC(roctracer_open_pool_expl)              \
+  DO_FUNC(roctracer_set_properties)
+#endif
+FOREACH_ROCTRACER_API(ROCTRACER_API_WRAPPER)
+
+#undef FOREACH_ROCTRACER_API
+#undef ROCTRACER_API_WRAPPER
+
+}  // namespace wrap
+}  // namespace stream_executor
 
 #endif  // XLA_STREAM_EXECUTOR_ROCM_ROCTRACER_WRAPPER_H_


### PR DESCRIPTION
## Motivation

Add rocprofiler-sdk (v3) profiler integration with roctracer (v1) fallback and Fix roctracer (v1) profiler build 

## Technical Details

Integrates **rocprofiler-sdk (v3)** as the default ROCm profiler backend in XLA, while keeping **roctracer (v1)** as a compile-time fallback for environments where rocprofiler-sdk is unavailable. Also fixes a v1 build break introduced by v3-only APIs that leaked through the shared code path.


**1. `530b8e8` — Add rocprofiler-sdk (v3) integration with roctracer fallback** (`cj401-amd <chunyjin@amd.com>`)
Introduces the rocprofiler-sdk (v3) tracer path alongside the existing roctracer (v1) implementation. The two backends are mutually-exclusive compile-time options, selected by `XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V3` / `_V1`. v3 is the default; v1 remains available for fallback.
**2. `3c291b1` — [ROCm] Fix roctracer (v1) profiler build for rocm-jaxlib-v0.8.2** (cherry-picked from [ROCm/xla#795](https://github.com/ROCm/xla/pull/795), original author `magaonka <magaonka@amd.com>`, upstream SHA `ecb43ed`)
The v3 integration added `RocmTracer::GpuAgents()` and a matching test that only exist on the rocprofiler-sdk (v3) backend. The roctracer (v1) backend does not expose these APIs, which broke `//pjrt/tools:build_gpu_plugin_wheel` when built with `--define=xla_rocm_profiler=v1`.
This commit guards:
- the v3-only `SetGpuAgents(rocm_tracer_->GpuAgents())` call in `xla/backends/profiler/gpu/device_tracer_rocm.cc`, and
- the entire v3-only test file `xla/backends/profiler/gpu/rocm_tracer_test.cc`
with `#if XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V3`. `SetGpuAgents()` is a no-op on the base `RocmTraceCollector`, so the v1 path preserves pre-cherrypick behavior.


## Test Plan

Run XLA CI and build JAX wheels and run UT suite.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
