### PR TITLE
[rocm-jaxlib-v0.9.1] Apply missing patches for CI benchmarks

### DIFF
--- a/.github/workflows/generate_benchmark_matrix.yml
+++ b/.github/workflows/generate_benchmark_matrix.yml
@@ -44,7 +44,7 @@ jobs:
   generate:
     name: Generate Matrix (${{ inputs.workflow_type }})
     runs-on: linux-mi250-4
-    container: rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa
+    container: ${{ vars.DOCKER_IMAGE }}
     outputs:
       matrix_json_output: ${{ steps.run_generator.outputs.matrix_json }}
     defaults:

--- a/.github/workflows/postsubmit_benchmark.yml
+++ b/.github/workflows/postsubmit_benchmark.yml
@@ -147,6 +147,15 @@ jobs:
           ref: ${{ env.CHECKOUT_REF }}
           persist-credentials: false
 
+      - name: Get RBE cluster keys
+        env:
+          RBE_CI_CERT: ${{ secrets.RBE_CI_CERT }}
+          RBE_CI_KEY: ${{ secrets.RBE_CI_KEY }}
+        run: |
+          mkdir -p /tf/certificates
+          echo "$RBE_CI_CERT" > /tf/certificates/ci-cert.crt
+          echo "$RBE_CI_KEY" > /tf/certificates/ci-cert.key
+
       - name: Build Binaries
         id: build_binaries
         run: |

--- a/build_tools/ci/build.py
+++ b/build_tools/ci/build.py
@@ -716,6 +716,7 @@ Build(
            "tensorflow-build@sha256:"
            "66eb4c1e39db76fae2eb0a1029490acbe7bfce0e00d6ab435e170f743921f4c4"
     },
+    startup_options={"bazelrc": "build_tools/rocm/rocm_xla.bazelrc"},
     subcommand="build",
 )
 

--- a/build_tools/ci/build.py
+++ b/build_tools/ci/build.py
@@ -714,7 +714,7 @@ Build(
         "TF_ROCM_AMDGPU_TARGETS": "gfx90a",
         "TF_ROCM_RBE_DOCKER_IMAGE": "rocm/"
            "tensorflow-build@sha256:"
-           "7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa"
+           "66eb4c1e39db76fae2eb0a1029490acbe7bfce0e00d6ab435e170f743921f4c4"
     },
     subcommand="build",
 )

--- a/build_tools/ci/build.py
+++ b/build_tools/ci/build.py
@@ -714,7 +714,7 @@ Build(
     },
     repo_env={
         "TF_ROCM_AMDGPU_TARGETS": "gfx90a",
-        "TF_ROCM_RBE_DOCKER_IMAGE": "rocm/"
+        "TF_ROCM_RBE_DOCKER_IMAGE": "rocm/" # rocm/tensorflow-build:latest-jammy-pythonall-rocm7.2.1-ci_official
            "tensorflow-build@sha256:"
            "66eb4c1e39db76fae2eb0a1029490acbe7bfce0e00d6ab435e170f743921f4c4"
     },

--- a/build_tools/ci/build.py
+++ b/build_tools/ci/build.py
@@ -708,6 +708,7 @@ Build(
     options={
         "run_under": "//build_tools/ci:parallel_gpu_execute",
         "//xla/tsl:ci_build": True,
+        "remote_download_toplevel": True,  # Override remote_download_minimal from rocm_rbe
         **_DEFAULT_BAZEL_OPTIONS,
     },
     repo_env={

--- a/build_tools/ci/build.py
+++ b/build_tools/ci/build.py
@@ -709,6 +709,7 @@ Build(
         "run_under": "//build_tools/ci:parallel_gpu_execute",
         "//xla/tsl:ci_build": True,
         "remote_download_toplevel": True,  # Override remote_download_minimal from rocm_rbe
+        "spawn_strategy": "local",
         **_DEFAULT_BAZEL_OPTIONS,
     },
     repo_env={

--- a/build_tools/ci/build.py
+++ b/build_tools/ci/build.py
@@ -701,7 +701,7 @@ Build(
 Build(
     type_=BuildType.XLA_LINUX_X86_GPU_ROCM_BENCHMARK_PRESUBMIT_GITHUB_ACTIONS,
     repo="openxla/xla",
-    configs=("rocm_ci",),
+    configs=("rocm_ci", "rocm_rbe"),
     target_patterns=_XLA_GPU_PRESUBMIT_BENCHMARKS_DEFAULT_TARGET_PATTERNS,
     test_tag_filters=rocm_tag_filters,
     build_tag_filters=rocm_tag_filters,
@@ -712,6 +712,9 @@ Build(
     },
     repo_env={
         "TF_ROCM_AMDGPU_TARGETS": "gfx90a",
+        "TF_ROCM_RBE_DOCKER_IMAGE": "rocm/"
+           "tensorflow-build@sha256:"
+           "7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa"
     },
     subcommand="build",
 )

--- a/xla/tools/benchmarks/registries/default_registry.yml
+++ b/xla/tools/benchmarks/registries/default_registry.yml
@@ -30,7 +30,7 @@ benchmarks: [
       topology: { num_hosts: 1, num_devices_per_host: 1, multi_host: false, multi_device: false }
       target_metrics: [GPU_DEVICE_TIME, GPU_DEVICE_MEMCPY_TIME]
       workflow_type: [POSTSUBMIT]
-      runtime_flags: ["--num_repeats=5", "--hlo_argument_mode=uninitialized"]
+      runtime_flags: ["--num_repeats=5"]
     }]
     update_frequency_policy: QUARTERLY
   },
@@ -48,7 +48,7 @@ benchmarks: [
       topology: { num_hosts: 1, num_devices_per_host: 1, multi_host: false, multi_device: false }
       target_metrics: [GPU_DEVICE_TIME, GPU_DEVICE_MEMCPY_TIME]
       workflow_type: [POSTSUBMIT]
-      runtime_flags: ["--num_repeats=5", "--hlo_argument_mode=uninitialized"]
+      runtime_flags: ["--num_repeats=5"]
       xla_compilation_flags: ["--xla_gpu_enable_command_buffer="]
     }]
     update_frequency_policy: QUARTERLY

--- a/xla/tools/benchmarks/registries/default_registry.yml
+++ b/xla/tools/benchmarks/registries/default_registry.yml
@@ -49,7 +49,6 @@ benchmarks: [
       target_metrics: [GPU_DEVICE_TIME, GPU_DEVICE_MEMCPY_TIME]
       workflow_type: [POSTSUBMIT]
       runtime_flags: ["--num_repeats=5"]
-      xla_compilation_flags: ["--xla_gpu_enable_command_buffer="]
     }]
     update_frequency_policy: QUARTERLY
     # TODO(juliagmt): remove this label once the benchmark is stable.

--- a/xla/tools/benchmarks/utils/generate_benchmark_matrices.cc
+++ b/xla/tools/benchmarks/utils/generate_benchmark_matrices.cc
@@ -130,7 +130,7 @@ GetHardwareToContainerImage() {
           {"GPU_MI250",
            "rocm/"
            "tensorflow-build@sha256:"
-           "7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa"},
+           "66eb4c1e39db76fae2eb0a1029490acbe7bfce0e00d6ab435e170f743921f4c4"},
       };
   return *kHardwareToContainerImage;
 }


### PR DESCRIPTION
## Motivation

Cherry picking changes requested in this PR for `v0.9.0`  version https://github.com/ROCm/xla/pull/761

## Technical Details

- Enabled RBE 
- Unset hlo argument mode for all benchmarks
- Removed now unnecessary compilation flag for `gemma2`
- Using new Docker image

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
