### PR TITLE
[ROCm] Fix leading comma in feature string from GetFeatureStrFromGCNA…

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/amdgpu_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/amdgpu_backend.cc
@@ -717,7 +717,8 @@ std::pair<std::string, std::string> GetFeatureStrFromGCNArchName(
     // The rest of the tokens are the feature/targetid strings
     auto mapped_token = MapGCNArchNameTokenToFeatureStr(tokens[i], gfx);
     if (!mapped_token.empty()) {
-      mapped_tokens += "," + mapped_token;
+      if (!mapped_tokens.empty()) mapped_tokens += ",";
+      mapped_tokens += mapped_token;
     }
   }
   return std::pair{gfx, mapped_tokens};


### PR DESCRIPTION
…rchName

The refactor in PR #38613 (ab29f26200) changed the loop to prepend a comma on every non-empty mapped token. For arch names with feature suffixes (e.g. gfx950:sramecc+:xnack-), this produces ",+sramecc,-xnack" instead of "+sramecc,-xnack".

Older LLVM silently tolerated the leading empty feature; LLVM at or after 19463aab0271572a3e9e2f45ec21014553241c05 (pulled into XLA on 2026-04-22 by commit f92ee5a67d) no longer tolerates it and segfaults inside MCSubtargetInfo::checkFeatures while constructing an AMDGPUTargetMachine for gfx950.

Reproduces on AMD Instinct MI355X (gfx950:sramecc+:xnack-) with any ROCm plugin/PJRT wheel built from an XLA commit >= f92ee5a67d, e.g. every ROCm nightly since 2026-04-22 run 4782.

Fix: only prepend a comma when mapped_tokens is non-empty, matching the pre-refactor absl::StrJoin behavior.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
