### PR TITLE
Add keep_going option to CI build script

### DIFF
--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -68,6 +68,7 @@ done
         echo "${EXCLUDED_TESTS[*]}"
     ) \
     --cache_test_results=yes \
+    --keep_going \
     -- \
     //xla/... \
     -//xla/backends/gpu/tests:sorting.hlo.test_mi200 \


### PR DESCRIPTION
Keep going to show the whole list of failed tests