### PR TITLE
[RocM] Preserve last-writer-wins for maybe_live_out aliases in command…

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -3896,6 +3896,8 @@ cc_library(
         "//xla:util",
         "//xla/ffi:ffi_api",
         "//xla/hlo/ir:hlo",
+        "//xla/runtime:buffer_use",
+        "//xla/service:buffer_assignment",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:semantic_version",
         "//xla/tsl/platform:errors",

--- a/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
+++ b/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
@@ -49,6 +49,8 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/while_thunk.h"
 #include "xla/ffi/ffi_api.h"
 #include "xla/hlo/ir/hlo_module.h"
+#include "xla/runtime/buffer_use.h"
+#include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/semantic_version.h"
 #include "xla/tsl/platform/errors.h"
@@ -477,6 +479,71 @@ std::string CommandBufferConversionPass::CommandBufferConfig::ToString() const {
   return absl::StrCat("enabled_commands: [", cmd_names, "]");
 }
 
+// Configuration for the live-out alias-split logic in
+// CommandBufferConversionPass::Run().
+//
+//   XLA_GPU_CMDBUF_SPLIT_ON_LIVE_OUT_ALIAS = "1" (default) | "0"
+//
+// When enabled, the conversion pass tracks the set of `maybe_live_out`
+// BufferAllocation::Index values that the current command-buffer chunk
+// has already written.  Before adding a new thunk to the chunk, if any
+// of the thunk's write targets would re-write a `maybe_live_out` index
+// already in the set, the current chunk is flushed first and the new
+// thunk starts a fresh chunk.  Each command buffer then writes any
+// given `maybe_live_out` allocation by at most one thunk, preserving
+// HLO last-writer-wins semantics for output allocations across
+// command-buffer boundaries.
+//
+// Background: HLO buffer assignment may alias multiple writers to the
+// same allocation when that allocation is `maybe_live_out`, because
+// under the serial HLO schedule only the last writer's value is
+// observable.  When all such writers are captured into a single
+// command buffer, the buffer holds the aliased virtual address for
+// the entire graph duration, which can let consumers observe
+// intermediate alias content instead of the HLO-defined last-writer
+// value.  Splitting the chunk inserts a graph boundary between
+// writers so each output allocation has at most one writer per graph,
+// restoring the expected publication semantics through the standard
+// inter-graph stream barrier.
+class LiveOutAliasSplit {
+ public:
+  static const LiveOutAliasSplit& Get() {
+    static LiveOutAliasSplit* f = new LiveOutAliasSplit();
+    return *f;
+  }
+  bool enabled() const { return enabled_; }
+
+ private:
+  LiveOutAliasSplit() {
+    const char* e = std::getenv("XLA_GPU_CMDBUF_SPLIT_ON_LIVE_OUT_ALIAS");
+    if (e == nullptr || e[0] == '\0') {
+      // Default: enabled.  Set the env to "0" to disable.
+      enabled_ = true;
+      return;
+    }
+    enabled_ = (e[0] != '0');
+  }
+  bool enabled_ = true;
+};
+
+// Returns the set of `maybe_live_out` BufferAllocation::Index values
+// that `thunk` writes to.  Returns an empty set when none of the
+// thunk's writes target a `maybe_live_out` allocation.  Used by the
+// live-out alias-split logic in Run() to decide whether two thunks in
+// the same command-buffer chunk would rewrite the same allocation.
+absl::flat_hash_set<BufferAllocation::Index> CollectLiveOutWriteIndices(
+    const Thunk& thunk) {
+  absl::flat_hash_set<BufferAllocation::Index> out;
+  for (const BufferUse& use : thunk.buffer_uses()) {
+    if (use.access() == BufferUse::MemoryAccess::kRead) continue;
+    const BufferAllocation* alloc = use.slice().allocation();
+    if (alloc == nullptr) continue;
+    if (!alloc->maybe_live_out()) continue;
+    out.insert(use.slice().index());
+  }
+  return out;
+}
+
 absl::StatusOr<bool> CommandBufferConversionPass::Run(
     SequentialThunk* root_thunk, const DebugOptions& debug_options,
     const HloModule* absl_nullable hlo_module,
@@ -494,15 +561,59 @@ absl::StatusOr<bool> CommandBufferConversionPass::Run(
           debug_options.xla_gpu_command_buffer_scheduling_mode()));
 
   bool changed = false;
+  const bool live_out_split_enabled = LiveOutAliasSplit::Get().enabled();
 
   std::vector<std::unique_ptr<Thunk>> current_command_buffer_thunks;
+  // Tracks the `BufferAllocation::Index` of every `maybe_live_out`
+  // allocation written by some thunk already added to
+  // `current_command_buffer_thunks`.  Reset whenever a chunk is
+  // flushed.  See LiveOutAliasSplit for the rationale.
+  absl::flat_hash_set<BufferAllocation::Index> chunk_live_out_writes;
   std::vector<std::unique_ptr<Thunk>> new_thunks;
 
   auto flush_command_buffer = [&]() -> absl::Status {
+    chunk_live_out_writes.clear();
     return FlushCommandBuffer(synchronization_mode, debug_options,
                               current_command_buffer_thunks, new_thunks,
                               changed);
   };
+
+  // Returns true iff adding `incoming` (one thunk or a whole async
+  // region) to the current chunk would cause a `maybe_live_out`
+  // allocation to be written by both an earlier thunk in the chunk
+  // and one of these incoming thunks.  When that would happen,
+  // callers must flush the current chunk first so the new thunks land
+  // in a fresh chunk; the publication of the last writer's value is
+  // then provided by the inter-graph stream barrier rather than by
+  // intra-graph ordering of aliased writes.
+  auto would_alias_live_out =
+      [&](absl::Span<const std::unique_ptr<Thunk>> incoming) {
+        if (!live_out_split_enabled) return false;
+        for (const auto& th : incoming) {
+          auto idxs = CollectLiveOutWriteIndices(*th);
+          for (BufferAllocation::Index i : idxs) {
+            if (chunk_live_out_writes.contains(i)) {
+              VLOG(2) << "Splitting command buffer at thunk '"
+                      << th->thunk_info().profile_annotation
+                      << "': would re-write maybe_live_out allocation #"
+                      << i << " already written earlier in this chunk";
+              return true;
+            }
+          }
+        }
+        return false;
+      };
+
+  auto record_chunk_writes =
+      [&](absl::Span<const std::unique_ptr<Thunk>> incoming) {
+        if (!live_out_split_enabled) return;
+        for (const auto& th : incoming) {
+          auto idxs = CollectLiveOutWriteIndices(*th);
+          for (BufferAllocation::Index i : idxs) {
+            chunk_live_out_writes.insert(i);
+          }
+        }
+      };
 
   auto& original_thunks = root_thunk->thunks();
 
@@ -517,16 +628,31 @@ absl::StatusOr<bool> CommandBufferConversionPass::Run(
           absl::MakeSpan(original_thunks).subspan(i), config);
 
       if (!region.empty()) {
+        // Live-out alias-split applied to async regions atomically:
+        // either the whole region triggers a split, or none of it does.
+        // Async start/done pairs must remain in the same command buffer.
+        if (would_alias_live_out(region)) {
+          TF_RETURN_IF_ERROR(flush_command_buffer());
+        }
         // If a valid region is found, add the whole region to the current
         // sequence and continue processing.
         i += region.size() - 1;
+        record_chunk_writes(region);
         absl::c_move(region, std::back_inserter(current_command_buffer_thunks));
         continue;
       }
     } else if (IsConvertible(*thunk.get(), config) && !thunk->IsAsyncDone()) {
+      // If this thunk would re-write a `maybe_live_out` allocation
+      // already written earlier in the current chunk, close the chunk
+      // first.  See LiveOutAliasSplit for the rationale.
+      auto incoming_view = absl::MakeConstSpan(&thunk, 1);
+      if (would_alias_live_out(incoming_view)) {
+        TF_RETURN_IF_ERROR(flush_command_buffer());
+      }
       // Check if thunk is convertible and not an async done: async done thunks
       // can be only added to the current_command_buffer_thunks as part of a
       // valid async regions.
+      record_chunk_writes(incoming_view);
       current_command_buffer_thunks.push_back(std::move(thunk));
       continue;
     }


### PR DESCRIPTION
## Motivation

When the command-buffer conversion pass bundles consecutive convertible thunks
into a single HIP/CUDA graph, it currently does not consider whether two thunks
in the same chunk would write to the **same** `maybe_live_out` `BufferAllocation`.

HLO buffer assignment intentionally aliases multiple writers onto the same
`maybe_live_out` slot whenever it can prove that under the serial HLO schedule
only the **last** writer is observable (earlier writes are dead). That contract
is safe at the HLO level, but it leaks once those writers are captured into
**one graph**:

* The graph's underlying virtual address for the aliased slot stays "live" for
  the entire graph lifetime.
* PJRT's output-buffer event is recorded at the **end** of the graph; it does
  not order intra-graph intermediate states against external consumers.
* On multi-GPU, peer ranks performing collectives that touch that VA can
  observe an intermediate alias content (an earlier writer's output) instead
  of the HLO-defined last-writer value, producing wrong results downstream.

The single-stream / single-rank case is unaffected because the only consumer
is fenced by the graph's end-event.

## Technical Details

In `xla/backends/gpu/runtime/command_buffer_conversion_pass.cc`,
`CommandBufferConversionPass::Run`:

1. New helper `CollectLiveOutWriteIndices(thunk)` returns the subset of
   `thunk.buffer_uses()` that **write** to allocations marked
   `maybe_live_out()`.
2. New per-chunk set `chunk_live_out_writes` (cleared on every flush) tracks
   the union of those indices for thunks already added to the current chunk.
3. New lambda `would_alias_live_out(incoming)` returns `true` iff `incoming`
   would re-write any allocation already in the set.
4. Two call-sites in the main thunk-walk loop:
   * Single thunk path: if `would_alias_live_out` → `flush_command_buffer()`
     first, then add the thunk to the new (empty) chunk.
   * Async start/done region path: same check applied **atomically** to the
     whole region (start/done pairs must stay in the same chunk).
5. Configuration: `XLA_GPU_CMDBUF_SPLIT_ON_LIVE_OUT_ALIAS` (default `"1"`,
   set to `"0"` to disable). Default ON, so no opt-in is required.

After the split, every `maybe_live_out` allocation is written by **at most
one thunk** in any single command buffer. The standard inter-graph stream
barrier then publishes the correct last-writer value, matching HLO semantics.

Diff scope:

| File | Lines |
|---|---:|
| `xla/backends/gpu/runtime/command_buffer_conversion_pass.cc` | +126 / -0 |
| `xla/backends/gpu/runtime/BUILD` | +2 / -0 (`buffer_use`, `buffer_assignment` deps) |

No public API change. No header change. No effect on configurations where the
HLO has at most one `maybe_live_out` writer per chunk (the common case).

## Test Plan

Two-axis A/B/C on a 4-GPU correctness regression:

| arm | env | what it proves |
|---|---|---|
| `split_on` | (default) | Fix is active; correctness restored. |
| `split_off` | `XLA_GPU_CMDBUF_SPLIT_ON_LIVE_OUT_ALIAS=0` | Reverts to old behavior; previously-failing case must still fail. |
| `no_cmdbuf` | `--xla_gpu_enable_command_buffer=` | Control: cmd-buffers off entirely; correctness must hold. |

Plus a wall-clock perf comparison across the same three arms.

## Test Result

Correctness (multi-GPU, 50 trials total across arms):

| arm | trials | failed runs | sub-tests passed |
|---|---:|---:|---:|
| `split_on` (FIX, default)   | **30** | **0** | **16560 / 16560** |
| `split_off` (no fix)         | 20 | 5 (~25 %) | 9678 / 11040 |
| `no_cmdbuf` (workaround)     | 10 | 0 | 5520 / 5520 |

If the bug-OFF rate is ~25 %, P(0 failures in 30 trials) ≈ `(0.75)^30 ≈ 1.8e-4`.
The fix arm is statistically indistinguishable from "fully eliminated".

Performance (3 trials × 3 arms, wall-clock per pytest):

| arm | avg ms | Δ vs FIX |
|---|---:|---:|
| `split_on` (FIX)  | 309 243 | — |
| `split_off`       | 312 565 | +1.07 % |
| `no_cmdbuf`       | 310 993 | +0.57 % |

VLOG=2 audit confirms the split fires only on `maybe_live_out` allocations
(observed e.g. on indices `#0`, `#1`, `#14`, `#15` in the test workload) and
exactly between the writers that the buffer-assignment dump identifies as
aliased. Non-`maybe_live_out` allocations are never split on.

## Submission Checklist

- [x] Built with `-c opt --config=rocm` (gfx942), no warnings introduced.
- [x] No public API change; no behavior change on inputs with at most one
      `maybe_live_out` writer per chunk.
- [x] Default-ON env knob (`XLA_GPU_CMDBUF_SPLIT_ON_LIVE_OUT_ALIAS=0` reverts).
- [x] Followed contributing guidelines:
      <https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests>