### PR TITLE
[ROCm] Cherry-pick: [XLA:GPU] Insert ReshapeDecomposer before post-GemmRewriter LayoutNormalization

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1847,6 +1847,11 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
     // Rewrite GEMMs with broadcasted inputs as strided GEMMs.
     pipeline.AddPass<GemmBroadcastFoldingRewriter>();
 
+    // GemmRewriter pins "__cublas$lt$matmul" output layouts to {n-1,...,1,0},
+    // which can leave a downstream reshape no longer bitcast-compatible.
+    // Decompose any such reshape so LayoutNormalization's ReshapeIsBitcast
+    // precondition holds.
+    pipeline.AddPass<ReshapeDecomposer>();
     pipeline.AddPass<LayoutNormalization>(&NormalizeLayoutForGpuCustomCalls);
     // Remove any redundant operations (such as bitcasts) introduced by layout
     // normalization.
@@ -1917,6 +1922,11 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
   // Rewrite GEMMs with broadcasted inputs as strided GEMMs.
   pipeline.AddPass<GemmBroadcastFoldingRewriter>();
 
+  // GemmRewriter pins "__cublas$lt$matmul" output layouts to {n-1,...,1,0},
+  // which can leave a downstream reshape no longer bitcast-compatible.
+  // Decompose any such reshape so LayoutNormalization's ReshapeIsBitcast
+  // precondition holds.
+  pipeline.AddPass<ReshapeDecomposer>();
   pipeline.AddPass<LayoutNormalization>(&NormalizeLayoutForGpuCustomCalls);
 
   // Layout normalization will create scatters that are not simplified and


### PR DESCRIPTION
Cherry-pick of upstream [openxla/xla#41481](https://github.com/openxla/xla/pull/41481)
(copybara import on `openxla:main`: commit `788f26991b161ebe5bb7797815083b5d37246e69`).

---

## Original PR description

📝 **Summary of Changes**
Fix intermittent RET_CHECK in `xla/service/layout_normalization.cc:431` failure
hit by `jax.nn.dot_product_attention(impl='xla')` under multi-GPU pytest.

**Root cause:**
- When the autotuner picks hipBLASLt over Triton for a dot, GemmRewriter
  pins the `__cublas$lt$matmul` output to the canonical layout
  `{n-1, ..., 1, 0}`.
- Layout assignment had already planned the downstream reshape assuming
  a non-canonical layout, so after the pin the reshape is no longer a
  bitcast.
- LayoutNormalization then fails its `ShapeUtil::ReshapeIsBitcast`
  invariant and aborts.

**Fix:**
- Insert a `ReshapeDecomposer` pass before each post-GemmRewriter
  `LayoutNormalization` in `gpu_compiler.cc`.
- Any downstream non-bitcast reshape left behind by the layout pin is
  decomposed into transpose + bitcast, restoring the
  `ReshapeIsBitcast` invariant `LayoutNormalization` relies on.

Without this, many JAX tests fail intermittently with:
```
RET_CHECK failure in external/xla/xla/service/layout_normalization.cc:431
```
whenever autotuning flips the dot backend to hipBLASLt.

🚀 **Kind of Contribution**
🐛 Bug Fix
