### PR TITLE
Extend `collective_perf_table` tool to support more data types and 2D shapes for all-gather op

### DIFF
--- a/xla/tools/collective_perf_table_gen.cc
+++ b/xla/tools/collective_perf_table_gen.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xla/tools/collective_perf_table_gen.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -45,6 +46,7 @@ limitations under the License.
 #include "xla/hlo/utils/hlo_query.h"
 #include "xla/pjrt/pjrt_client.h"
 #include "xla/pjrt/plugin/xla_gpu/xla_gpu_client_options.h"
+#include "xla/primitive_util.h"
 #include "xla/service/backend.h"
 #include "xla/service/gpu/model/hlo_op_profile.pb.h"
 #include "xla/service/gpu/model/hlo_op_profiles.h"
@@ -61,24 +63,26 @@ namespace xla::gpu {
 
 namespace {
 
-// Helper function to get bytes per element for a given primitive type.
-int64_t GetBytesPerElement(PrimitiveType type) {
-  switch (type) {
+// Helper function to get the total number of elements for a given tensor size
+// and data type. This centralizes the handling of sub-byte types (S4/U4).
+int64_t GetElementCount(int64_t tensor_size_bytes, PrimitiveType data_type) {
+  switch (data_type) {
     case S4:
     case U4:
-      // 4-bit types: 2 elements per byte, so 0.5 bytes per element
-      // We return 1 and handle the special case in dimension calculations
-      return 1;
+      // 4-bit types: 2 elements per byte
+      return tensor_size_bytes * 2;
     case F8E4M3FN:
     case F8E5M2:
-      return 1;
+      return tensor_size_bytes;
     case F16:
     case BF16:
-      return 2;
+      CHECK_EQ(tensor_size_bytes % 2, 0);
+      return tensor_size_bytes / 2;
     case F32:
-      return 4;
+      CHECK_EQ(tensor_size_bytes % 4, 0);
+      return tensor_size_bytes / 4;
     default:
-      LOG(FATAL) << "Unsupported data type: " << PrimitiveType_Name(type);
+      LOG(FATAL) << "Unsupported data type: " << PrimitiveType_Name(data_type);
   }
 }
 
@@ -107,8 +111,8 @@ struct StaticSpec {
   // std::nullopt for others.
   std::optional<CollectivePermuteCostModelType> collective_permute_pattern;
   int64_t tensor_size_bytes;
-  PrimitiveType data_type;
-  bool use_2d_shape;  // Only applicable for all-gather
+  PrimitiveType data_type = F32;
+  bool use_2d_shape = false;  // Only applicable for all-gather
 };
 
 struct ExplicitSpec {
@@ -158,17 +162,8 @@ int64_t GetInputDim(CollectivePerfTableGen::CollectiveType type,
                     int64_t tensor_size_bytes,
                     IotaReplicaGroupList replica_groups,
                     PrimitiveType data_type) {
-  int64_t bytes_per_elem = GetBytesPerElement(data_type);
+  int64_t elements_total = GetElementCount(tensor_size_bytes, data_type);
   int64_t dim_size = -1;
-
-  // For 4-bit types (u4/s4), we have 2 elements per byte
-  int64_t elements_total = tensor_size_bytes;
-  if (data_type == S4 || data_type == U4) {
-    elements_total = tensor_size_bytes * 2;  // 2 elements per byte
-  } else {
-    CHECK_EQ(tensor_size_bytes % bytes_per_elem, 0);
-    elements_total = tensor_size_bytes / bytes_per_elem;
-  }
 
   switch (type) {
     case CollectivePerfTableGen::CollectiveType::ALL_REDUCE:
@@ -190,17 +185,8 @@ int64_t GetOutputDim(CollectivePerfTableGen::CollectiveType type,
                      int64_t tensor_size_bytes,
                      IotaReplicaGroupList replica_groups,
                      PrimitiveType data_type) {
-  int64_t bytes_per_elem = GetBytesPerElement(data_type);
+  int64_t elements_total = GetElementCount(tensor_size_bytes, data_type);
   int64_t dim_size = -1;
-
-  // For 4-bit types (u4/s4), we have 2 elements per byte
-  int64_t elements_total = tensor_size_bytes;
-  if (data_type == S4 || data_type == U4) {
-    elements_total = tensor_size_bytes * 2;  // 2 elements per byte
-  } else {
-    CHECK_EQ(tensor_size_bytes % bytes_per_elem, 0);
-    elements_total = tensor_size_bytes / bytes_per_elem;
-  }
 
   switch (type) {
     case CollectivePerfTableGen::CollectiveType::ALL_REDUCE:
@@ -218,6 +204,19 @@ int64_t GetOutputDim(CollectivePerfTableGen::CollectiveType type,
   return dim_size;
 }
 
+// Helper function to find the largest factor of n that is <= sqrt(n)
+// This ensures dim0 * dim1 == n exactly for 2D shape decomposition
+int64_t FindLargestFactorLessThanOrEqualSqrt(int64_t n) {
+  int64_t sqrt_n = static_cast<int64_t>(std::sqrt(n));
+  // Search downward from sqrt(n) to find the largest factor
+  for (int64_t candidate = sqrt_n; candidate >= 1; --candidate) {
+    if (n % candidate == 0) {
+      return candidate;
+    }
+  }
+  return 1;  // Fallback (should never happen for n > 0)
+}
+
 std::string GetHlo(
     CollectivePerfTableGen::CollectiveType type, int64_t input_dim,
     int64_t output_dim, const IotaReplicaGroupList& replica_groups,
@@ -226,33 +225,8 @@ std::string GetHlo(
   CHECK(type != CollectivePerfTableGen::CollectiveType::COLLECTIVE_PERMUTE ||
         collective_permute_pattern.has_value());
 
-  // Get the type string for HLO
-  std::string type_str;
-  switch (data_type) {
-    case S4:
-      type_str = "s4";
-      break;
-    case U4:
-      type_str = "u4";
-      break;
-    case F8E4M3FN:
-      type_str = "f8e4m3fn";
-      break;
-    case F8E5M2:
-      type_str = "f8e5m2";
-      break;
-    case F16:
-      type_str = "f16";
-      break;
-    case BF16:
-      type_str = "bf16";
-      break;
-    case F32:
-      type_str = "f32";
-      break;
-    default:
-      LOG(FATAL) << "Unsupported data type: " << PrimitiveType_Name(data_type);
-  }
+  // Get the type string for HLO using the utility function
+  std::string type_str = primitive_util::LowercasePrimitiveTypeName(data_type);
 
   // Get layout specification - use E(4) for u4/s4 types
   std::string layout_1d = RequiresPackedLayout(data_type) ? "{0:E(4)}" : "{0}";
@@ -282,10 +256,14 @@ std::string GetHlo(
       break;
     case CollectivePerfTableGen::CollectiveType::ALL_GATHER:
       if (use_2d_shape) {
-        // For 2D shapes, we need to compute appropriate dimensions
-        // We'll use a square-ish shape for simplicity
-        int64_t dim0 = static_cast<int64_t>(std::sqrt(input_dim));
+        // For 2D shapes, find the largest factor <= sqrt(input_dim)
+        // This ensures dim0 * dim1 == input_dim exactly (no truncation)
+        int64_t dim0 = FindLargestFactorLessThanOrEqualSqrt(input_dim);
         int64_t dim1 = input_dim / dim0;
+        // Verify the factorization is exact
+        CHECK_EQ(dim0 * dim1, input_dim)
+            << "2D shape decomposition failed: " << dim0 << " * " << dim1
+            << " != " << input_dim;
         int64_t out_dim0 = dim0 * replica_groups.num_devices_per_group();
         int64_t out_dim1 = dim1;
         hlo = absl::Substitute(R"(

--- a/xla/tools/collective_perf_table_gen.cc
+++ b/xla/tools/collective_perf_table_gen.cc
@@ -61,10 +61,31 @@ namespace xla::gpu {
 
 namespace {
 
-// Assume we're always issuing transfers for f32 data type. It should not
-// necessarily change the derating curve properties, yet the effects of compute
-// for e.g. all reduce are yet to be measured.
-constexpr uint8_t kBytesPerElem = 4;
+// Helper function to get bytes per element for a given primitive type.
+int64_t GetBytesPerElement(PrimitiveType type) {
+  switch (type) {
+    case S4:
+    case U4:
+      // 4-bit types: 2 elements per byte, so 0.5 bytes per element
+      // We return 1 and handle the special case in dimension calculations
+      return 1;
+    case F8E4M3FN:
+    case F8E5M2:
+      return 1;
+    case F16:
+    case BF16:
+      return 2;
+    case F32:
+      return 4;
+    default:
+      LOG(FATAL) << "Unsupported data type: " << PrimitiveType_Name(type);
+  }
+}
+
+// Helper function to check if a type requires special layout (E(4))
+bool RequiresPackedLayout(PrimitiveType type) {
+  return type == S4 || type == U4;
+}
 
 // Mem fraction dedicated to XLA buffers.
 constexpr double kGpuMemFraction = 0.8;
@@ -86,6 +107,8 @@ struct StaticSpec {
   // std::nullopt for others.
   std::optional<CollectivePermuteCostModelType> collective_permute_pattern;
   int64_t tensor_size_bytes;
+  PrimitiveType data_type;
+  bool use_2d_shape;  // Only applicable for all-gather
 };
 
 struct ExplicitSpec {
@@ -133,19 +156,29 @@ int64_t GetMedianRuntimeNs(const std::vector<ExecutionProfile>& profiles) {
 
 int64_t GetInputDim(CollectivePerfTableGen::CollectiveType type,
                     int64_t tensor_size_bytes,
-                    IotaReplicaGroupList replica_groups) {
+                    IotaReplicaGroupList replica_groups,
+                    PrimitiveType data_type) {
+  int64_t bytes_per_elem = GetBytesPerElement(data_type);
   int64_t dim_size = -1;
-  CHECK_EQ(tensor_size_bytes % kBytesPerElem, 0);
+
+  // For 4-bit types (u4/s4), we have 2 elements per byte
+  int64_t elements_total = tensor_size_bytes;
+  if (data_type == S4 || data_type == U4) {
+    elements_total = tensor_size_bytes * 2;  // 2 elements per byte
+  } else {
+    CHECK_EQ(tensor_size_bytes % bytes_per_elem, 0);
+    elements_total = tensor_size_bytes / bytes_per_elem;
+  }
+
   switch (type) {
     case CollectivePerfTableGen::CollectiveType::ALL_REDUCE:
     case CollectivePerfTableGen::CollectiveType::REDUCE_SCATTER:
     case CollectivePerfTableGen::CollectiveType::ALL_TO_ALL:
     case CollectivePerfTableGen::CollectiveType::COLLECTIVE_PERMUTE:
-      dim_size = tensor_size_bytes / kBytesPerElem;
+      dim_size = elements_total;
       break;
     case CollectivePerfTableGen::CollectiveType::ALL_GATHER:
-      dim_size = tensor_size_bytes /
-                 (kBytesPerElem * replica_groups.num_devices_per_group());
+      dim_size = elements_total / replica_groups.num_devices_per_group();
       break;
     default:
       LOG(FATAL) << "Unsupported collective type.";
@@ -155,19 +188,29 @@ int64_t GetInputDim(CollectivePerfTableGen::CollectiveType type,
 
 int64_t GetOutputDim(CollectivePerfTableGen::CollectiveType type,
                      int64_t tensor_size_bytes,
-                     IotaReplicaGroupList replica_groups) {
+                     IotaReplicaGroupList replica_groups,
+                     PrimitiveType data_type) {
+  int64_t bytes_per_elem = GetBytesPerElement(data_type);
   int64_t dim_size = -1;
-  CHECK_EQ(tensor_size_bytes % kBytesPerElem, 0);
+
+  // For 4-bit types (u4/s4), we have 2 elements per byte
+  int64_t elements_total = tensor_size_bytes;
+  if (data_type == S4 || data_type == U4) {
+    elements_total = tensor_size_bytes * 2;  // 2 elements per byte
+  } else {
+    CHECK_EQ(tensor_size_bytes % bytes_per_elem, 0);
+    elements_total = tensor_size_bytes / bytes_per_elem;
+  }
+
   switch (type) {
     case CollectivePerfTableGen::CollectiveType::ALL_REDUCE:
     case CollectivePerfTableGen::CollectiveType::ALL_GATHER:
     case CollectivePerfTableGen::CollectiveType::ALL_TO_ALL:
     case CollectivePerfTableGen::CollectiveType::COLLECTIVE_PERMUTE:
-      dim_size = tensor_size_bytes / kBytesPerElem;
+      dim_size = elements_total;
       break;
     case CollectivePerfTableGen::CollectiveType::REDUCE_SCATTER:
-      dim_size = tensor_size_bytes /
-                 (kBytesPerElem * replica_groups.num_devices_per_group());
+      dim_size = elements_total / replica_groups.num_devices_per_group();
       break;
     default:
       LOG(FATAL) << "Unsupported collective type.";
@@ -178,10 +221,43 @@ int64_t GetOutputDim(CollectivePerfTableGen::CollectiveType type,
 std::string GetHlo(
     CollectivePerfTableGen::CollectiveType type, int64_t input_dim,
     int64_t output_dim, const IotaReplicaGroupList& replica_groups,
-    std::optional<CollectivePermuteCostModelType> collective_permute_pattern) {
-  CHECK_EQ(kBytesPerElem, 4);
+    std::optional<CollectivePermuteCostModelType> collective_permute_pattern,
+    PrimitiveType data_type, bool use_2d_shape) {
   CHECK(type != CollectivePerfTableGen::CollectiveType::COLLECTIVE_PERMUTE ||
         collective_permute_pattern.has_value());
+
+  // Get the type string for HLO
+  std::string type_str;
+  switch (data_type) {
+    case S4:
+      type_str = "s4";
+      break;
+    case U4:
+      type_str = "u4";
+      break;
+    case F8E4M3FN:
+      type_str = "f8e4m3fn";
+      break;
+    case F8E5M2:
+      type_str = "f8e5m2";
+      break;
+    case F16:
+      type_str = "f16";
+      break;
+    case BF16:
+      type_str = "bf16";
+      break;
+    case F32:
+      type_str = "f32";
+      break;
+    default:
+      LOG(FATAL) << "Unsupported data type: " << PrimitiveType_Name(data_type);
+  }
+
+  // Get layout specification - use E(4) for u4/s4 types
+  std::string layout_1d = RequiresPackedLayout(data_type) ? "{0:E(4)}" : "{0}";
+  std::string layout_2d =
+      RequiresPackedLayout(data_type) ? "{1,0:E(4)}" : "{1,0}";
 
   std::string hlo;
   switch (type) {
@@ -190,8 +266,8 @@ std::string GetHlo(
         HloModule m
 
         add {
-          a = f32[] parameter(0)
-          b = f32[] parameter(1)
+          a = $0[] parameter(0)
+          b = $0[] parameter(1)
           ROOT res = add(a, b)
         }
 
@@ -201,29 +277,49 @@ std::string GetHlo(
             to_apply=add, use_global_device_ids=true, channel_id=1
         }
       )",
-                             "f32", input_dim, output_dim,
+                             type_str, input_dim, output_dim,
                              replica_groups.ToString());
       break;
     case CollectivePerfTableGen::CollectiveType::ALL_GATHER:
-      hlo = absl::Substitute(R"(
+      if (use_2d_shape) {
+        // For 2D shapes, we need to compute appropriate dimensions
+        // We'll use a square-ish shape for simplicity
+        int64_t dim0 = static_cast<int64_t>(std::sqrt(input_dim));
+        int64_t dim1 = input_dim / dim0;
+        int64_t out_dim0 = dim0 * replica_groups.num_devices_per_group();
+        int64_t out_dim1 = dim1;
+        hlo = absl::Substitute(R"(
         HloModule m
 
         ENTRY e {
-          p0 = $0[$1] parameter(0)
-          ROOT _ = $0[$2] all-gather(p0), replica_groups=$3,
+          p0 = $0[$1,$2]$6 parameter(0)
+          ROOT _ = $0[$3,$4]$6 all-gather(p0), replica_groups=$5,
             use_global_device_ids=true, channel_id=1, dimensions={0}
         }
       )",
-                             "f32", input_dim, output_dim,
-                             replica_groups.ToString());
+                               type_str, dim0, dim1, out_dim0, out_dim1,
+                               replica_groups.ToString(), layout_2d);
+      } else {
+        hlo = absl::Substitute(R"(
+        HloModule m
+
+        ENTRY e {
+          p0 = $0[$1]$4 parameter(0)
+          ROOT _ = $0[$2]$4 all-gather(p0), replica_groups=$3,
+            use_global_device_ids=true, channel_id=1, dimensions={0}
+        }
+      )",
+                               type_str, input_dim, output_dim,
+                               replica_groups.ToString(), layout_1d);
+      }
       break;
     case CollectivePerfTableGen::CollectiveType::REDUCE_SCATTER:
       hlo = absl::Substitute(R"(
         HloModule m
 
         add {
-          a = f32[] parameter(0)
-          b = f32[] parameter(1)
+          a = $0[] parameter(0)
+          b = $0[] parameter(1)
           ROOT res = add(a, b)
         }
 
@@ -234,7 +330,7 @@ std::string GetHlo(
             dimensions={0}
         }
       )",
-                             "f32", input_dim, output_dim,
+                             type_str, input_dim, output_dim,
                              replica_groups.ToString());
       break;
     case CollectivePerfTableGen::CollectiveType::ALL_TO_ALL:
@@ -247,7 +343,7 @@ std::string GetHlo(
           dimensions={0}
         }
       )",
-                             "f32", input_dim, output_dim,
+                             type_str, input_dim, output_dim,
                              replica_groups.ToString());
       break;
     case CollectivePerfTableGen::CollectiveType::COLLECTIVE_PERMUTE: {
@@ -260,32 +356,32 @@ std::string GetHlo(
         HloModule collective-permute-while-loop-microbenchmark, num_partitions=$2
 
         while_cond {
-          iter = (f32[$0], u32[]) parameter(0)
+          iter = ($3[$0], u32[]) parameter(0)
           i = u32[] get-tuple-element(iter), index=1
           ub = u32[] constant(100)
           ROOT compare = pred[] compare(i, ub), direction=LT
         }
 
         while_body {
-          iter = (f32[$0], u32[]) parameter(0)
+          iter = ($3[$0], u32[]) parameter(0)
           i = u32[] get-tuple-element(iter), index=1
-          arg = f32[$0] get-tuple-element(iter), index=0
-          collective-permute = f32[$0] collective-permute(arg), channel_id=1, source_target_pairs=$1
+          arg = $3[$0] get-tuple-element(iter), index=0
+          collective-permute = $3[$0] collective-permute(arg), channel_id=1, source_target_pairs=$1
           c1 = u32[] constant(1)
           i_next = u32[] add(i, c1)
-          ROOT out = (f32[$0], u32[]) tuple(collective-permute, i_next)
+          ROOT out = ($3[$0], u32[]) tuple(collective-permute, i_next)
         }
 
         ENTRY main {
-          arg = f32[$0] parameter(0)
+          arg = $3[$0] parameter(0)
           c0 = u32[] constant(0)
-          cp_first_iter = f32[$0] collective-permute(arg), channel_id=1, source_target_pairs=$1
-          init = (f32[$0], u32[]) tuple(cp_first_iter, c0)
-          while = (f32[$0], u32[]) while(init), condition=while_cond, body=while_body
-          ROOT result = f32[$0] get-tuple-element(while), index=0
+          cp_first_iter = $3[$0] collective-permute(arg), channel_id=1, source_target_pairs=$1
+          init = ($3[$0], u32[]) tuple(cp_first_iter, c0)
+          while = ($3[$0], u32[]) while(init), condition=while_cond, body=while_body
+          ROOT result = $3[$0] get-tuple-element(while), index=0
         }
       )",
-          input_dim, source_target_pairs, num_devices);
+          input_dim, source_target_pairs, num_devices, type_str);
       break;
     }
     default:
@@ -296,14 +392,15 @@ std::string GetHlo(
 
 std::unique_ptr<HloModule> CreateCollectiveModule(const StaticSpec& spec) {
   int64_t input_dim = GetInputDim(spec.collective_type, spec.tensor_size_bytes,
-                                  spec.replica_groups);
+                                  spec.replica_groups, spec.data_type);
 
-  int64_t output_dim = GetOutputDim(
-      spec.collective_type, spec.tensor_size_bytes, spec.replica_groups);
+  int64_t output_dim =
+      GetOutputDim(spec.collective_type, spec.tensor_size_bytes,
+                   spec.replica_groups, spec.data_type);
 
-  std::string hlo =
-      GetHlo(spec.collective_type, input_dim, output_dim, spec.replica_groups,
-             spec.collective_permute_pattern);
+  std::string hlo = GetHlo(spec.collective_type, input_dim, output_dim,
+                           spec.replica_groups, spec.collective_permute_pattern,
+                           spec.data_type, spec.use_2d_shape);
 
   HloModuleConfig config;
   config.set_num_partitions(spec.replica_groups.num_devices_per_group() *
@@ -488,23 +585,36 @@ DeviceHloInstructionProfiles CollectivePerfTableGen::ComputeTable() {
         int num_devices = replica_groups.num_devices_per_group() *
                           replica_groups.num_replica_groups();
 
-        if (collective_type != CollectiveType::COLLECTIVE_PERMUTE) {
-          static_specs.push_back(
-              {collective_type, replica_groups, std::nullopt, tensor_size});
-          continue;
-        }
-        for (CollectivePermuteCostModelType pattern :
-             config_.collective_permute_patterns) {
-          // Skip patterns that require an even number of devices if n is odd.
-          if (num_devices % 2 != 0 &&
-              (pattern ==
-                   CollectivePermuteCostModelType::kIntraPartitionOneWay ||
-               pattern == CollectivePermuteCostModelType::
-                              kIntraPartitionTwoWayAllMutual)) {
-            continue;
+        for (PrimitiveType data_type : config_.data_types) {
+          // For all-gather, test both 1D and 2D shapes if configured
+          std::vector<bool> shape_configs = {false};
+          if (collective_type == CollectiveType::ALL_GATHER &&
+              config_.test_2d_shapes) {
+            shape_configs.push_back(true);  // Add 2D shape test
           }
-          static_specs.push_back(
-              {collective_type, replica_groups, pattern, tensor_size});
+
+          for (bool use_2d_shape : shape_configs) {
+            if (collective_type != CollectiveType::COLLECTIVE_PERMUTE) {
+              static_specs.push_back({collective_type, replica_groups,
+                                      std::nullopt, tensor_size, data_type,
+                                      use_2d_shape});
+              continue;
+            }
+            for (CollectivePermuteCostModelType pattern :
+                 config_.collective_permute_patterns) {
+              // Skip patterns that require an even number of devices if n is
+              // odd.
+              if (num_devices % 2 != 0 &&
+                  (pattern ==
+                       CollectivePermuteCostModelType::kIntraPartitionOneWay ||
+                   pattern == CollectivePermuteCostModelType::
+                                  kIntraPartitionTwoWayAllMutual)) {
+                continue;
+              }
+              static_specs.push_back({collective_type, replica_groups, pattern,
+                                      tensor_size, data_type, use_2d_shape});
+            }
+          }
         }
       }
     }

--- a/xla/tools/collective_perf_table_gen.h
+++ b/xla/tools/collective_perf_table_gen.h
@@ -74,6 +74,10 @@ class CollectivePerfTableGen {
         CollectivePermuteCostModelType::kIntraPartitionTwoWayHasNonMutual,
     };
     std::vector<std::string> replica_groups_list;
+    // Data types to test. Defaults to F32 only.
+    std::vector<PrimitiveType> data_types = {F32};
+    // Whether to test 2D shapes for all-gather. Defaults to false (1D only).
+    bool test_2d_shapes = false;
 
     // Execution opts.
     bool dry_run = false;

--- a/xla/tools/collective_perf_table_gen_main.cc
+++ b/xla/tools/collective_perf_table_gen_main.cc
@@ -42,6 +42,7 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/util/command_line_flags.h"
+#include "xla/xla_data.pb.h"
 #include "tsl/platform/init_main.h"
 #include "tsl/platform/path.h"
 
@@ -142,6 +143,34 @@ std::vector<CollectivePerfTableGen::CollectiveType> ParseCollectives(
       types.push_back(
           CollectivePerfTableGen::CollectiveType::COLLECTIVE_PERMUTE);
       continue;
+    }
+  }
+  CHECK_GT(types.size(), 0);
+  return types;
+}
+
+std::vector<xla::PrimitiveType> ParseDataTypes(absl::string_view unparsed) {
+  std::vector<xla::PrimitiveType> types;
+  if (unparsed.empty()) {
+    return {xla::F32};  // Default to F32
+  }
+  for (absl::string_view token : absl::StrSplit(unparsed, ',')) {
+    if (token == "S4" || token == "s4") {
+      types.push_back(xla::S4);
+    } else if (token == "U4" || token == "u4") {
+      types.push_back(xla::U4);
+    } else if (token == "F32" || token == "f32") {
+      types.push_back(xla::F32);
+    } else if (token == "F16" || token == "f16") {
+      types.push_back(xla::F16);
+    } else if (token == "BF16" || token == "bf16") {
+      types.push_back(xla::BF16);
+    } else if (token == "F8E4M3FN" || token == "f8e4m3fn") {
+      types.push_back(xla::F8E4M3FN);
+    } else if (token == "F8E5M2" || token == "f8e5m2") {
+      types.push_back(xla::F8E5M2);
+    } else {
+      LOG(FATAL) << "Unsupported data type: " << token;
     }
   }
   CHECK_GT(types.size(), 0);
@@ -293,6 +322,8 @@ int main(int argc, char* argv[]) {
   std::string merge_path;
   std::vector<std::string> merge_files;
   std::string update_header_path;
+  std::string data_types_unparsed = "F32";
+  bool test_2d_shapes = false;
 
   // Parse flags.
   std::vector<tsl::Flag> flag_list = {
@@ -337,6 +368,13 @@ int main(int argc, char* argv[]) {
       tsl::Flag(
           "update_header_path", &update_header_path,
           "Path to C++ header file to update in-place with new profiles."),
+      tsl::Flag("data_types", &data_types_unparsed,
+                "Comma separated list of data types to test. "
+                "Allowed values: S4, U4, F32, F16, BF16, F8E4M3FN, F8E5M2. "
+                "Defaults to F32."),
+      tsl::Flag("test_2d_shapes", &test_2d_shapes,
+                "Whether to test 2D shapes for all-gather operations. "
+                "Defaults to false (1D shapes only)."),
   };
 
   std::string kUsageString =
@@ -359,6 +397,71 @@ int main(int argc, char* argv[]) {
   cfg.replica_groups_list =
       CollectiveDeviceLists(collective_devices_spec_unparsed);
   cfg.output = output;
+  cfg.data_types = ParseDataTypes(data_types_unparsed);
+  cfg.test_2d_shapes = test_2d_shapes;
+
+  // Validate that 2D shapes are only used with ALL_GATHER
+  if (test_2d_shapes) {
+    bool has_all_gather = false;
+    bool has_other_collectives = false;
+    for (const auto& collective_type : cfg.collective_types) {
+      if (collective_type ==
+          CollectivePerfTableGen::CollectiveType::ALL_GATHER) {
+        has_all_gather = true;
+      } else {
+        has_other_collectives = true;
+      }
+    }
+
+    if (!has_all_gather) {
+      LOG(FATAL) << "Error: --test_2d_shapes=true requires ALL_GATHER to be "
+                 << "included in --collectives. 2D shapes are only supported "
+                 << "for ALL_GATHER operations.";
+    }
+
+    if (has_other_collectives) {
+      LOG(WARNING)
+          << "Warning: --test_2d_shapes=true is set, but other "
+          << "collective types besides ALL_GATHER are also specified. "
+          << "2D shapes will only be tested for ALL_GATHER operations. "
+          << "Other collectives will use 1D shapes only.";
+    }
+  }
+
+  // Validate that U4/S4 data types are only used with ALL_GATHER
+  bool has_4bit_types = false;
+  for (const auto& data_type : cfg.data_types) {
+    if (data_type == xla::S4 || data_type == xla::U4) {
+      has_4bit_types = true;
+      break;
+    }
+  }
+
+  if (has_4bit_types) {
+    bool has_all_gather = false;
+    bool has_other_collectives = false;
+    for (const auto& collective_type : cfg.collective_types) {
+      if (collective_type ==
+          CollectivePerfTableGen::CollectiveType::ALL_GATHER) {
+        has_all_gather = true;
+      } else {
+        has_other_collectives = true;
+      }
+    }
+
+    if (!has_all_gather) {
+      LOG(FATAL) << "Error: U4/S4 data types require ALL_GATHER to be "
+                 << "included in --collectives. 4-bit data types are only "
+                 << "supported for ALL_GATHER operations.";
+    }
+
+    if (has_other_collectives) {
+      LOG(FATAL)
+          << "Error: U4/S4 data types are only supported for "
+          << "ALL_GATHER operations. Please remove other collective "
+          << "types from --collectives or remove U4/S4 from --data_types.";
+    }
+  }
 
   std::unique_ptr<CollectivePerfTableGen> gen =
       CollectivePerfTableGen::Create(cfg);

--- a/xla/tools/collective_perf_table_gen_main.cc
+++ b/xla/tools/collective_perf_table_gen_main.cc
@@ -36,6 +36,7 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
 #include "google/protobuf/text_format.h"
+#include "xla/primitive_util.h"
 #include "xla/service/gpu/model/collective_interpolator_data.h"
 #include "xla/service/gpu/model/hlo_op_profile.pb.h"
 #include "xla/tools/collective_perf_table_gen.h"
@@ -155,20 +156,10 @@ std::vector<xla::PrimitiveType> ParseDataTypes(absl::string_view unparsed) {
     return {xla::F32};  // Default to F32
   }
   for (absl::string_view token : absl::StrSplit(unparsed, ',')) {
-    if (token == "S4" || token == "s4") {
-      types.push_back(xla::S4);
-    } else if (token == "U4" || token == "u4") {
-      types.push_back(xla::U4);
-    } else if (token == "F32" || token == "f32") {
-      types.push_back(xla::F32);
-    } else if (token == "F16" || token == "f16") {
-      types.push_back(xla::F16);
-    } else if (token == "BF16" || token == "bf16") {
-      types.push_back(xla::BF16);
-    } else if (token == "F8E4M3FN" || token == "f8e4m3fn") {
-      types.push_back(xla::F8E4M3FN);
-    } else if (token == "F8E5M2" || token == "f8e5m2") {
-      types.push_back(xla::F8E5M2);
+    std::string lower_token = absl::AsciiStrToLower(token);
+    auto type_or = xla::primitive_util::StringToPrimitiveType(lower_token);
+    if (type_or.ok()) {
+      types.push_back(type_or.value());
     } else {
       LOG(FATAL) << "Unsupported data type: " << token;
     }
@@ -400,8 +391,12 @@ int main(int argc, char* argv[]) {
   cfg.data_types = ParseDataTypes(data_types_unparsed);
   cfg.test_2d_shapes = test_2d_shapes;
 
-  // Validate that 2D shapes are only used with ALL_GATHER
-  if (test_2d_shapes) {
+  // Validate ALL_GATHER-only features (2D shapes and 4-bit types)
+  bool has_4bit_types = absl::c_any_of(
+      cfg.data_types,
+      [](xla::PrimitiveType t) { return t == xla::S4 || t == xla::U4; });
+
+  if (test_2d_shapes || has_4bit_types) {
     bool has_all_gather = false;
     bool has_other_collectives = false;
     for (const auto& collective_type : cfg.collective_types) {
@@ -414,52 +409,33 @@ int main(int argc, char* argv[]) {
     }
 
     if (!has_all_gather) {
-      LOG(FATAL) << "Error: --test_2d_shapes=true requires ALL_GATHER to be "
-                 << "included in --collectives. 2D shapes are only supported "
-                 << "for ALL_GATHER operations.";
-    }
-
-    if (has_other_collectives) {
-      LOG(WARNING)
-          << "Warning: --test_2d_shapes=true is set, but other "
-          << "collective types besides ALL_GATHER are also specified. "
-          << "2D shapes will only be tested for ALL_GATHER operations. "
-          << "Other collectives will use 1D shapes only.";
-    }
-  }
-
-  // Validate that U4/S4 data types are only used with ALL_GATHER
-  bool has_4bit_types = false;
-  for (const auto& data_type : cfg.data_types) {
-    if (data_type == xla::S4 || data_type == xla::U4) {
-      has_4bit_types = true;
-      break;
-    }
-  }
-
-  if (has_4bit_types) {
-    bool has_all_gather = false;
-    bool has_other_collectives = false;
-    for (const auto& collective_type : cfg.collective_types) {
-      if (collective_type ==
-          CollectivePerfTableGen::CollectiveType::ALL_GATHER) {
-        has_all_gather = true;
+      if (test_2d_shapes && has_4bit_types) {
+        LOG(FATAL) << "--test_2d_shapes=true and U4/S4 data types require "
+                   << "ALL_GATHER to be included in --collectives.";
+      } else if (test_2d_shapes) {
+        LOG(FATAL) << "--test_2d_shapes=true requires ALL_GATHER to be "
+                   << "included in --collectives. 2D shapes are only "
+                   << "supported for ALL_GATHER operations.";
       } else {
-        has_other_collectives = true;
+        LOG(FATAL) << "U4/S4 data types require ALL_GATHER to be included in "
+                   << "--collectives. 4-bit data types are only supported for "
+                   << "ALL_GATHER operations.";
       }
     }
 
-    if (!has_all_gather) {
-      LOG(FATAL) << "Error: U4/S4 data types require ALL_GATHER to be "
-                 << "included in --collectives. 4-bit data types are only "
-                 << "supported for ALL_GATHER operations.";
-    }
-
     if (has_other_collectives) {
-      LOG(FATAL)
-          << "Error: U4/S4 data types are only supported for "
-          << "ALL_GATHER operations. Please remove other collective "
-          << "types from --collectives or remove U4/S4 from --data_types.";
+      if (has_4bit_types) {
+        LOG(FATAL) << "U4/S4 data types are only supported for ALL_GATHER "
+                   << "operations. Please remove other collective types from "
+                   << "--collectives or remove U4/S4 from --data_types.";
+      }
+      if (test_2d_shapes) {
+        LOG(WARNING)
+            << "--test_2d_shapes=true is set, but other collective "
+            << "types besides ALL_GATHER are also specified. 2D "
+            << "shapes will only be tested for ALL_GATHER "
+            << "operations. Other collectives will use 1D shapes only.";
+      }
     }
   }
 


### PR DESCRIPTION
## Motivation
The current collective_perf_table tool has some limitations when it comes to evaluate the all-gather op:
- only 1D input/output
- only FP32 data type

2D shapes and more data types would allow us to use this tool to evaluate more different configurations.

## Technical Details
This PR extends the `collective_perf_table` too to enable more data types and 2D shapes for all-gather op.

## Usage example

```bash
# Explicit data type selection
bazel run -- //xla/tools:collective_perf_table_gen_main \
  --collectives=ALL_GATHER \
  --data_types=F32,F16,BF16 \
  --test_2d_shapes=true \
  --output=perf.pbtxt
```

### Supported Data Types
- **Standard floating-point:** `F32`, `F16`, `BF16`
- **8-bit floating-point:** `F8E4M3FN`, `F8E5M2`
- **4-bit integers:** `S4` (signed), `U4` (unsigned)  (`ALL_GATHER` only)
