### PR TITLE
Exclude some TritonBackendTest until default configs set is extended.

### DIFF
--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -36,6 +36,10 @@ EXCLUDED_TESTS=(
     "StreamExecutorGpuClientTest.GetAbiVersion"
     # TODO: fix, memory stats mismatch (se_gpu_pjrt_client_test)
     "StreamExecutorGpuClientTest.GetCompiledMemoryStatsWithTupleAndNcclUserBuffers"
+    # TODO: remove when more triton default configs are added
+    "TritonBackendTest.CostModelOptions_Filter"
+    "TritonBackendTest.CostModelOptions_TopFromDefault"
+    "TritonBackendTest.CostModelOptions_Combination"
 )
 
 TAG_FILTERS=$("${SCRIPT_DIR}/rocm_tag_filters.sh")


### PR DESCRIPTION
## Motivation

Failing //xla/backends/gpu/autotuner:triton_test_amdgpu_any test

## Technical Details

Failing tests skipped until additiona default triton configs are added

## Test Plan

//xla/backends/gpu/autotuner:triton_test_amdgpu_any

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
