### PR TITLE
[XLA:GPU] Fix num_warps in ROCm default Triton config for 16x16 tile

### DIFF
--- a/xla/backends/gpu/autotuner/triton/dot_search_space.cc
+++ b/xla/backends/gpu/autotuner/triton/dot_search_space.cc
@@ -338,13 +338,33 @@ int64_t TritonDotFusionSearchSpace::GetNumResultTiles(
 }
 
 int TritonDotFusionSearchSpace::GetMaxWarpsPerCta(OutputTile tile) const {
+  const int max_warps =
+      device_description_.threads_per_block_limit() /
+      std::max<int>(device_description_.threads_per_warp(), 1);
+
+  if (device_description_.gpu_compute_capability().IsRocm()) {
+    // On AMD, Triton lowers tl.dot to MFMA on CDNA or WMMA on RDNA3+. In
+    // Triton's amd_mfma encoding only 16x16x* and 32x32x* instrShapes are
+    // emitted (see triton-lang/triton third_party/amd's chooseMfmaInstruction
+    // and PRs #5937 / #8213); the smaller V_MFMA_*_4x4x* exists in hardware
+    // (AMD "matrix cores" lab note, https://gpuopen.com/learn/amd-lab-notes/
+    // amd-lab-notes-matrix-cores-readme/) but Triton does not select it.
+    // RDNA3+ WMMA only supports a 16x16x16 tile size at all (AMD GPUOpen
+    // "WMMA on RDNA3", https://gpuopen.com/learn/wmma_on_rdna3 and the RDNA3
+    // ISA reference). So the smallest per-wave output sub-tile on AMD is
+    // 16x16, not 16x8. More importantly, extra warps per CTA on AMD are used
+    // by Triton's stream pipeliner to software-pipeline the K loop (see
+    // triton-lang/triton PR #4148, "Introduce stream pipeliner v2", and ROCm
+    // "Optimizing Triton kernels"), not to tile the M*N output spatially.
+    // So we don't impose a per-output-tile cap here -- only the hardware
+    // bound (threads_per_block_limit / threads_per_warp) applies.
+    return std::max(min_warps_per_cta_, max_warps);
+  }
+
   // A single mma instruction is of output shape at least 16x8 (the same
   // also holds for wgmma: the warp-group level instruction is at least
   // 64x8, and split 4-ways across the 4 warps in the group).
   constexpr OutputTile kMmaSubTile = {16, 8};
-  const int max_warps =
-      device_description_.threads_per_block_limit() /
-      std::max<int>(device_description_.threads_per_warp(), 1);
   const int lhs_warps = CeilOfRatio(tile.lhs_dim, kMmaSubTile.lhs_dim);
   const int rhs_warps = CeilOfRatio(tile.rhs_dim, kMmaSubTile.rhs_dim);
   return std::max(min_warps_per_cta_,


### PR DESCRIPTION
Fixes the following three tests on ROCm (verified on MI350X / gfx950, applicable to MI200/MI300 as well):

    TritonBackendTest.CostModelOptions_TopFromDefault
    TritonBackendTest.CostModelOptions_Filter
    TritonBackendTest.CostModelOptions_Combination

Background
==========

TritonDotFusionSearchSpace::OptimizeConfigSet filters the exhaustive search space against the hints from rocm.txtpb using exact TritonGemmConfig equality (only block_m / block_n / block_k are clamped; num_warps / num_stages / waves_per_eu / ... are not). Therefore each hint must agree with what the search space actually generates for the declared tile shape, or it is silently dropped.

According to xla/backends/gpu/autotuner/triton/dot_search_space.cc:

    int TritonDotFusionSearchSpace::GetMaxWarpsPerCta(OutputTile tile) const {
      // A single mma instruction is of output shape at least 16x8 (the same
      // also holds for wgmma: the warp-group level instruction is at least
      // 64x8, and split 4-ways across the 4 warps in the group).
      constexpr OutputTile kMmaSubTile = {16, 8};
      const int max_warps =
          device_description_.threads_per_block_limit() /
          std::max<int>(device_description_.threads_per_warp(), 1);
      const int lhs_warps = CeilOfRatio(tile.lhs_dim, kMmaSubTile.lhs_dim);
      const int rhs_warps = CeilOfRatio(tile.rhs_dim, kMmaSubTile.rhs_dim);
      return std::max(min_warps_per_cta_,
                      std::min(max_warps, lhs_warps * rhs_warps));
    }

For a 16x16 output tile this evaluates (on every AMD GPU, since threads_per_block_limit=1024 and threads_per_warp=64 are identical across gfx90a / gfx942 / gfx950) to:

    lhs_warps        = ceil(16 / 16) = 1
    rhs_warps        = ceil(16 / 8)  = 2
    max_warps        = 1024 / 64     = 16
    GetMaxWarpsPerCta = max(min_warps_per_cta_=2,
                            min(16, 1*2))      = 2

AddCtaSizeParameter therefore only emits num_warps=2 for a 16x16 tile. The previous hint asked for num_warps=4, so it had no matching entry in the exhaustive set and was filtered out by OptimizeConfigSet, leaving the optimized default set with a single config. The three CostModelOptions_* tests assume the default set yields >=2 estimable configs and so they all fail:

  - CostModelOptions_TopFromDefault expects size 2  -> gets 1.
  - CostModelOptions_Filter expects new < default   -> gets 1 vs 1.
  - CostModelOptions_Combination  expects size 7    -> gets 6 (1 top +
                                                              5 mixin).

Fix
===

Align the 16x16 hint with the search space by setting num_warps=2. Both hints now survive OptimizeConfigSet, the default set has two distinct configs again, and the three tests pass.

This is a regression introduced by commit bda66ea5 ("[XLA:GPU] Remove split_k > 1 from default configs") which reduced rocm.txtpb from 6 hints to 2 and so unmasked the latent mismatch in the 16x16 hint.

Verification
============

Executed inside the same docker image the ROCm/xla CI uses:
  rocm/tensorflow-build:latest-jammy-pythonall-rocm7.2.1-ci_official
on AMD Instinct MI350X (gfx950) with ROCm 7.2.1:

  bazel test --config=rocm --repo_env=TF_ROCM_AMDGPU_TARGETS=gfx950 \
      --test_filter='TritonBackendTest.*' \
      //xla/backends/gpu/autotuner:triton_test

  -> 19 PASSED, 7 SKIPPED (CUDA-only), 0 FAILED.

The 7 SKIPPED tests all hit GTEST_SKIP() << "Not supported on ROCm."; they cover Ampere / Hopper / Blackwell / TMA / warp-specialization features. triton_configs_test also passes.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
