### PR TITLE
[ROCm] Streamline bazel targets for rocm libraries

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -119,9 +119,11 @@ cc_library(
         ":link_only": [
         ],
         ":multiple_rocm_paths": [
+            "-Wl,-rpath,external/local_config_rocm/rocm/%{rocm_root}/lib",
             "-Wl,-rpath=%{rocm_lib_paths}",
         ],
         "//conditions:default": [
+            "-Wl,-rpath,external/local_config_rocm/rocm/%{rocm_root}/lib",
             "-Wl,-rpath,/opt/rocm/lib",
         ],
     }),
@@ -263,6 +265,7 @@ rocm_lib_import(
     data = glob([
         "%{rocm_root}/lib/libMIOpen.so*",
         "%{rocm_root}/share/miopen/**",
+        "%{rocm_root}/lib/librocm-core.so*",
     ]),
     interface_library = "%{rocm_root}/lib/libMIOpen.so",
     deps = [

--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -1,5 +1,5 @@
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_import.bzl", "cc_import")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 # Macros for building ROCm code.
 def if_rocm(if_true, if_false = []):
@@ -11,7 +11,7 @@ def if_rocm(if_true, if_false = []):
     """
     return select({
         "@local_config_rocm//rocm:using_hipcc": if_true,
-        "//conditions:default": if_false
+        "//conditions:default": if_false,
     })
 
 def rocm_default_copts():
@@ -73,19 +73,19 @@ def rocm_hipblaslt():
 
 def if_rocm_hipblaslt(x):
     if %{rocm_is_configured} and (%{rocm_hipblaslt} == "True"):
-      return select({"//conditions:default": x})
+        return select({"//conditions:default": x})
     return select({"//conditions:default": []})
 
 def rocm_library(copts = [], deps = [], **kwargs):
     """Wrapper over cc_library which adds default ROCm options."""
     if "@local_config_rocm//rocm:rocm_headers" not in deps:
-      deps.append("@local_config_rocm//rocm:rocm_headers")
+        deps.append("@local_config_rocm//rocm:rocm_headers")
     cc_library(copts = rocm_default_copts() + copts, deps = deps, **kwargs)
 
 def get_rbe_amdgpu_pool(is_single_gpu = False):
     return "%{single_gpu_rbe_pool}" if is_single_gpu else "%{multi_gpu_rbe_pool}"
 
-def rocm_lib_import(name, interface_library, data, deps=[]):
+def rocm_lib_import(name, interface_library, data, deps):
     cc_import(
         name = name + "_interface",
         interface_library = interface_library,


### PR DESCRIPTION
Remove DsoLoader indirection and directly link to rocm libs