### PR TITLE
Implement cache for pjrt client streams

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -42,6 +42,8 @@ limitations under the License.
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
@@ -221,6 +223,28 @@ static absl::flat_hash_map<std::string, PjRtDeviceAttribute> GetAttrsForDevices(
   return attrs;
 }
 
+// Process-level cache of LocalDeviceState objects.
+//
+// Streams can be expensive to create, so eagerly create 18
+// streams per GPU per client can quickly become very expensive.
+//
+// By caching LocalDeviceState objects across client cycles and resetting
+// them (sync + clear bookkeeping) instead of destroy+recreate, we eliminate
+// the stream creation cost on the 2nd and subsequent client creations.
+//
+// Thread safety: protected by a mutex; only accessed during
+// GetStreamExecutorGpuClient() and ~StreamExecutorGpuClient().
+struct DeviceStateCache {
+  absl::Mutex mu;
+  // Map from device ordinal to cached LocalDeviceState (already Reset()).
+  std::map<int, std::unique_ptr<LocalDeviceState>> states ABSL_GUARDED_BY(mu);
+};
+
+static DeviceStateCache& GetDeviceStateCache() {
+  static auto* cache = new DeviceStateCache();
+  return *cache;
+}
+
 StreamExecutorGpuClient::StreamExecutorGpuClient(
     std::string platform_name, LocalClient* client,
     std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> devices,
@@ -277,6 +301,61 @@ StreamExecutorGpuClient::StreamExecutorGpuClient(
                [](const PjRtMemorySpace* a, const PjRtMemorySpace* b) {
                  return a->id() < b->id();
                });
+}
+
+StreamExecutorGpuClient::~StreamExecutorGpuClient() {
+  // Step 1: Quiesce async dispatch threads on all addressable devices.
+  // This must run before we call Reset() or release_local_device_state(),
+  // since the async_dispatch_thread may be enqueuing work on the streams.
+  // (~PjRtStreamExecutorClient() also does this, but it runs AFTER our body,
+  // so by doing it here we ensure quiescing before the cache return.)
+  for (auto* device : addressable_devices()) {
+    auto* se_device = tensorflow::down_cast<PjRtStreamExecutorDevice*>(device);
+    if (!se_device->local_device_state()) continue;
+    if (se_device->local_device_state()->async_dispatch_thread()) {
+      absl::Notification done;
+      se_device->local_device_state()->async_dispatch_thread()->Schedule(
+          [&]() { done.Notify(); });
+      done.WaitForNotification();
+    }
+  }
+
+  // Step 2: Always destroy the RCCL global clique cache.
+  // ncclComm_t handles in these cliques are permanently invalidated.
+  // The next AcquireGpuClique() call will create fresh communicators.
+  // This also ensures test isolation for collective operations.
+  gpu::internal::DestroyAcquiredCliques();
+
+  // Step 3: For each addressable device, try to reset and cache the
+  // LocalDeviceState (sync + clear bookkeeping). On success, transfer
+  // ownership from the device to the cache. The ~PjRtStreamExecutorClient()
+  // destructor (which runs after this body) will skip quiescing for devices
+  // with nullptr local_device_state() — already done in step 1.
+  auto& cache = GetDeviceStateCache();
+  absl::MutexLock lock(&cache.mu);
+
+  for (auto* device : addressable_devices()) {
+    auto* se_device = tensorflow::down_cast<PjRtStreamExecutorDevice*>(device);
+    if (!se_device->local_device_state()) continue;
+
+    int ordinal = device->local_device_id().value();
+    absl::Status reset_status = se_device->local_device_state()->Reset();
+
+    if (reset_status.ok()) {
+      // Transfer ownership to cache. Device's local_device_state_ becomes
+      // nullptr; ~PjRtStreamExecutorDevice() will safely skip it.
+      cache.states.emplace(ordinal, se_device->release_local_device_state());
+      VLOG(1) << "StreamExecutorGpuClient: device=" << ordinal
+              << " LocalDeviceState returned to cache (streams preserved)";
+    } else {
+      // Streams in error state (e.g., GPU hardware fault). Do NOT cache.
+      // Let ~PjRtStreamExecutorDevice() destroy it normally via
+      // hipStreamDestroy.
+      LOG(WARNING) << "StreamExecutorGpuClient: device=" << ordinal
+                   << " Reset() failed: " << reset_status
+                   << " — LocalDeviceState will be destroyed and recreated";
+    }
+  }
 }
 
 absl::string_view StreamExecutorGpuClient::platform_version() const {
@@ -701,7 +780,7 @@ StreamExecutorGpuClient::CrossHostSendBuffers(
                 [&](PjRtRawBufferRef buf_raw_buffer,
                     std::vector<tsl::RCReference<tsl::AsyncValue>>
                         buf_definition_events) mutable
-                    -> absl::StatusOr<PjRtDeviceEventRef> {
+                -> absl::StatusOr<PjRtDeviceEventRef> {
                   // Keep raw_buffer alive until the usage_event completes,
                   // preventing the allocation from being freed while the
                   // send is in-flight.
@@ -1463,19 +1542,39 @@ absl::StatusOr<std::shared_ptr<tsl::Allocator>> CreateCudaAsyncAllocator(
 #endif  // defined(GOOGLE_CUDA) && CUDA_VERSION >= 11020
 
 // Builds a LocalDeviceState for each GPU present.
+//
+// On the first call (cold start), this creates new LocalDeviceState objects.
+// On subsequent calls, cached states are reused after Reset()
+// to avoid the stream creation overhead.
+//
+// RCCL clique cache is always cleared before reuse via DestroyAcquiredCliques,
+// ensuring new communicators are created for the next client's collective ops.
 absl::StatusOr<std::map<int, std::unique_ptr<LocalDeviceState>>>
 BuildLocalDeviceStates(LocalClient* xla_client, bool schedule_async,
                        std::optional<int> max_inflight_computations) {
+  auto& cache = GetDeviceStateCache();
+  absl::MutexLock lock(&cache.mu);
+
   std::map<int, std::unique_ptr<LocalDeviceState>> addressable_devices;
   for (se::StreamExecutor* executor :
        xla_client->backend().stream_executors()) {
-    addressable_devices.emplace(
-        executor->device_ordinal(),
-        std::make_unique<LocalDeviceState>(
-            executor, xla_client, LocalDeviceState::kComputeSynchronized,
-            max_inflight_computations, /*allow_event_reuse=*/true,
-            /*use_callback_stream=*/true, /*device_ordinal=*/-1,
-            /*stream_options=*/std::nullopt, schedule_async));
+    int ordinal = executor->device_ordinal();
+
+    auto it = cache.states.find(ordinal);
+    if (it != cache.states.end()) {
+      // Reuse cached state: streams already exist, just sync + reset metadata.
+      addressable_devices.emplace(ordinal, std::move(it->second));
+      cache.states.erase(it);
+    } else {
+      // Cold start: create new LocalDeviceState.
+      addressable_devices.emplace(
+          ordinal,
+          std::make_unique<LocalDeviceState>(
+              executor, xla_client, LocalDeviceState::kComputeSynchronized,
+              max_inflight_computations, /*allow_event_reuse=*/true,
+              /*use_callback_stream=*/true, /*device_ordinal=*/-1,
+              /*stream_options=*/std::nullopt, schedule_async));
+    }
   }
   return std::move(addressable_devices);
 }

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -223,16 +223,19 @@ static absl::flat_hash_map<std::string, PjRtDeviceAttribute> GetAttrsForDevices(
   return attrs;
 }
 
-// Process-level cache of LocalDeviceState objects.
+// Process-level cache of LocalDeviceState objects, keyed by device ordinal.
 //
-// Streams can be expensive to create, so eagerly create 18
-// streams per GPU per client can quickly become very expensive.
+// Performance optimisation: creating ~18 GPU streams and several worker threads
+// per device on every PjRtClient instantiation is expensive. Instead the
+// outgoing client resets each LocalDeviceState (drain + clear bookkeeping) and
+// stores it here; the incoming client reconfigures and reuses it, paying only a
+// stream synchronisation cost instead of a stream creation cost.
 //
-// By caching LocalDeviceState objects across client cycles and resetting
-// them (sync + clear bookkeeping) instead of destroy+recreate, we eliminate
-// the stream creation cost on the 2nd and subsequent client creations.
+// Intentional leak: the singleton (`new`, never `delete`) holds at most one
+// entry per physical GPU for the lifetime of the process. There is no eviction
+// policy. The OS reclaims all resources on exit.
 //
-// Thread safety: protected by a mutex; only accessed during
+// Thread safety: mu guards all map accesses. The cache is only accessed in
 // GetStreamExecutorGpuClient() and ~StreamExecutorGpuClient().
 struct DeviceStateCache {
   absl::Mutex mu;
@@ -241,7 +244,7 @@ struct DeviceStateCache {
 };
 
 static DeviceStateCache& GetDeviceStateCache() {
-  static auto* cache = new DeviceStateCache();
+  static auto* cache = new DeviceStateCache();  // Intentional leak; see above.
   return *cache;
 }
 
@@ -320,10 +323,19 @@ StreamExecutorGpuClient::~StreamExecutorGpuClient() {
     }
   }
 
-  // Step 2: Always destroy the RCCL global clique cache.
-  // ncclComm_t handles in these cliques are permanently invalidated.
-  // The next AcquireGpuClique() call will create fresh communicators.
-  // This also ensures test isolation for collective operations.
+  // Step 2: Destroy the RCCL/NCCL global clique cache.
+  //
+  // This MUST happen before Reset() (Step 3). ncclCommDestroy / rccl's
+  // equivalent may issue host-side synchronization and can enqueue GPU work on
+  // the LocalDeviceState's device-to-device streams. By destroying cliques
+  // first, any such GPU work is in-flight on the streams when Reset() is
+  // called. SynchronizeAllActivity() inside Reset() then drains everything —
+  // both XLA work and communicator-destruction work — before the streams are
+  // cached and handed to the next client.
+  //
+  // ncclComm_t handles are permanently invalidated after this point; the next
+  // AcquireGpuClique() call will create fresh communicators. This also
+  // provides test isolation for collective operations.
   gpu::internal::DestroyAcquiredCliques();
 
   // Step 3: For each addressable device, try to reset and cache the
@@ -335,7 +347,10 @@ StreamExecutorGpuClient::~StreamExecutorGpuClient() {
   absl::MutexLock lock(&cache.mu);
 
   for (auto* device : addressable_devices()) {
-    auto* se_device = tensorflow::down_cast<PjRtStreamExecutorDevice*>(device);
+    // Cast to StreamExecutorGpuDevice* (not the base type) so that the
+    // friend-granted access to the protected release_local_device_state()
+    // method is resolved through the GPU-specific type.
+    auto* se_device = tensorflow::down_cast<StreamExecutorGpuDevice*>(device);
     if (!se_device->local_device_state()) continue;
 
     int ordinal = device->local_device_id().value();
@@ -1563,8 +1578,26 @@ BuildLocalDeviceStates(LocalClient* xla_client, bool schedule_async,
     auto it = cache.states.find(ordinal);
     if (it != cache.states.end()) {
       // Reuse cached state: streams already exist, just sync + reset metadata.
-      addressable_devices.emplace(ordinal, std::move(it->second));
+      // Reconfigure() adjusts async_dispatch_thread_ and compute_semaphore_ to
+      // match the new client's parameters. This must happen here (at retrieval
+      // time) rather than in Reset() (which runs at cache-time in the old
+      // client's destructor) because the new client's parameters are not known
+      // until BuildLocalDeviceStates() is called.
+      auto state = std::move(it->second);
       cache.states.erase(it);
+      // Defensive: StreamExecutors are singletons in the current GPU platform
+      // implementation, so the cached state's executor must be the same object
+      // as the one provided by the new XlaClient. If this ever fires it means
+      // we are handing a cached state whose GPU streams belong to a different
+      // physical device than the one the new client expects — a serious
+      // misconfiguration that would cause silent data corruption.
+      DCHECK_EQ(state->executor(), executor)
+          << "Cached LocalDeviceState for ordinal " << ordinal
+          << " has a different StreamExecutor than the new XlaClient. "
+             "The cache key (device ordinal) is not sufficient to guarantee "
+             "executor identity.";
+      state->Reconfigure(schedule_async, max_inflight_computations);
+      addressable_devices.emplace(ordinal, std::move(state));
     } else {
       // Cold start: create new LocalDeviceState.
       addressable_devices.emplace(

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -123,6 +123,10 @@ class StreamExecutorGpuClient : public xla::PjRtStreamExecutorClient {
       std::shared_ptr<const GpuTopology> gpu_topology,
       std::optional<int> num_processes);
 
+  // Destructor that returns LocalDeviceState objects to the process-level
+  // stream cache (if Reset() succeeds) and cleans up RCCL cliques.
+  ~StreamExecutorGpuClient() override;
+
   std::optional<std::shared_ptr<KeyValueStoreInterface>> key_value_store()
       const override {
     return kv_store_;

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -95,6 +95,13 @@ class StreamExecutorGpuDevice : public PjRtStreamExecutorDevice {
   absl::Status ClearMemoryStats() override;
 
  private:
+  // StreamExecutorGpuClient is the only class permitted to call the protected
+  // release_local_device_state() method (inherited from
+  // PjRtStreamExecutorDevice). This friend declaration is intentionally at the
+  // GPU-specific subclass level to avoid introducing a dependency on
+  // StreamExecutorGpuClient in the platform-neutral base header.
+  friend class StreamExecutorGpuClient;
+
   std::string device_vendor_;
 };
 

--- a/xla/pjrt/local_device_state.cc
+++ b/xla/pjrt/local_device_state.cc
@@ -178,6 +178,41 @@ LocalDeviceState::~LocalDeviceState() {
   compute_events_.clear();
 }
 
+absl::Status LocalDeviceState::Reset() {
+  // Step 1: Drain all pending GPU work on all streams.
+  // After a normal execution this completes quickly (streams already idle).
+  TF_RETURN_IF_ERROR(SynchronizeAllActivity());
+
+  // Step 2: Reset XLA-level sequencing bookkeeping.
+  // All events in compute_events_ have already fired (GPU work completed
+  // above), so clearing the deque is safe. Resetting the counters to 0 is
+  // required so the new client's operations start from a consistent baseline.
+  {
+    absl::MutexLock lock(mu_);
+    compute_events_.clear();
+    next_compute_stream_sync_point_.store(0);
+    base_compute_event_sequence_id_ = 0;
+  }
+
+  // Step 3: Clear the callback stream map.
+  // Callback streams are re-created on demand when ThenExecuteCallback is
+  // called.
+  if (callback_stream_map_.has_value()) {
+    absl::MutexLock lock(callback_stream_map_mu_);
+    callback_stream_map_->clear();
+  }
+
+  // Step 4: Drain the usage stream pool.
+  // Pooled streams have been synchronized above; clear the pool so the new
+  // client starts from a known empty state.
+  {
+    absl::MutexLock lock(stream_pool_mu_);
+    while (!usage_stream_pool_.empty()) usage_stream_pool_.pop();
+  }
+
+  return absl::OkStatus();
+}
+
 absl::Status LocalDeviceState::SynchronizeAllActivity() {
   absl::Status status;
   // TODO(phawkins): in theory the call to SynchronizeAllActivity below should

--- a/xla/pjrt/local_device_state.cc
+++ b/xla/pjrt/local_device_state.cc
@@ -183,10 +183,33 @@ absl::Status LocalDeviceState::Reset() {
   // After a normal execution this completes quickly (streams already idle).
   TF_RETURN_IF_ERROR(SynchronizeAllActivity());
 
-  // Step 2: Reset XLA-level sequencing bookkeeping.
-  // All events in compute_events_ have already fired (GPU work completed
-  // above), so clearing the deque is safe. Resetting the counters to 0 is
-  // required so the new client's operations start from a consistent baseline.
+  // Step 2: Drain the callback thread.
+  //
+  // SynchronizeAllActivity() guarantees that all GPU-stream host-callbacks
+  // (registered via DoHostCallback / ThenExecuteCallback) have been *invoked*,
+  // which means every call to callback_thread_->Schedule() that they contain
+  // has already been issued.  However, callback_thread_ is a single-threaded
+  // work queue: those scheduled closures may still be sitting in the queue or
+  // actively running when SynchronizeAllActivity() returns.
+  //
+  // In particular, the closures include:
+  //   - event.SetStateConcrete()  (from AllocateAndRecordEvent)
+  //   - the AndThen callback that calls compute_events_.pop_front()
+  //     (from GetEventForComputeStreamSyncPoint)
+  //
+  // If we clear compute_events_ while any of those closures are still queued,
+  // pop_front() would be called on an empty deque — undefined behaviour.
+  //
+  // Scheduling a sentinel task and blocking until it executes guarantees that
+  // every closure enqueued before this point has completed.
+  callback_thread_->Drain();
+
+  // Step 3: Reset XLA-level sequencing bookkeeping.
+  // All events in compute_events_ have already fired (GPU work completed in
+  // Step 1) and all callbacks that touch compute_events_ have completed
+  // (drained in Step 2), so clearing the deque is now safe.  Resetting the
+  // counters to 0 is required so the new client's operations start from a
+  // consistent baseline.
   {
     absl::MutexLock lock(mu_);
     compute_events_.clear();
@@ -194,7 +217,7 @@ absl::Status LocalDeviceState::Reset() {
     base_compute_event_sequence_id_ = 0;
   }
 
-  // Step 3: Clear the callback stream map.
+  // Step 4: Clear the callback stream map.
   // Callback streams are re-created on demand when ThenExecuteCallback is
   // called.
   if (callback_stream_map_.has_value()) {
@@ -202,7 +225,7 @@ absl::Status LocalDeviceState::Reset() {
     callback_stream_map_->clear();
   }
 
-  // Step 4: Drain the usage stream pool.
+  // Step 5: Drain the usage stream pool.
   // Pooled streams have been synchronized above; clear the pool so the new
   // client starts from a known empty state.
   {
@@ -211,6 +234,33 @@ absl::Status LocalDeviceState::Reset() {
   }
 
   return absl::OkStatus();
+}
+
+void LocalDeviceState::Reconfigure(
+    bool schedule_async, std::optional<int> max_inflight_computations) {
+  // Adjust async_dispatch_thread_.
+  // When this is called from BuildLocalDeviceStates(), the cached state's
+  // thread (if any) was already drained by ~StreamExecutorGpuClient() before
+  // Reset() was called, so the thread is idle and safe to destroy.
+  if (schedule_async && !async_dispatch_thread_) {
+    tsl::ThreadOptions thread_options;
+    thread_options.numa_node = executor_->numa_node();
+    async_dispatch_thread_ = std::make_unique<WorkerThread>(
+        tsl::Env::Default(), thread_options, "py_xla_dispatch");
+  } else if (!schedule_async && async_dispatch_thread_) {
+    // ~WorkerThread() blocks until all queued work completes, which is fine
+    // since the thread is already idle at this point.
+    async_dispatch_thread_.reset();
+  }
+
+  // Reconfigure compute_semaphore_.
+  // After Reset(), all in-flight computations have completed so the old
+  // semaphore (if any) is at full capacity. Replace it unconditionally to
+  // match the new client's throttling policy.
+  compute_semaphore_.reset();
+  if (max_inflight_computations.has_value()) {
+    compute_semaphore_.emplace(*max_inflight_computations);
+  }
 }
 
 absl::Status LocalDeviceState::SynchronizeAllActivity() {

--- a/xla/pjrt/local_device_state.h
+++ b/xla/pjrt/local_device_state.h
@@ -239,6 +239,19 @@ class LocalDeviceState {
       size_t sync_point, AsyncWorkRunner* async_work_runner,
       bool nullptr_if_past = false);
 
+  // Resets this LocalDeviceState for reuse by a new PjRtClient without paying
+  // the Stream create overhead again. Specifically:
+  //   1. Calls SynchronizeAllActivity() to drain all pending GPU work.
+  //   2. Clears XLA bookkeeping (compute_events_, sync point counters).
+  //   3. Clears the callback stream map (streams are re-created on demand).
+  //   4. Drains the usage stream pool.
+  //
+  // Returns OK if streams are clean and the state can be reused.
+  // Returns a non-OK status if SynchronizeAllActivity() fails (e.g., a GPU
+  // hardware fault left the streams in an error state) — in that case the
+  // caller should destroy this object and create a new LocalDeviceState.
+  absl::Status Reset();
+
  private:
   absl::Status SynchronizeAllActivity();
 

--- a/xla/pjrt/local_device_state.h
+++ b/xla/pjrt/local_device_state.h
@@ -242,15 +242,43 @@ class LocalDeviceState {
   // Resets this LocalDeviceState for reuse by a new PjRtClient without paying
   // the Stream create overhead again. Specifically:
   //   1. Calls SynchronizeAllActivity() to drain all pending GPU work.
-  //   2. Clears XLA bookkeeping (compute_events_, sync point counters).
-  //   3. Clears the callback stream map (streams are re-created on demand).
-  //   4. Drains the usage stream pool.
+  //   2. Drains callback_thread_ via a sentinel task so that all host-side
+  //      callbacks queued by ThenExecuteCallback (e.g. SetStateConcrete and
+  //      the AndThen that pops from compute_events_) have completed before any
+  //      shared state is mutated. This closes the race between Reset() and
+  //      in-flight callbacks.
+  //   3. Clears XLA bookkeeping (compute_events_, sync point counters).
+  //   4. Clears the callback stream map (streams are re-created on demand).
+  //   5. Drains the usage stream pool.
+  //
+  // Note: Reset() deliberately does NOT reconfigure schedule_async or
+  // max_inflight_computations because Reset() is called at cache-time (when
+  // the old client is torn down) and the next client's parameters are not yet
+  // known. Call Reconfigure() after retrieving the state from the cache.
   //
   // Returns OK if streams are clean and the state can be reused.
   // Returns a non-OK status if SynchronizeAllActivity() fails (e.g., a GPU
   // hardware fault left the streams in an error state) — in that case the
   // caller should destroy this object and create a new LocalDeviceState.
   absl::Status Reset();
+
+  // Reconfigures this LocalDeviceState to match the parameters of a new
+  // PjRtClient. Must be called after retrieving a previously-Reset() state
+  // from the device state cache, before handing it to the new client.
+  //
+  // Adjusts:
+  //   - async_dispatch_thread_: created if schedule_async=true and the thread
+  //     is absent; destroyed (after draining) if schedule_async=false and the
+  //     thread is present.
+  //   - compute_semaphore_: replaced with a new semaphore sized to
+  //     max_inflight_computations (or cleared if nullopt).
+  //
+  // Precondition: async_dispatch_thread_ must be idle (no pending work).
+  // This is guaranteed when Reconfigure() is called from
+  // BuildLocalDeviceStates() because ~StreamExecutorGpuClient() drains the
+  // thread before Reset() is invoked.
+  void Reconfigure(bool schedule_async,
+                   std::optional<int> max_inflight_computations);
 
  private:
   absl::Status SynchronizeAllActivity();

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -159,6 +159,13 @@ class PjRtStreamExecutorDevice : public PjRtDevice {
     return local_device_state_.get();
   }
 
+  // Releases ownership of the local device state for caching/reuse.
+  // After this call, local_device_state() returns nullptr.
+  // The device must not be used after this call.
+  std::unique_ptr<LocalDeviceState> release_local_device_state() {
+    return std::move(local_device_state_);
+  }
+
   // If this is a device local to this host, returns a LocalDeviceState object
   // that can be used to manipulate the device. Returns an error if the device
   // is not local to this host.
@@ -191,7 +198,7 @@ class PjRtStreamExecutorDevice : public PjRtDevice {
  private:
   const LocalDeviceId local_device_id_;
   const LocalChipId local_hardware_id_;
-  const std::unique_ptr<LocalDeviceState> local_device_state_;
+  std::unique_ptr<LocalDeviceState> local_device_state_;
   PjRtStreamExecutorDeviceDescription description_;
   absl::flat_hash_map<std::string, PjRtDeviceAttribute> attributes_;
   PjRtClient* client_ = nullptr;

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -159,13 +159,6 @@ class PjRtStreamExecutorDevice : public PjRtDevice {
     return local_device_state_.get();
   }
 
-  // Releases ownership of the local device state for caching/reuse.
-  // After this call, local_device_state() returns nullptr.
-  // The device must not be used after this call.
-  std::unique_ptr<LocalDeviceState> release_local_device_state() {
-    return std::move(local_device_state_);
-  }
-
   // If this is a device local to this host, returns a LocalDeviceState object
   // that can be used to manipulate the device. Returns an error if the device
   // is not local to this host.
@@ -193,6 +186,15 @@ class PjRtStreamExecutorDevice : public PjRtDevice {
   std::unique_ptr<ScopedAsyncTrackingEvent> CreateAsyncTrackingEvent(
       absl::string_view description) const override {
     return nullptr;
+  }
+
+ protected:
+  // Releases ownership of the local device state for caching/reuse.
+  // After this call, local_device_state() returns nullptr and the device
+  // must not be used again. Access is restricted to subclasses and their
+  // designated friends to prevent accidental misuse by unrelated code.
+  std::unique_ptr<LocalDeviceState> release_local_device_state() {
+    return std::move(local_device_state_);
   }
 
  private:

--- a/xla/pjrt/worker_thread.cc
+++ b/xla/pjrt/worker_thread.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
 #include "xla/tsl/platform/env.h"
 
 namespace xla {
@@ -42,6 +43,14 @@ void WorkerThread::Schedule(absl::AnyInvocable<void() &&> fn) {
   CHECK(fn != nullptr);
   absl::MutexLock lock(mu_);
   work_queue_.push(std::move(fn));
+}
+
+void WorkerThread::Drain() {
+  absl::Notification done;
+  // Schedule a sentinel closure after all currently-queued work. When the
+  // worker thread executes it, we know every prior closure has completed.
+  Schedule([&done]() { done.Notify(); });
+  done.WaitForNotification();
 }
 
 bool WorkerThread::WorkAvailable() { return !work_queue_.empty(); }

--- a/xla/pjrt/worker_thread.h
+++ b/xla/pjrt/worker_thread.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/base/thread_annotations.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
 #include "xla/tsl/platform/env.h"
 #include "tsl/platform/env.h"
 
@@ -42,6 +43,14 @@ class WorkerThread {
 
   // Adds 'fn' to the queue of closures to be executed by the worker thread.
   void Schedule(absl::AnyInvocable<void() &&> fn);
+
+  // Blocks the calling thread until all closures that were enqueued before this
+  // call have completed. Any closures enqueued concurrently with or after this
+  // call may or may not have run when Drain() returns.
+  //
+  // Implementation: schedules a sentinel no-op closure and waits for it to be
+  // dequeued and executed, which guarantees that all prior closures have run.
+  void Drain();
 
   // Returns true if there is any outstanding work.
   bool HasBacklog() {


### PR DESCRIPTION
## Motivation

The iota_test was very slow on AMD targets (compared to NVDIA) because the pjrt client was destroyed and recreated for each of the 4500 tests that make up the `iota_test`. This task in ROCm is ~40× slower than with CUDA (see table below).

Phase | H100 | AMD MI300X
-- | -- | --
Previous client teardown + new client init (pre-BFC log) | ~35ms total | ~963ms total
BFC allocator re-setup (8 GPUs) | ~0.3ms | ~0.1ms
Per-test GPU lifecycle cost | 35ms | 1009ms

The main cause of slowdowns when creating and destroying a pjrt client lies in the creation and destruction of streams.
```
Per-test overhead (8 GPU ROCm, iota_test):

CREATION (~406ms):
  Phase1 GetGpuXlaClient:      0.2ms    (negligible, singleton)
  Phase2 hipStreamCreate ×112: 385ms    ← dominant creation cost
  Phase3 EnablePeerAccess:     0.4ms    (negligible, cached)
  Phase4 BFC Allocator:        0.2ms    (negligible, no prealloc)
  Phase5 BuildDistributed:      20ms    (RCCL topology)

DESTRUCTION (~513ms):
  dtor body:                   0.05ms
  thread pool shutdown:       138ms 
  hipStreamDestroy ×112:      375ms    ← dominant destruction cost
  SyncAllActivity:              1.5ms   (device 0 only)

TOTAL OVERHEAD:                ~919ms per test
ACTUAL COMPUTATION:             ~90ms  (IotaReshapeExtraDims = 1012ms total)
```


This PR therefore implements a cache to avoid creating and destroying the stream for each client/test, and to allow existing streams to be reused (after they have been cleared) for the next test in the process.
Note that the stream and associated meta data are cleared before being placed in the cache to ensure reusing the stream  can be reused safely. If a previous test failed due to a hardware failure preventing the stream from being cleared safely, it is destroyed and recreated for the next client/test.

On MI350:
Iota test | main (seconds) | with cache (seconds) | Improvement 
-- | -- | -- | --
Shard=1 | 2337 | 264 | 88.7%
Shard=50 | 610.8 | 61.1 | 90.0%
