### PR TITLE
Update execute_ci_build_upstream.sh

### DIFF
--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -56,7 +56,6 @@ done
     //xla/... \
     -//xla/tests:dot_operation_test_amdgpu_any \
     -//xla/backends/gpu/autotuner:triton_test_amdgpu_any \
-    -//xla/backends/gpu/transforms:gemm_rewriter_group_gemm_test_amdgpu_any \
     -//xla/tests:iota_test_amdgpu_any \
     -//xla/backends/gpu/tests:sorting_test_amdgpu_any \
     -//xla/hlo/builder/lib:self_adjoint_eig_test_amdgpu_any


### PR DESCRIPTION
Remove //xla/backends/gpu/transforms:gemm_rewriter_group_gemm_test_amdgpu_any
from the list of excluded tests. It is fixed after incorporation of the patch https://github.com/openxla/xla/pull/42613 into https://github.com/openxla/xla/commit/796ddbdf090eabe56d6a5652b7da86509c43efec

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
