### PR TITLE
Improve gpu collectives performance model 

### DIFF
--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -459,6 +459,93 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
 }
 
 TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       AllGatherOverlapWithAnalyticalCostModel) {
+  absl::string_view kHloModule = R"(
+    HloModule m, num_partitions=8
+
+    ENTRY main {
+      lhs = f32[8192,8192] parameter(0)
+      rhs = f32[8192,8192] parameter(1)
+      comm = f32[1024] parameter(2)
+      compute = f32[8192,8192] dot(lhs, rhs),
+        lhs_contracting_dims={1}, rhs_contracting_dims={0}
+      ag = (f32[1024], f32[8192]) all-gather-start(comm), dimensions={0},
+        replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1,
+        use_global_device_ids=true
+      ag_done = f32[8192] all-gather-done(ag)
+      ROOT tuple = (f32[8192], f32[8192,8192]) tuple(ag_done, compute)
+    }
+  )";
+
+  HloModuleConfig config = GetModuleConfig("");
+  DebugOptions& debug_options = config.mutable_debug_options();
+  debug_options.set_xla_gpu_enable_latency_hiding_scheduler(true);
+  debug_options.set_xla_gpu_enable_analytical_latency_estimator(true);
+  config.set_num_partitions(8);
+  config.set_use_spmd_partitioning(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule, config));
+  TF_ASSERT_OK(ScheduleModule(module.get()));
+
+  const auto& sequence =
+      module->schedule().sequence(module->entry_computation()).instructions();
+  int64_t ag_idx = GetIndexByName(sequence, "ag");
+  int64_t compute_idx = GetIndexByName(sequence, "compute");
+  int64_t ag_done_idx = GetIndexByName(sequence, "ag_done");
+
+  EXPECT_LT(ag_idx, compute_idx);
+  EXPECT_LT(compute_idx, ag_done_idx);
+}
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       ReduceScatterOverlapWithAnalyticalCostModel) {
+  absl::string_view kHloModule = R"(
+    HloModule m, num_partitions=8
+
+    reduce {
+      x = f32[] parameter(0)
+      y = f32[] parameter(1)
+      ROOT _ = f32[] add(x, y)
+    }
+
+    ENTRY main {
+      lhs = f32[8192,8192] parameter(0)
+      rhs = f32[8192,8192] parameter(1)
+      comm = f32[8192] parameter(2)
+      compute = f32[8192,8192] dot(lhs, rhs),
+        lhs_contracting_dims={1}, rhs_contracting_dims={0}
+      rs = ((f32[8192]), f32[1024]) reduce-scatter-start(comm),
+        to_apply=reduce, dimensions={0},
+        replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1,
+        use_global_device_ids=true
+      rs_done = f32[1024] reduce-scatter-done(rs)
+      ROOT tuple = (f32[1024], f32[8192,8192]) tuple(rs_done, compute)
+    }
+  )";
+
+  HloModuleConfig config = GetModuleConfig("");
+  DebugOptions& debug_options = config.mutable_debug_options();
+  debug_options.set_xla_gpu_enable_latency_hiding_scheduler(true);
+  debug_options.set_xla_gpu_enable_analytical_latency_estimator(true);
+  config.set_num_partitions(8);
+  config.set_use_spmd_partitioning(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule, config));
+  TF_ASSERT_OK(ScheduleModule(module.get()));
+
+  const auto& sequence =
+      module->schedule().sequence(module->entry_computation()).instructions();
+  int64_t rs_idx = GetIndexByName(sequence, "rs");
+  int64_t compute_idx = GetIndexByName(sequence, "compute");
+  int64_t rs_done_idx = GetIndexByName(sequence, "rs_done");
+
+  EXPECT_LT(rs_idx, compute_idx);
+  EXPECT_LT(compute_idx, rs_done_idx);
+}
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
        OverlappingRanksPreventOverlappingCollectives) {
   absl::string_view kFdoProfile = R"pb(
     costs { name: "add_0" cost_us: 100000.0 }

--- a/xla/service/gpu/model/gpu_collective_performance_model.cc
+++ b/xla/service/gpu/model/gpu_collective_performance_model.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "absl/time/time.h"
 #include "xla/hlo/analysis/hlo_dataflow_analysis.h"
 #include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/service/gpu/model/gpu_hlo_cost_analysis.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
@@ -281,7 +282,7 @@ int GetNumThreads(int warp_size, int min_num_threads, int max_num_threads,
 }
 
 template <typename GpuBandwidthSettings>
-absl::Duration ComputeAllreduceTimeImpl(
+absl::Duration ComputeCollectiveTimeImpl(
     const HloInstruction& instr, const GpuHloCostAnalysis* cost_analysis,
     const se::DeviceDescription& gpu_device_info,
     const GpuBandwidthSettings& bandwidth_settings) {
@@ -356,17 +357,17 @@ RocmBandwidthSettings CreateSettings(
 }  // namespace
 
 /*static*/ absl::Duration
-GpuPerformanceWithCollectiveModel::ComputeAllreduceTime(
+GpuPerformanceWithCollectiveModel::ComputeCollectiveTimeForRing(
     const HloInstruction& instr, const GpuHloCostAnalysis* cost_analysis,
     const se::DeviceDescription& gpu_device_info) {
   // We use nccl group call to launch multiple allreduces so launch overhead
   // only occurs once.
   if (auto ptr =
           gpu_device_info.gpu_compute_capability().cuda_compute_capability()) {
-    return ComputeAllreduceTimeImpl(instr, cost_analysis, gpu_device_info,
-                                    CreateSettings(*ptr));
+    return ComputeCollectiveTimeImpl(instr, cost_analysis, gpu_device_info,
+                                     CreateSettings(*ptr));
   }
-  return ComputeAllreduceTimeImpl(
+  return ComputeCollectiveTimeImpl(
       instr, cost_analysis, gpu_device_info,
       CreateSettings(
           *gpu_device_info.gpu_compute_capability().rocm_compute_capability()));
@@ -388,7 +389,25 @@ GpuPerformanceWithCollectiveModel::ComputeCollectiveTime(
   switch (instr.opcode()) {
     case HloOpcode::kAllReduce:
     case HloOpcode::kAllReduceStart:
-      return ComputeAllreduceTime(instr, cost_analysis, gpu_device_info);
+    case HloOpcode::kAllGather:
+    case HloOpcode::kAllGatherStart:
+    case HloOpcode::kReduceScatter:
+      return ComputeCollectiveTimeForRing(instr, cost_analysis,
+                                          gpu_device_info);
+    case HloOpcode::kAsyncStart: {
+      auto* async_start = Cast<HloAsyncStartInstruction>(&instr);
+      switch (async_start->async_wrapped_opcode()) {
+        case HloOpcode::kReduceScatter:
+          return ComputeCollectiveTimeForRing(instr, cost_analysis,
+                                              gpu_device_info);
+        default:
+          break;
+      }
+      LOG(WARNING)
+          << "Runtime estimate for " << instr.name()
+          << " not implemented. Returning only the kernel launch time.";
+      return kNcclKernelLaunchOverhead;
+    }
     default: {
       LOG(WARNING)
           << "Runtime estimate for " << instr.name()

--- a/xla/service/gpu/model/gpu_collective_performance_model.h
+++ b/xla/service/gpu/model/gpu_collective_performance_model.h
@@ -36,7 +36,7 @@ class GpuPerformanceWithCollectiveModel : public GpuPerformanceModelBase {
       const se::DeviceDescription& gpu_device_info);
 
  private:
-  static absl::Duration ComputeAllreduceTime(
+  static absl::Duration ComputeCollectiveTimeForRing(
       const HloInstruction& instr, const GpuHloCostAnalysis* cost_analysis,
       const se::DeviceDescription& gpu_device_info);
 };

--- a/xla/service/gpu/model/gpu_hlo_cost_analysis.cc
+++ b/xla/service/gpu/model/gpu_hlo_cost_analysis.cc
@@ -413,21 +413,13 @@ absl::Status GpuHloCostAnalysis::HandleAllReduce(
   current_properties_.set_output_bytes_accessed(output_bytes_accessed);
   current_properties_[kCollBytesTransferred] = output_bytes_accessed;
   current_properties_[kBytesAccessedKey] = bytes_accessed;
-  current_properties_[kCollNumDevicesKey] = num_ranks;
   // Since allreduce has compute, we need to get flops for the compute
   // part which is an elementwise op.
   current_properties_[kFlopsKey] = GetFlopsForElementwiseOp(
       allreduce->to_apply()->root_instruction()->opcode(), allreduce->shape());
 
-  // TODO TJ support multi-node case, we need to know how many nodes there are.
-  int num_intra_steps = 2 * (num_ranks - 1);
-  // Compute algorithmic scaling ratio, this can be used to be multiplied with
-  // bus bandwidth to get the effective bandwidth of the algorithm. The scaling
-  // ratio differs based on what algorithm NCCL chooses to use. This is the
-  // scaling factor for ring since NCCL will only use ring for single-node, need
-  // to add support for tree algo in multi-node case.
-  float scaling_ratio = (1.0 * num_ranks) / num_intra_steps;
-  current_properties_[kCollAlgoScaleRatioKey] = scaling_ratio;
+  SetRingCollectiveProperties(num_ranks,
+                              /*num_intra_steps=*/2 * (num_ranks - 1));
 
   return absl::OkStatus();
 }
@@ -501,14 +493,33 @@ absl::Status GpuHloCostAnalysis::HandleReduce(const HloInstruction* hlo) {
   return absl::OkStatus();
 }
 
+void GpuHloCostAnalysis::SetRingCollectiveProperties(int64_t num_ranks,
+                                                     int64_t num_intra_steps) {
+  current_properties_[kCollNumDevicesKey] = num_ranks;
+  // TODO TJ support multi-node case, we need to know how many nodes there are.
+  // Compute algorithmic scaling ratio, this can be used to be multiplied with
+  // bus bandwidth to get the effective bandwidth of the algorithm. The scaling
+  // ratio differs based on what algorithm NCCL chooses to use. This is the
+  // scaling factor for ring since NCCL will only use ring for single-node, need
+  // to add support for tree algo in multi-node case.
+  current_properties_[kCollAlgoScaleRatioKey] =
+      num_intra_steps > 0 ? static_cast<float>(num_ranks) / num_intra_steps : 0;
+}
+
 absl::Status GpuHloCostAnalysis::HandleAllReduceStart(
     const HloInstruction* hlo) {
+  TF_ASSIGN_OR_RETURN(int64_t num_ranks,
+                      NumRanks(*Cast<HloAllReduceInstruction>(hlo)));
+
   int64_t bytes_transferred = ShapeSize(hlo->shape(), options_.shape_size);
 
   current_properties_[kFlopsKey] = GetFlopsForElementwiseOp(
       hlo->to_apply()->root_instruction()->opcode(), hlo->shape());
   current_properties_[kBytesAccessedKey] = bytes_transferred;
   current_properties_[kCollBytesTransferred] = bytes_transferred;
+  SetRingCollectiveProperties(num_ranks,
+                              /*num_intra_steps=*/2 * (num_ranks - 1));
+
   return absl::OkStatus();
 }
 
@@ -523,6 +534,7 @@ absl::Status GpuHloCostAnalysis::HandleAllGather(const HloInstruction* hlo) {
 
   current_properties_[kBytesAccessedKey] = write_bytes + read_bytes;
   current_properties_[kCollBytesTransferred] = bytes_transferred;
+  SetRingCollectiveProperties(num_ranks, /*num_intra_steps=*/num_ranks - 1);
 
   return absl::OkStatus();
 }
@@ -540,6 +552,7 @@ absl::Status GpuHloCostAnalysis::HandleAllGatherStart(
 
   current_properties_[kBytesAccessedKey] = write_bytes + read_bytes;
   current_properties_[kCollBytesTransferred] = bytes_transferred;
+  SetRingCollectiveProperties(num_ranks, /*num_intra_steps=*/num_ranks - 1);
 
   return absl::OkStatus();
 }
@@ -573,6 +586,7 @@ absl::Status GpuHloCostAnalysis::HandleReduceScatter(
   current_properties_[kCollBytesTransferred] = bytes_transferred;
   current_properties_[kFlopsKey] = GetFlopsForElementwiseOp(
       hlo->to_apply()->root_instruction()->opcode(), hlo->shape());
+  SetRingCollectiveProperties(num_ranks, /*num_intra_steps=*/num_ranks - 1);
 
   return absl::OkStatus();
 }

--- a/xla/service/gpu/model/gpu_hlo_cost_analysis.h
+++ b/xla/service/gpu/model/gpu_hlo_cost_analysis.h
@@ -110,6 +110,11 @@ class GpuHloCostAnalysis : public HloCostAnalysis {
   int64_t GetFlopsForElementwiseOp(const HloInstruction* instr);
 
  protected:
+  // Populates kCollNumDevicesKey and kCollAlgoScaleRatioKey in
+  // current_properties_ for a ring-algorithm collective with `num_ranks`
+  // participants and `num_intra_steps` ring steps.
+  void SetRingCollectiveProperties(int64_t num_ranks, int64_t num_intra_steps);
+
   std::unique_ptr<HloCostAnalysis> CreateNestedCostAnalysis() override;
   int64_t FusionParameterReadBytes(const HloInstruction* hlo) const override;
   absl::Status FusionCalculateUtilizations(


### PR DESCRIPTION
Enable all-gather and reduce-scatter in gpu collectives perf model. Improves computatin-communication overlap when using the analytical latency estimator.