### PR TITLE
Remove SVDTest from ignore tests list

### DIFF
--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -11,7 +11,6 @@ EXCLUDED_TESTS=(
     "TritonAndBlasSupportForDifferentTensorSizes/TritonAndBlasSupportForDifferentTensorSizes.IsDotAlgorithmSupportedByTriton/dot_bf16_bf16_f32_x*"
     "DeterminismTest.CublasDot"
     "F8E5M2Tests/DotAlgorithmSupportTest.AlgorithmIsSupportedFromCudaCapability/dot_any_f8_any_f8_f32_*"
-    "SVDTest.Various_Size_Random_Matrix*"
     "CubSort/CubSortPairsTest*"
     "SampleFileTest.Convolution" # https://wardite.cluster.engflow.com/invocations/default/c105260c-873a-4634-ab69-905a43ca5cf8
 )


### PR DESCRIPTION
As we excluded failing nodes on rbe this test must be green now.