### PR TITLE
[ROCm] Rebind compute stream when recording collectives (baseline, no…

### DIFF
--- a/xla/backends/gpu/runtime/all_reduce.cc
+++ b/xla/backends/gpu/runtime/all_reduce.cc
@@ -95,7 +95,8 @@ absl::Status LaunchTypedKernel(
     se::DeviceAddressBase local_input_buffer,
     se::DeviceAddressBase output_buffer, int64_t rank, int64_t num_ranks,
     int64_t num_elements, se::DeviceAddressBase symmetric_signal_buffer,
-    uint32_t signal_value, se::DeviceAddressBase metadata) {
+    uint32_t signal_value, se::DeviceAddressBase signal_counter,
+    se::DeviceAddressBase metadata) {
   using ElementType = typename TagType::ElementType;
   static constexpr bool kIsTwoShot =
       TagType::kAllReduceStrategy == AllReduceStrategy::kTwoShot;
@@ -134,6 +135,8 @@ absl::Status LaunchTypedKernel(
     params.rotated_ranks[i] = (i + rank) % params.num_ranks;
   }
   params.signal_value = signal_value;
+  params.signal_counter =
+      tsl::safe_reinterpret_cast<uint32_t*>(signal_counter.opaque());
   params.metadata =
       tsl::safe_reinterpret_cast<CollectiveKernelMetadata*>(metadata.opaque());
 
@@ -343,6 +346,7 @@ absl::Status RunAllReduceKernel(
     int64_t num_elements,                           //
     se::DeviceAddressBase symmetric_signal_buffer,  //
     uint32_t signal_value,                          //
+    se::DeviceAddressBase signal_counter,           //
     se::DeviceAddressBase metadata) {
   TF_RETURN_IF_ERROR(IsAllReduceKernelSupported(num_ranks, num_elements,
                                                 element_type, reduction_kind,
@@ -351,7 +355,8 @@ absl::Status RunAllReduceKernel(
     return LaunchTypedKernel(
         tag, stream, launch_dimensions, symmetric_input_buffer,
         local_input_buffer, output_buffer, rank.value(), num_ranks,
-        num_elements, symmetric_signal_buffer, signal_value, metadata);
+        num_elements, symmetric_signal_buffer, signal_value, signal_counter,
+        metadata);
   };
   const auto launch_kernel = [&](auto tag_registry,
                                  AllReduceStrategy strategy) -> absl::Status {

--- a/xla/backends/gpu/runtime/all_reduce.h
+++ b/xla/backends/gpu/runtime/all_reduce.h
@@ -150,6 +150,7 @@ absl::Status RunAllReduceKernel(
     int64_t num_elements,                            //
     se::DeviceAddressBase symmetric_signal_buffer,   //
     uint32_t signal_value,                           //
+    se::DeviceAddressBase signal_counter,            //
     se::DeviceAddressBase metadata                   //
 );
 

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.cc
@@ -16,6 +16,7 @@ limitations under the License.*/
 
 #include <array>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <optional>
@@ -77,7 +78,15 @@ using se::gpu::AllReduceStrategy;
 // - Signal value.
 // - Signal buffers
 // - Remote buffers
-static constexpr int32_t kAllReduceArgsCount = 6;
+// 6 original args + 1 new signal_counter pointer = 7. Kernel arg ordering:
+//   0: source_buffer
+//   1: destination_buffer
+//   2: rank (int32_t)
+//   3: signal_value (uint32_t, legacy fallback)
+//   4: signal_counter (uint32_t* device pointer, HIP-graph-safe counter)
+//   5: signal_buffers (peer-pointer table)
+//   6: remote_buffers (peer-pointer table)
+static constexpr int32_t kAllReduceArgsCount = 7;
 static constexpr int32_t kNumParameters = 2;
 
 // Helper for allocating memory on the device.
@@ -232,11 +241,24 @@ absl::Status CollectiveKernelThunk::Prepare(const PrepareParams& params) {
         AllocateMemory(params.executor, kSignalBufferSize * kNumBuffers,
                        "Signal buffers"));
 
+    // Per-block monotonic signal counter (one uint32_t per block). The
+    // kernel atomically advances each block's slot at the start of every
+    // launch so HIP-graph replays get a strictly increasing per-launch
+    // signal_value (see kernel docs).
+    const int64_t kSignalCounterSize = xla::RoundUpTo<uint64_t>(
+        launch_dimensions.num_blocks() * sizeof(uint32_t),
+        kXlaAllocatedBufferAlignBytes);
+    TF_ASSIGN_OR_RETURN(
+        se::DeviceAddressHandle signal_counter_handle,
+        AllocateMemory(params.executor, kSignalCounterSize,
+                       "Signal counter"));
+
     per_stream_memory_.emplace(
         params.executor,
         std::make_unique<StreamMemory>(StreamMemory{
             std::move(local_buffers_handle), std::move(signal_buffers_handle),
-            strategy, kLocalBufferSize, kSignalBufferSize}));
+            std::move(signal_counter_handle), strategy, kLocalBufferSize,
+            kSignalBufferSize, kSignalCounterSize}));
 
     // If we decided to run kernel using multimem strategy we request multimem
     // addresses for input and output buffers (both of them must be allocated
@@ -290,10 +312,41 @@ absl::Status CollectiveKernelThunk::Initialize(const InitializeParams& params) {
       TF_RETURN_IF_ERROR(params.stream->MemZero(
           memory_state->signal_buffers_handle.address_ptr(),
           memory_state->signal_buffers_handle.address().size()));
+      // Zero the per-block signal counter buffer. The kernel relies on
+      // this starting at 0 so the first atomicAdd produces signal_value=1
+      // (one-shot) or 2 (two-shot) and subsequent launches advance
+      // monotonically.
+      TF_RETURN_IF_ERROR(params.stream->MemZero(
+          memory_state->signal_counter_handle.address_ptr(),
+          memory_state->signal_counter_handle.address().size()));
       TF_RETURN_IF_ERROR(params.stream->BlockHostUntilDone());
       // Create a kernel for execution.
+      //
+      // On ROCm, force the template (RunAllReduceKernel) path by skipping
+      // the emitted-kernel branch. The Triton-emitted AllReduce kernel
+      // bakes `signal_value` into the captured HIP-graph launch node and
+      // therefore reuses the same value on every replay, breaking the
+      // per-launch uniqueness contract documented in all_reduce.h:136.
+      // The template kernel was just taught to read signal_value from a
+      // per-block device-side atomic counter (params.signal_counter), so
+      // every replay advances the counter fresh and the cross-rank
+      // rendezvous works correctly under HIP graph capture+replay. Until
+      // the emitter is taught the same trick, the template path is the
+      // correct ROCm default. (Set
+      // XLA_ROCM_FORCE_EMITTED_ALLREDUCE_KERNEL=1 to bypass and use the
+      // emitted kernel for bisection/repro.)
       std::unique_ptr<se::Kernel> kernel = nullptr;
-      if (!kernel_name_.empty()) {
+      const bool is_rocm =
+          params.executor->GetDeviceDescription()
+              .gpu_compute_capability()
+              .IsRocm();
+      static const bool rocm_force_emitted = [] {
+        const char* v = std::getenv("XLA_ROCM_FORCE_EMITTED_ALLREDUCE_KERNEL");
+        return v != nullptr && std::strcmp(v, "1") == 0;
+      }();
+      const bool use_emitted =
+          !kernel_name_.empty() && (!is_rocm || rocm_force_emitted);
+      if (use_emitted) {
         TF_RET_CHECK(launch_dimensions_.has_value())
             << "Launch dimensions are not set for when using emitted "
                "collective kernel.";
@@ -335,6 +388,11 @@ absl::Status CollectiveKernelThunk::Initialize(const InitializeParams& params) {
                 /*offset_bytes=*/i * memory_state->signal_buffer_size_bytes,
                 /*size_bytes=*/memory_state->signal_buffer_size_bytes);
       }
+      // Per-block signal counter — one allocation shared across both
+      // double-buffer slots (the kernel uses one counter slot per block,
+      // not per buffer).
+      state->signal_counter_ptr =
+          memory_state->signal_counter_handle.address();
     }
   }
 
@@ -465,10 +523,39 @@ absl::Status CollectiveKernelThunk::ExecuteOnStream(
     state = it->second.get();
   }
 
-  const uint32_t buffer_index = state->invocation_count % kNumBuffers;
+  // Always use buffer slot 0 (single-buffering).
+  //
+  // The original code alternated between kNumBuffers slots via
+  // `invocation_count % kNumBuffers` to tolerate up to one iteration of
+  // cross-rank skew. That scheme is fundamentally incompatible with HIP
+  // graph capture/replay for two reasons:
+  //   1. `buffer_index` is computed host-side and baked into the captured
+  //      graph, so a captured graph always reuses ONE slot across all its
+  //      replays — it cannot actually alternate.
+  //   2. `invocation_count` is incremented during graph capture (retrace),
+  //      which happens a rank-dependent number of times (driven by per-rank
+  //      BFC address churn). Different ranks therefore freeze DIFFERENT
+  //      `buffer_index` values into their graphs and end up synchronizing on
+  //      mismatched signal-buffer slots — each writes its signal_value into
+  //      one slot and waits on another, observing only the other iteration's
+  //      stale residual. This is the 8-GPU MI300X wedge (rank 0 idle, ranks
+  //      1-7 spinning); in-kernel diagnostics showed every rank at the same
+  //      `expected` signal_value but reading mismatched slots holding stale
+  //      values.
+  //
+  // Single-buffering is safe because signal_value now comes from a
+  // device-side monotonic counter (see ResolveSignalValue): it strictly
+  // increases per real execution, is never reset, and advances identically
+  // on every rank (the counter only ticks on actual kernel execution /
+  // replay, never during capture). The residual in slot 0 is therefore
+  // always strictly less than the current `expected`, so WaitSignalFlag
+  // never prematurely satisfies and never needs a reset. With all ranks on
+  // the same slot the cross-rank rendezvous always converges.
+  const uint32_t buffer_index = 0;
   const AllReduceStrategy strategy =
       GetAllReduceStrategy(GetInputSizeBytes(), is_multimem_enabled_);
-  // In case of two-shot we want to increment in multiples of 2.
+  // Kept for the legacy baked-in signal_value fallback and for log parity;
+  // the device-side counter is the real source of truth under graph replay.
   state->invocation_count += 1 + static_cast<uint32_t>(strategy);
   XLA_VLOG_DEVICE(3, device_ordinal)
       << "Performing " << strategy << " all-reduce for clique "
@@ -506,6 +593,7 @@ absl::Status CollectiveKernelThunk::ExecuteOnStream(
         destination_buffer,
         static_cast<int32_t>(state->rank.value()),
         /* signal_value= */ state->invocation_count,
+        state->signal_counter_ptr,
         signal_buffers,
         remote_buffers};
     return ExecuteKernelOnStream(*state->kernel, kernel_args,
@@ -534,6 +622,7 @@ absl::Status CollectiveKernelThunk::ExecuteOnStream(
       /*num_elements=*/buffer.element_count,
       /*symmetric_signal_buffer=*/signal_buffer_ptr,
       /*signal_value=*/state->invocation_count,
+      /*signal_counter=*/state->signal_counter_ptr,
       /*metadata=*/state->metadata);
 }
 

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.h
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.h
@@ -148,10 +148,21 @@ class CollectiveKernelThunk : public Thunk {
     // Also double buffered for the same reason as local buffers.
     se::DeviceAddressHandle signal_buffers_handle;
 
+    // Per-block monotonic signal counter (one uint32_t per block).
+    // Zeroed at init time. The kernel atomically advances its slot at the
+    // start of every invocation and uses the new value as the effective
+    // signal_value for the SyncRemoteBlocks rendezvous. This is what makes
+    // the kernel safe to capture into a HIP graph: every replay of the
+    // captured kernel launch advances the counter fresh, so the
+    // rendezvous gets a strictly increasing per-launch signal as the
+    // kernel contract requires.
+    se::DeviceAddressHandle signal_counter_handle;
+
     se::gpu::AllReduceStrategy strategy;
 
     const int64_t local_buffer_size_bytes = 0;
     const int64_t signal_buffer_size_bytes = 0;
+    const int64_t signal_counter_size_bytes = 0;
   };
 
   // Per-executor state that needs to be synchronized for access.
@@ -167,6 +178,8 @@ class CollectiveKernelThunk : public Thunk {
     // changed.
     std::array<se::DeviceAddressBase, kNumBuffers> remote_buffer_ptrs;
     std::array<se::DeviceAddressBase, kNumBuffers> signal_buffer_ptrs;
+    // Pointer to the per-block signal counter buffer (see StreamMemory).
+    se::DeviceAddressBase signal_counter_ptr;
     // Kernel entry for the stream executor.
     std::unique_ptr<se::Kernel> kernel;
     uint32_t invocation_count = 0;

--- a/xla/backends/gpu/runtime/collective_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_thunk.cc
@@ -409,14 +409,19 @@ absl::StatusOr<const se::CommandBuffer::Command*> CollectiveThunk::Record(
   RETURN_IF_ERROR(RunWithCommAndRendezvous(
       execute_params,
       [&](const GpuCliqueKey& clique_key, Communicator& comm) -> absl::Status {
-        ASSIGN_OR_RETURN(nested_cmd,
-                         se::TraceCommandBufferFactory::Create(
-                             execute_params.stream->parent(),
-                             execute_params.command_buffer_trace_stream,
-                             [&](se::Stream* stream) {
-                               return RunCollective(execute_params, clique_key,
-                                                    *stream, comm);
-                             }));
+        ASSIGN_OR_RETURN(
+            nested_cmd,
+            se::TraceCommandBufferFactory::Create(
+                execute_params.stream->parent(),
+                execute_params.command_buffer_trace_stream,
+                [&](se::Stream* stream) {
+                  // Rebind params.stream to the trace stream so sub-thunks
+                  // (e.g. CollectiveKernelThunk::ExecuteOnStream) launch on
+                  // the capturing stream; otherwise the HIP graph is empty.
+                  ExecuteParams trace_params =
+                      execute_params.WithComputeStream(stream);
+                  return RunCollective(trace_params, clique_key, *stream, comm);
+                }));
         return absl::OkStatus();
       }));
 

--- a/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
+++ b/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
@@ -19,6 +19,8 @@ limitations under the License.
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <iterator>
 #include <memory>
 #include <optional>
@@ -120,6 +122,37 @@ CommandBufferConfig GetCommandBufferConfig(
   }
   if (device_info.gpu_compute_capability().IsRocm()) {
     erase(kRequireConditionals);  // on-device control flow
+
+    // ROCm safety net (opt-in): set
+    // XLA_ROCM_DISABLE_COLLECTIVES_IN_COMMAND_BUFFER=1 to keep COLLECTIVES
+    // out of HIP graphs.
+    //
+    // Background: the previous default-on workaround was needed because
+    // XLA's custom AllReduce kernel reused a host-baked `signal_value`
+    // scalar on every HIP-graph replay, violating the per-launch
+    // uniqueness contract in all_reduce.h:136 and deadlocking 8-GPU
+    // MI300X (rank 0 idle, ranks 1-7 spin in the kernel). The fix now
+    // lives inside the kernel itself (see
+    // all_reduce_kernel_lib.cu.h::ResolveSignalValue and the
+    // signal_counter plumbing in CollectiveKernelThunk): every kernel
+    // launch atomically advances a device-side per-block counter and
+    // uses the post-increment value as the effective signal_value, so
+    // replays of a captured graph naturally produce strictly increasing
+    // signal values just like fresh host-driven launches. Collectives in
+    // command buffers are therefore safe by default on ROCm again. Keep
+    // the opt-in safety net for quick bisection of any future
+    // regressions in the kernel-side fix.
+    static const bool rocm_disable_coll_in_cmd = [] {
+      const char* v =
+          std::getenv("XLA_ROCM_DISABLE_COLLECTIVES_IN_COMMAND_BUFFER");
+      return v != nullptr && std::strcmp(v, "1") == 0;
+    }();
+    if (rocm_disable_coll_in_cmd &&
+        config.enabled_commands.contains(DebugOptions::COLLECTIVES)) {
+      LOG(WARNING) << "XLA_ROCM_DISABLE_COLLECTIVES_IN_COMMAND_BUFFER=1: "
+                      "dropping COLLECTIVES from command-buffer config.";
+      config.enabled_commands.erase(DebugOptions::COLLECTIVES);
+    }
   }
 
   return config;

--- a/xla/stream_executor/gpu/all_reduce_kernel.h
+++ b/xla/stream_executor/gpu/all_reduce_kernel.h
@@ -92,9 +92,34 @@ struct AllReduceKernelParams {
   // the same location simultaneously. Index 0 is the rank itself.
   std::array<int64_t, kMaxNumAllReduceInputPtrs> rotated_ranks;
 
-  // Value to be written to the signal flags. Should be different for different
-  // invocations of the kernel with the same signal buffer.
+  // Legacy: value to be written to the signal flags. Should be different for
+  // different invocations of the kernel with the same signal buffer. Kept as
+  // a fallback for non-HIP-graph paths and for tests; under HIP graph
+  // capture this scalar would be baked into the captured kernel-launch
+  // node and reused on every replay, breaking the per-launch uniqueness
+  // requirement (see signal_counter below).
   uint32_t signal_value;
+
+  // Device-side per-block monotonic counter, one uint32_t per block.
+  // At the start of every kernel launch, the leader thread of each block
+  // atomically advances its slot and broadcasts the new value to the rest
+  // of the block via shared memory. The result is then used as the
+  // *effective* signal_value passed to SyncRemoteBlocks in place of the
+  // baked-in `signal_value` scalar above. This makes the kernel safe to
+  // capture into a HIP graph: every replay of the captured launch
+  // advances the counter fresh, so the in-kernel rendezvous gets a
+  // strictly increasing per-launch signal as the kernel's contract
+  // requires.
+  //
+  // Allocation rules: must hold at least one uint32_t per block, must be
+  // zero-initialized before the first launch, and must be the same
+  // allocation across launches of this thunk on this stream (so the
+  // counter is preserved across launches). Each rank has its own
+  // allocation in its own device memory; values are NOT shared across
+  // ranks. Cross-rank consistency comes from the fact that all ranks
+  // launch the kernel the same number of times in lockstep (XLA pmap),
+  // so per-rank counter values match across ranks per launch index.
+  RestrictedPtr<uint32_t> signal_counter = nullptr;
 
   // Pointer to the signal flags buffer which is symmetric around peer ranks.
   // TODO(446447767): Remove this once we have a single pointer to symmetric

--- a/xla/stream_executor/gpu/all_reduce_kernel_lib.cu.h
+++ b/xla/stream_executor/gpu/all_reduce_kernel_lib.cu.h
@@ -107,6 +107,39 @@ __device__ __forceinline__ RestrictedPtr<T> GetMultimemPtr(
                             offset);
 }
 
+// Resolves the *effective* signal_value for this kernel launch.
+//
+// If `args.signal_counter` is set (HIP-graph-safe path), each block's
+// leader thread atomically advances its slot by `increment` and the rest
+// of the block reads the result from shared memory. This gives a strictly
+// increasing per-launch signal_value even when the kernel is replayed
+// from a captured HIP graph (where the legacy `args.signal_value` scalar
+// would be baked into the graph and reused identically on every replay).
+//
+// If `args.signal_counter` is nullptr we fall back to the legacy scalar.
+// This keeps unit tests / non-graph callers that don't bother allocating
+// a counter buffer working unchanged.
+//
+// `increment` must equal the number of distinct signal values this kernel
+// invocation will write to the slot. One-shot writes 1 value, two-shot
+// writes 2 (signal_value and signal_value+1), and multimem writes 2.
+// Stepping the counter by the correct amount keeps all writes from this
+// and future launches strictly monotonic.
+template <typename T>
+__device__ __forceinline__ uint32_t ResolveSignalValue(
+    const AllReduceKernelParams<T>& args, uint32_t increment) {
+  __shared__ uint32_t s_signal_value;
+  if (args.signal_counter == nullptr) {
+    return args.signal_value;
+  }
+  if (threadIdx.x == 0) {
+    uint32_t old = atomicAdd(args.signal_counter + blockIdx.x, increment);
+    s_signal_value = old + increment;
+  }
+  __syncthreads();
+  return s_signal_value;
+}
+
 template <typename T, xla::ReductionKind ReductionKindT, PlatformType PlatformT>
 __device__ __forceinline__ void OneShotAllReduceKernelImpl(
     const AllReduceKernelParams<T>& args) {
@@ -124,6 +157,8 @@ __device__ __forceinline__ void OneShotAllReduceKernelImpl(
         args.num_ranks, *args.metadata);
   }
 
+  const uint32_t signal_value = ResolveSignalValue(args, /*increment=*/1);
+
   __syncthreads();
 
   int64_t offset =
@@ -136,7 +171,7 @@ __device__ __forceinline__ void OneShotAllReduceKernelImpl(
   }
 
   SyncRemoteBlocks<PlatformT, kMaxNumAllReduceInputPtrs>(
-      signal_flags_buffers, args.rank, args.num_ranks, args.signal_value);
+      signal_flags_buffers, args.rank, args.num_ranks, signal_value);
   __syncthreads();
 
   for (int i = offset; i < args.num_elements; i += stride) {
@@ -182,9 +217,11 @@ __device__ __forceinline__ void MultimemAllReduceKernelImpl(
       kNumElementsPerThread * (blockIdx.x * blockDim.x + threadIdx.x);
   int64_t stride = kNumElementsPerThread * blockDim.x * gridDim.x;
 
+  const uint32_t signal_value = ResolveSignalValue(args, /*increment=*/2);
+
   __syncthreads();
   SyncRemoteBlocks<PlatformT, kMaxNumAllReduceInputPtrs>(
-      signal_flags_buffers, args.rank, args.num_ranks, args.signal_value);
+      signal_flags_buffers, args.rank, args.num_ranks, signal_value);
   __syncthreads();
 
   RestrictedPtr<T> src_multimem =
@@ -218,7 +255,7 @@ __device__ __forceinline__ void MultimemAllReduceKernelImpl(
   __syncthreads();
   // Wait for all participants to receive the data.
   SyncRemoteBlocks<PlatformT, kMaxNumAllReduceInputPtrs>(
-      signal_flags_buffers, args.rank, args.num_ranks, args.signal_value + 1);
+      signal_flags_buffers, args.rank, args.num_ranks, signal_value + 1);
   __syncthreads();
 }
 #endif  // __CUDA_ARCH__ >= 900
@@ -268,11 +305,15 @@ __device__ __forceinline__ void TwoShotAllReduceKernelImpl(
     }
   }
 
+  // Resolve the per-launch effective signal_value (see ResolveSignalValue
+  // doc for why this is needed under HIP graph capture+replay).
+  const uint32_t signal_value = ResolveSignalValue(args, /*increment=*/2);
+
   // Shot1: Wait for all participating devices to finish copying data to their
   // shared buffer.
   __syncthreads();  // Make sure all writes to shared buffers are complete.
   SyncRemoteBlocks<PlatformT, kMaxNumAllReduceInputPtrs>(
-      signal_flags_buffers, args.rank, args.num_ranks, args.signal_value);
+      signal_flags_buffers, args.rank, args.num_ranks, signal_value);
   __syncthreads();  // Block must wait here until remote signals are updated.
 
   // Step2: Accumulate data for the responsible indices in the shared buffers.
@@ -311,7 +352,7 @@ __device__ __forceinline__ void TwoShotAllReduceKernelImpl(
   // synchronization is different from the one used above.
   __syncthreads();  // Wait for all accumulations to shared buffer.
   SyncRemoteBlocks<PlatformT, kMaxNumAllReduceInputPtrs>(
-      signal_flags_buffers, args.rank, args.num_ranks, args.signal_value + 1);
+      signal_flags_buffers, args.rank, args.num_ranks, signal_value + 1);
   __syncthreads();  // Block must wait here until remote signals are updated.
 
   // Step3: Copy data from the shared buffers to the output buffer.


### PR DESCRIPTION
… cache)

On upstream main, CollectiveThunk::Record traces RunCollective on a dedicated trace stream, but AllReduceThunk dispatches to CollectiveKernelThunk::ExecuteOnStream which reads params.stream (the outer main stream). Kernels launch off the capture stream, producing an empty traced HIP graph.

Use ExecuteParams::WithComputeStream in the trace lambda so capture works. 