### PR TITLE
Cherry pick/profiler v1 build fix v092

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -455,7 +455,7 @@ cc_library(
         ":use_v1": ["@local_config_rocm//rocm:roctracer"],
         ":use_rocprofiler_sdk": ["@local_config_rocm//rocm:rocprofiler_sdk"],
         "//conditions:default": ["@local_config_rocm//rocm:rocprofiler_sdk"],
-    })
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -579,6 +579,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/synchronization",
         "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:dso_loader",
         "@tsl//tsl/platform:env",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:logging",

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -32,6 +32,10 @@ limitations under the License.
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "rocm/include/rocprofiler-sdk/fwd.h"
+#include "rocm/include/rocprofiler-sdk/rocprofiler.h"
+#include "rocm/include/roctracer/roctracer.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/platform/status.h"
 #include "xla/tsl/profiler/utils/parse_annotation.h"
@@ -41,10 +45,6 @@ limitations under the License.
 #include "xla/tsl/profiler/utils/xplane_utils.h"
 #include "tsl/platform/abi.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
-#include "rocm/include/hip/hip_runtime.h"
-#include "rocm/include/rocprofiler-sdk/fwd.h"
-#include "rocm/include/rocprofiler-sdk/rocprofiler.h"
-#include "rocm/include/roctracer/roctracer.h"
 
 namespace xla {
 namespace profiler {

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -511,9 +511,12 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
   if (event.source == RocmTracerEventSource::ApiCallback) {
     if (!is_auxiliary) {
       if (num_callback_events_ >= options_.max_callback_api_events) {
-        OnEventsDropped("max callback event capacity reached",
-                        event.correlation_id);
-        PrintRocmTracerEvent(event, ". Dropped!");
+        LOG(WARNING)
+            << "!!! Number of callback events = " << num_callback_events_
+            << " is greater than/equal to the max callback api events = "
+            << options_.max_callback_api_events
+            << ". To collect more GPU events, please set "
+               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events=X ";
         return;
       }
       num_callback_events_++;
@@ -530,11 +533,16 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
     if (event.domain == RocmTracerEventDomain::HIP_API) {
       // we do not count HIP_OPS activities.
       if (num_activity_events_ >= options_.max_activity_api_events) {
-        OnEventsDropped("max activity event capacity reached",
-                        event.correlation_id);
-        PrintRocmTracerEvent(event, ". Dropped!");
+        LOG_FIRST_N(WARNING, 1)
+            << "Number of activity events (" << num_activity_events_
+            << ") has reached the configured limit "
+               "(xla_gpu_rocm_max_trace_events="
+            << options_.max_activity_api_events
+            << "). To collect more GPU events, increase "
+               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events=<value>.";
         return;
       }
+
       num_activity_events_++;
     }
 

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -32,10 +32,6 @@ limitations under the License.
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
-#include "rocm/include/hip/hip_runtime.h"
-#include "rocm/include/rocprofiler-sdk/fwd.h"
-#include "rocm/include/rocprofiler-sdk/rocprofiler.h"
-#include "rocm/include/roctracer/roctracer.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/platform/status.h"
 #include "xla/tsl/profiler/utils/parse_annotation.h"
@@ -45,6 +41,10 @@ limitations under the License.
 #include "xla/tsl/profiler/utils/xplane_utils.h"
 #include "tsl/platform/abi.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "rocm/include/rocprofiler-sdk/fwd.h"
+#include "rocm/include/rocprofiler-sdk/rocprofiler.h"
+#include "rocm/include/roctracer/roctracer.h"
 
 namespace xla {
 namespace profiler {
@@ -136,6 +136,19 @@ void PrintRocmTracerEvent(const RocmTracerEvent& event,
   VLOG(3) << oss.str() << ' ' << message;
 }
 
+#if XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V1
+static uint64_t get_timestamp() {
+  uint64_t ts;
+  if (roctracer_get_timestamp(&ts) != ROCTRACER_STATUS_SUCCESS) {
+    const char* errstr = roctracer_error_string();
+    LOG(ERROR) << "function roctracer_get_timestamp failed with error "
+               << errstr;
+    // Return 0 on error.
+    return 0;
+  }
+  return ts;
+}
+#else
 uint64_t get_timestamp() {
   uint64_t ts;
   rocprofiler_status_t CHECKSTATUS = rocprofiler_get_timestamp(&ts);
@@ -147,6 +160,7 @@ uint64_t get_timestamp() {
   }
   return ts;
 }
+#endif  // XLA_GPU_ROCM_TRACER_BACKEND == XLA_GPU_ROCM_TRACER_BACKEND_V1
 }  // namespace
 
 OccupancyStats PerDeviceCollector::GetOccupancy(
@@ -497,12 +511,9 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
   if (event.source == RocmTracerEventSource::ApiCallback) {
     if (!is_auxiliary) {
       if (num_callback_events_ >= options_.max_callback_api_events) {
-        LOG(WARNING)
-            << "!!! Number of callback events = " << num_callback_events_
-            << " is greater than/equal to the max callback api events = "
-            << options_.max_callback_api_events
-            << ". To collect more GPU events, please set "
-               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events=X ";
+        OnEventsDropped("max callback event capacity reached",
+                        event.correlation_id);
+        PrintRocmTracerEvent(event, ". Dropped!");
         return;
       }
       num_callback_events_++;
@@ -519,16 +530,11 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
     if (event.domain == RocmTracerEventDomain::HIP_API) {
       // we do not count HIP_OPS activities.
       if (num_activity_events_ >= options_.max_activity_api_events) {
-        LOG_FIRST_N(WARNING, 1)
-            << "Number of activity events (" << num_activity_events_
-            << ") has reached the configured limit "
-               "(xla_gpu_rocm_max_trace_events="
-            << options_.max_activity_api_events
-            << "). To collect more GPU events, increase "
-               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events=<value>.";
+        OnEventsDropped("max activity event capacity reached",
+                        event.correlation_id);
+        PrintRocmTracerEvent(event, ". Dropped!");
         return;
       }
-
       num_activity_events_++;
     }
 

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -30,11 +30,11 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "rocprofiler-sdk/agent.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/utils/xplane_builder.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
-#include "rocm/include/hip/hip_runtime.h"
-#include "rocprofiler-sdk/agent.h"
 
 // Backend: 3=v3 (rocprofiler-sdk), 1=v1 (roctracer). Default to v3.
 #if !defined(XLA_GPU_ROCM_TRACER_BACKEND_V3)

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -30,11 +30,24 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
-#include "rocm/include/hip/hip_runtime.h"
-#include "rocprofiler-sdk/agent.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/utils/xplane_builder.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "rocprofiler-sdk/agent.h"
+
+// Backend: 3=v3 (rocprofiler-sdk), 1=v1 (roctracer). Default to v3.
+#if !defined(XLA_GPU_ROCM_TRACER_BACKEND_V3)
+#define XLA_GPU_ROCM_TRACER_BACKEND_V3 3
+#endif
+
+#if !defined(XLA_GPU_ROCM_TRACER_BACKEND_V1)
+#define XLA_GPU_ROCM_TRACER_BACKEND_V1 1
+#endif
+
+#ifndef XLA_GPU_ROCM_TRACER_BACKEND
+#error "XLA_GPU_ROCM_TRACER_BACKEND not defined"
+#endif
 
 namespace xla {
 namespace profiler {


### PR DESCRIPTION
## Motivation
Cherry-pick from https://github.com/ROCm/xla/pull/871
PR https://github.com/ROCm/xla/pull/804 ("Streamline bazel targets for rocm libraries") unconditionally references rocprofiler-sdk (v3) symbols in rocm_collector.cc, breaking v1 profiler builds that use --define=xla_rocm_profiler=v1.

## Technical Details

Guard rocprofiler_get_timestamp/rocprofiler_get_status_string behind #if XLA_GPU_ROCM_TRACER_BACKEND != XLA_GPU_ROCM_TRACER_BACKEND_V1, using roctracer_get_timestamp for the v1 path.
Remove unconditional rocprofiler-sdk includes from the header.
essentially this PR copies the diffs of https://github.com/ROCm/xla/commit/b6a2823eef9048aa367ed985c60ca23672a9925a xla/backends/profiler/gpu/rocm_collector.cc and xla/backends/profiler/gpu/rocm_collector.h to 0.9.1 because they were missing.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
