### PR TITLE
Restore LOG(WARNING)/LOG_FIRST_N for trace-event capacity limits

### DIFF
--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -511,9 +511,12 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
   if (event.source == RocmTracerEventSource::ApiCallback) {
     if (!is_auxiliary) {
       if (num_callback_events_ >= options_.max_callback_api_events) {
-        OnEventsDropped("max callback event capacity reached",
-                        event.correlation_id);
-        PrintRocmTracerEvent(event, ". Dropped!");
+        LOG(WARNING)
+            << "!!! Number of callback events = " << num_callback_events_
+            << " is greater than/equal to the max callback api events = "
+            << options_.max_callback_api_events
+            << ". To collect more GPU events, please set "
+               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events=X ";
         return;
       }
       num_callback_events_++;
@@ -530,11 +533,16 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
     if (event.domain == RocmTracerEventDomain::HIP_API) {
       // we do not count HIP_OPS activities.
       if (num_activity_events_ >= options_.max_activity_api_events) {
-        OnEventsDropped("max activity event capacity reached",
-                        event.correlation_id);
-        PrintRocmTracerEvent(event, ". Dropped!");
+        LOG_FIRST_N(WARNING, 1)
+            << "Number of activity events (" << num_activity_events_
+            << ") has reached the configured limit "
+               "(xla_gpu_rocm_max_trace_events="
+            << options_.max_activity_api_events
+            << "). To collect more GPU events, increase "
+               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events=<value>.";
         return;
       }
+
       num_activity_events_++;
     }
 


### PR DESCRIPTION
## Motivation

PR #871 (28d1cbc3e4) ported the v1/v3 rocprofiler-sdk backend split from ROCm/xla@b6a2823, but two hunks in `RocmTraceCollectorImpl::AddEvent()` were carried along by mistake, they silently reverted the capacity-limit
warnings from PR #33666 (710168c456) back to the older `OnEventsDropped(...) + PrintRocmTracerEvent(event, ". Dropped!")` form.
This PR restores those `LOG(WARNING)` / `LOG_FIRST_N(WARNING, 1)` messages so users hitting either limit are told to set
`XLA_FLAGS=--xla_gpu_rocm_max_trace_events=<value>` instead of just seeing dropped events at `VLOG(3)`.

## Technical Details

`xla/backends/profiler/gpu/rocm_collector.cc`: restore the `LOG(WARNING)` and `LOG_FIRST_N(WARNING, 1)` messages in `AddEvent()`'s callback-events and activity-events branches. The legitimate #871 / b6a2823 pieces (include reorder, V1-guarded `get_timestamp()`, header macros) are kept.

## Test Plan

Rebuild wheels

## Test Result

in progress...
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
