### PR TITLE
Add StreamExecutorGpuClientTest to CI build filters

### DIFF
--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -12,6 +12,7 @@ EXCLUDED_TESTS=(
     "DeterminismTest.CublasDot"
     "F8E5M2Tests/DotAlgorithmSupportTest.AlgorithmIsSupportedFromCudaCapability/dot_any_f8_any_f8_f32_*"
     "CubSort/CubSortPairsTest*"
+    "StreamExecutorGpuClientTest.GetAbiVersion"
     "SampleFileTest.Convolution" # https://wardite.cluster.engflow.com/invocations/default/c105260c-873a-4634-ab69-905a43ca5cf8
 )
 


### PR DESCRIPTION
Ignore StreamExecutorGpuClientTest.GetAbiVersion as it is failing upstream