### PR TITLE
Implement ROCm delay kernel

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -125,6 +125,7 @@ cc_library(
     ],
     deps = [
         ":rocm_command_buffer",
+        ":rocm_compute_capability",
         ":rocm_context",
         ":rocm_event",
         ":rocm_kernel",
@@ -754,6 +755,24 @@ rocm_library(
     alwayslink = True,
 )
 
+rocm_library(
+    name = "delay_kernel_rocm",
+    srcs = ["delay_kernel_rocm.cu.cc"],
+    hdrs = ["delay_kernel.h"],
+    # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:typed_kernel_factory",
+        "//xla/stream_executor/gpu:gpu_semaphore",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
 cc_library(
     name = "rocm_complex_converters",
     hdrs = ["rocm_complex_converters.h"],
@@ -911,12 +930,14 @@ cc_library(
         "rocm-only",
     ],
     deps = [
+        ":delay_kernel_rocm",
         ":rocm_event",
         ":rocm_status",
         "//xla/stream_executor:activate_context",
         "//xla/stream_executor:event_based_timer",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/gpu:gpu_semaphore",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:status_macros",
         "//xla/tsl/platform:statusor",
@@ -935,6 +956,7 @@ xla_test(
     backends = ["gpu"],
     tags = ["rocm-only"],
     deps = [
+        ":rocm_compute_capability",
         ":rocm_executor",
         ":rocm_platform_id",
         ":rocm_timer",

--- a/xla/stream_executor/rocm/delay_kernel.h
+++ b/xla/stream_executor/rocm/delay_kernel.h
@@ -1,0 +1,31 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_DELAY_KERNEL_H_
+#define XLA_STREAM_EXECUTOR_ROCM_DELAY_KERNEL_H_
+
+#include "absl/status/statusor.h"
+#include "xla/stream_executor/gpu/gpu_semaphore.h"
+#include "xla/stream_executor/stream.h"
+
+namespace stream_executor::gpu {
+
+// Launches the delay kernel on the given stream. The caller is responsible for
+// keeping the returned semaphore alive until the kernel finished executing.
+// Setting the semaphore to `kRelease` makes the kernel quit.
+absl::StatusOr<GpuSemaphore> LaunchDelayKernel(Stream* stream);
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_DELAY_KERNEL_H_

--- a/xla/stream_executor/rocm/delay_kernel_rocm.cu.cc
+++ b/xla/stream_executor/rocm/delay_kernel_rocm.cu.cc
@@ -1,0 +1,69 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+
+#include "absl/status/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/stream_executor/gpu/gpu_semaphore.h"
+#include "xla/stream_executor/rocm/delay_kernel.h"
+#include "xla/stream_executor/typed_kernel_factory.h"
+
+namespace stream_executor::gpu {
+namespace {
+// Wait for the value pointed to by `semaphore` to have value `target`, timing
+// out after a reasonable time if not reached
+__global__ void DelayKernel(volatile GpuSemaphoreState* semaphore,
+                            GpuSemaphoreState target) {
+  constexpr int64_t WAIT_CYCLES{1024};
+  constexpr int64_t TIMEOUT_CYCLES{200000000};
+  const int64_t tstart{clock64()};
+  bool target_not_reached;
+  while ((target_not_reached = (*semaphore != target)) &&
+         (clock64() - tstart) < TIMEOUT_CYCLES) {
+    int64_t elapsed{};
+    const int64_t t0{clock64()};
+    do {
+      elapsed = clock64() - t0;
+    } while (elapsed < WAIT_CYCLES);
+  }
+  if (target_not_reached) {
+    *semaphore = GpuSemaphoreState::kTimedOut;
+  }
+}
+}  // namespace
+
+absl::StatusOr<GpuSemaphore> LaunchDelayKernel(Stream* stream) {
+  StreamExecutor* executor = stream->parent();
+
+  // Semaphore value that will be used to signal to the delay
+  // kernel that it may exit
+  ASSIGN_OR_RETURN(auto semaphore, GpuSemaphore::Create(executor));
+  *semaphore = GpuSemaphoreState::kHold;
+  ASSIGN_OR_RETURN(
+      auto kernel,
+      (TypedKernelFactory<DeviceAddress<GpuSemaphoreState>,
+                          GpuSemaphoreState>::Create(executor, "DelayKernel",
+                                                     reinterpret_cast<void*>(
+                                                         DelayKernel))));
+  // Launch a delay kernel into the stream. Spin until GetElapsedDuration() is
+  // called, the timer is destroyed, or the timeout in the kernel is reached.
+  RETURN_IF_ERROR(kernel.Launch(ThreadDim(1, 1, 1), BlockDim(1, 1, 1), stream,
+                                semaphore.device(),
+                                GpuSemaphoreState::kRelease));
+
+  return semaphore;
+}
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -15,11 +15,10 @@ limitations under the License.
 
 #include "xla/stream_executor/rocm/rocm_executor.h"
 
-#include <unistd.h>
-
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -49,6 +48,7 @@ limitations under the License.
 #include "rocm/include/hip/hip_runtime.h"
 #include "rocm/include/hip/hip_version.h"
 #include "rocm/rocm_config.h"
+#include <unistd.h>
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/command_buffer.h"
@@ -76,6 +76,7 @@ limitations under the License.
 #include "xla/stream_executor/platform/initialize.h"
 #include "xla/stream_executor/plugin_registry.h"
 #include "xla/stream_executor/rocm/rocm_command_buffer.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
 #include "xla/stream_executor/rocm/rocm_context.h"
 #include "xla/stream_executor/rocm/rocm_event.h"
 #include "xla/stream_executor/rocm/rocm_kernel.h"
@@ -102,6 +103,24 @@ namespace stream_executor {
 namespace gpu {
 
 namespace {
+
+bool ShouldLaunchDelayKernel() {
+  // Disable the delay kernel when HIP is configured to serialize
+  // launches. With HIP_LAUNCH_BLOCKING=1 or AMD_SERIALIZE_KERNEL/
+  // AMD_SERIALIZE_COPY != 0 we hit the delay kernel timeout every time
+  static bool value = [] {
+    auto is_nonzero = [](const char* name) {
+      const char* v = std::getenv(name);
+      return v && absl::string_view{v} != "0" && absl::string_view{v} != "";
+    };
+    const char* blocking = std::getenv("HIP_LAUNCH_BLOCKING");
+    const bool launch_blocking = blocking && absl::string_view{blocking} == "1";
+    return !launch_blocking && !is_nonzero("AMD_SERIALIZE_KERNEL") &&
+           !is_nonzero("AMD_SERIALIZE_COPY");
+  }();
+  return value;
+}
+
 // Given const GPU memory, returns a librocm device pointer datatype, suitable
 // for passing directly to librocm APIs.
 //
@@ -582,7 +601,13 @@ RocmExecutor::CreateOrShareConstant(Stream* stream,
 
 absl::StatusOr<std::unique_ptr<EventBasedTimer>>
 RocmExecutor::CreateEventBasedTimer(Stream* stream, bool use_delay_kernel) {
-  ASSIGN_OR_RETURN(auto timer, RocmTimer::Create(this, stream));
+  const RocmTimer::TimerType timer_type =
+      (use_delay_kernel && delay_kernels_supported_ &&
+       ShouldLaunchDelayKernel())
+          ? RocmTimer::TimerType::kDelayKernel
+          : RocmTimer::TimerType::kEventBased;
+
+  ASSIGN_OR_RETURN(auto timer, RocmTimer::Create(this, stream, timer_type));
   return std::make_unique<RocmTimer>(std::move(timer));
 }
 
@@ -629,8 +654,15 @@ absl::Status RocmExecutor::Init() {
   ASSIGN_OR_RETURN(device_, GetDevice(device_ordinal()));
   ASSIGN_OR_RETURN(version_, GetGpuISAVersion(device_));
 
+  // Only enable on MI300+ where the feature is empirically observed to be
+  // beneficial
+  ASSIGN_OR_RETURN(std::string gcn_arch_name, GetGpuGCNArchName(device_));
+  delay_kernels_supported_ =
+      RocmComputeCapability(gcn_arch_name).gfx9_mi300_series();
+
   // Initialize peer access cache for all devices
   int device_count = 0;
+
   RETURN_IF_ERROR(
       ToStatus(hipGetDeviceCount(&device_count), "Failed to get device count"));
   for (int i = 0; i < device_count; ++i) {

--- a/xla/stream_executor/rocm/rocm_executor.h
+++ b/xla/stream_executor/rocm/rocm_executor.h
@@ -210,6 +210,10 @@ class RocmExecutor : public GpuExecutor {
 
   // Cache of peer access capabilities. Populated during Init().
   absl::flat_hash_map<int, bool> peer_access_cache_;
+
+  // Whether the delay kernel can be safely used on this device. Populated
+  // during Init().
+  bool delay_kernels_supported_ = false;
 };
 
 }  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_timer.cc
+++ b/xla/stream_executor/rocm/rocm_timer.cc
@@ -25,6 +25,8 @@ limitations under the License.
 #include "xla/tsl/platform/status_macros.h"
 #include "rocm/include/hip/hip_runtime.h"
 #include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/gpu/gpu_semaphore.h"
+#include "xla/stream_executor/rocm/delay_kernel.h"
 #include "xla/stream_executor/rocm/rocm_event.h"
 #include "xla/stream_executor/rocm/rocm_status.h"
 #include "xla/stream_executor/stream.h"
@@ -39,11 +41,8 @@ absl::StatusOr<float> GetEventElapsedTime(StreamExecutor* executor,
   std::unique_ptr<ActivateContext> activation = executor->Activate();
   // The stop event must have completed in order for hipEventElapsedTime to
   // work.
-  hipError_t res = hipEventSynchronize(stop);
-  if (res != hipSuccess) {
-    LOG(ERROR) << "failed to synchronize the stop event: " << ToString(res);
-    return false;
-  }
+  RETURN_IF_ERROR(ToStatus(hipEventSynchronize(stop),
+                           "failed to synchronize the stop event"));
   float elapsed_milliseconds;
   RETURN_IF_ERROR(
       ToStatus(hipEventElapsedTime(&elapsed_milliseconds, start, stop),
@@ -54,17 +53,42 @@ absl::StatusOr<float> GetEventElapsedTime(StreamExecutor* executor,
 }  // namespace
 
 RocmTimer::RocmTimer(StreamExecutor* executor, RocmEvent start_event,
-                     RocmEvent stop_event, Stream* stream)
-    : executor_(executor),
+                     RocmEvent stop_event, Stream* stream,
+                     GpuSemaphore semaphore)
+    : semaphore_(std::move(semaphore)),
+      executor_(executor),
       stream_(stream),
       start_event_(std::move(start_event)),
       stop_event_(std::move(stop_event)) {}
+
+RocmTimer::~RocmTimer() {
+  if (semaphore_ && !is_stopped_) {
+    // Signal the delay kernel that it can exit
+    *semaphore_ = GpuSemaphoreState::kRelease;
+    // Wait for the delay kernel to exit before destroying the value that it is
+    // watching.
+    absl::Status result = stream_->BlockHostUntilDone();
+    if (!result.ok()) {
+      LOG(ERROR) << result.message();
+    }
+  }
+}
 
 absl::StatusOr<absl::Duration> RocmTimer::GetElapsedDuration() {
   if (is_stopped_) {
     return absl::FailedPreconditionError("Measuring inactive timer");
   }
   RETURN_IF_ERROR(stream_->RecordEvent(&stop_event_));
+  // If we launched the delay kernel then check if it already timed out.
+  if (semaphore_) {
+    if (*semaphore_ == GpuSemaphoreState::kTimedOut) {
+      LOG_FIRST_N(WARNING, 5)
+          << "Delay kernel timed out, measured time has sub-optimal accuracy.";
+    } else {
+      // Signal that the kernel can exit
+      *semaphore_ = GpuSemaphoreState::kRelease;
+    }
+  }
   ASSIGN_OR_RETURN(float elapsed_milliseconds,
                    GetEventElapsedTime(executor_, start_event_.GetHandle(),
                                        stop_event_.GetHandle()));
@@ -73,13 +97,22 @@ absl::StatusOr<absl::Duration> RocmTimer::GetElapsedDuration() {
 }
 
 absl::StatusOr<RocmTimer> RocmTimer::Create(StreamExecutor* executor,
-                                            Stream* stream) {
+                                            Stream* stream,
+                                            TimerType timer_type) {
+  GpuSemaphore semaphore{};
+
+  if (timer_type == TimerType::kDelayKernel) {
+    ASSIGN_OR_RETURN(semaphore, LaunchDelayKernel(stream));
+  }
+
   ASSIGN_OR_RETURN(RocmEvent start_event,
                    RocmEvent::Create(executor, /*allow_timing=*/true));
   ASSIGN_OR_RETURN(RocmEvent stop_event,
                    RocmEvent::Create(executor, /*allow_timing=*/true));
+
   RETURN_IF_ERROR(stream->RecordEvent(&start_event));
+
   return RocmTimer(executor, std::move(start_event), std::move(stop_event),
-                   stream);
+                   stream, std::move(semaphore));
 }
 }  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_timer.h
+++ b/xla/stream_executor/rocm/rocm_timer.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 #include "xla/stream_executor/event_based_timer.h"
+#include "xla/stream_executor/gpu/gpu_semaphore.h"
 #include "xla/stream_executor/rocm/rocm_event.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
@@ -27,18 +28,24 @@ namespace stream_executor::gpu {
 
 class RocmTimer : public EventBasedTimer {
  public:
+  ~RocmTimer() override;
   RocmTimer(RocmTimer&&) = default;
   RocmTimer& operator=(RocmTimer&&) = default;
 
   absl::StatusOr<absl::Duration> GetElapsedDuration() override;
 
+  enum class TimerType {
+    kDelayKernel,
+    kEventBased,
+  };
   static absl::StatusOr<RocmTimer> Create(StreamExecutor* executor,
-                                          Stream* stream);
+                                          Stream* stream, TimerType timer_type);
 
  private:
   RocmTimer(StreamExecutor* executor, RocmEvent start_event,
-            RocmEvent stop_event, Stream* stream);
+            RocmEvent stop_event, Stream* stream, GpuSemaphore semaphore);
 
+  GpuSemaphore semaphore_;
   bool is_stopped_ = false;
   StreamExecutor* executor_;
   Stream* stream_;

--- a/xla/stream_executor/rocm/rocm_timer_test.cc
+++ b/xla/stream_executor/rocm/rocm_timer_test.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "xla/stream_executor/launch_dim.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
 #include "xla/stream_executor/rocm/rocm_executor.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/stream_executor/stream.h"
@@ -76,10 +77,30 @@ class RocmTimerTest : public ::testing::Test {
 
 TEST_F(RocmTimerTest, Create) {
   TF_ASSERT_OK_AND_ASSIGN(RocmTimer timer,
-                          RocmTimer::Create(executor_, stream_.get()));
+                          RocmTimer::Create(executor_, stream_.get(),
+                                            RocmTimer::TimerType::kEventBased));
 
   // We don't really care what kernel we launch here as long as it takes a
   // non-zero amount of time.
+  LaunchSomeKernel(executor_, stream_.get());
+
+  TF_ASSERT_OK_AND_ASSIGN(absl::Duration timer_result,
+                          timer.GetElapsedDuration());
+  EXPECT_THAT(timer_result, Gt(absl::ZeroDuration()));
+  EXPECT_THAT(timer.GetElapsedDuration(),
+              absl_testing::StatusIs(absl::StatusCode::kFailedPrecondition));
+}
+
+TEST_F(RocmTimerTest, CreateWithDelayKernel) {
+  if (!executor_->GetDeviceDescription()
+           .rocm_compute_capability()
+           .gfx9_mi300_series()) {
+    GTEST_SKIP() << "Delay kernel is only supported on MI300+ ";
+  }
+  TF_ASSERT_OK_AND_ASSIGN(
+      RocmTimer timer, RocmTimer::Create(executor_, stream_.get(),
+                                         RocmTimer::TimerType::kDelayKernel));
+
   LaunchSomeKernel(executor_, stream_.get());
 
   TF_ASSERT_OK_AND_ASSIGN(absl::Duration timer_result,


### PR DESCRIPTION
Port the CUDA delay-kernel to ROCm to reduce jitter in autotuning measurements. Gated to MI300+ and disabled when `HIP_LAUNCH_BLOCKING=1`, `AMD_SERIALIZE_KERNEL` or `AMD_SERIALIZE_COPY` are set, since those result in the kernel always hitting timeout.

Small bug fix: Fix `GetEventElapsedTime` silently returning false/0 on failures.