### PR TITLE
Modify CI build script for ROCm configuration

### DIFF
--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -65,6 +65,8 @@ done
     --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=${RBE_POOL} \
     --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_do_gfx950 \
     --local_test_jobs=1 \
+    --internal_spawn_scheduler \
+    --strategy=TestRunner=dynamic \
     -- \
     //xla/... \
     -//xla/tests:dot_operation_test_amdgpu_any \


### PR DESCRIPTION
Use dynamic spawn strategy to unblock when rbe queue is full and use remote cache results