### PR TITLE
Enable F64 GEMM dispatch to hipBLASLt on ROCm

### DIFF
--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -2592,6 +2592,9 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
         // TF32
         {ComputationType::kTF32AsF32, DataType::kFloat, PrimitiveType::F32,
          PrimitiveType::F32, DataType::kFloat},
+
+        {ComputationType::kF64, DataType::kDouble, PrimitiveType::F64,
+         PrimitiveType::F64, DataType::kDouble},
     };
     if (gpu_version_.IsRocm() &&
         absl::c_linear_search(supported_hipblas_type_combinations,


### PR DESCRIPTION
Pure-F64 dots on ROCm fail with `INTERNAL: GEMM is not supported by cublasLt and legacy cublas fallback is removed` because F64 is absent from `supported_hipblas_type_combinations` in `gemm_rewriter.cc` (the F64 entry exists only in the CUDA-gated table). hipBLASLt supports F64 GEMM, so this adds the missing entry to route F64 dots to hipBLASLt — no legacy cuBLAS/rocBLAS path is restored.