### PR TITLE
Update TF_ROCM_AMDGPU_TARGETS to include only gfx950

### DIFF
--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -52,7 +52,7 @@ done
     --execution_log_compact_file=execution_log.binpb.zst \
     --spawn_strategy=local \
     --repo_env=REMOTE_GPU_TESTING=1 \
-    --repo_env=TF_ROCM_AMDGPU_TARGETS=gfx90a,gfx942,gfx950 \
+    --repo_env=TF_ROCM_AMDGPU_TARGETS=gfx950 \
     --remote_download_outputs=minimal \
     --grpc_keepalive_time=30s \
     --test_sharding_strategy=disabled \


### PR DESCRIPTION
Removed 'gfx90a' and 'gfx942' from TF_ROCM_AMDGPU_TARGETS.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
