### PR TITLE
PR #43522: [ROCm] Allow mixed (F8E4M3FNUZ, F8E5M2FNUZ) in Triton dot …

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -841,6 +841,7 @@ xla_cc_test(
         "//xla/service/gpu/model:block_level_parameters",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor/cuda:cuda_compute_capability",
+        "//xla/stream_executor/rocm:rocm_compute_capability",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status:status_matchers",

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -571,7 +571,10 @@ CodegenDecision IsTritonSupportedDot(
            (lhs_type == compare2 && rhs_type == compare1);
   };
   // TODO(b/393299275): add support tests for mixed types.
-  if (lhs_type != rhs_type && !types_are(F8E5M2, F8E4M3FN)) {
+  const bool mixed_fp8_ok =
+      types_are(F8E5M2, F8E4M3FN) ||
+      (gpu_version.IsRocm() && types_are(F8E5M2FNUZ, F8E4M3FNUZ));
+  if (lhs_type != rhs_type && !mixed_fp8_ok) {
     return CodegenDecision::Forbid(
         "Dot operation only supports same types for lhs and rhs.");
   }

--- a/xla/backends/gpu/codegen/triton/support_test.cc
+++ b/xla/backends/gpu/codegen/triton/support_test.cc
@@ -50,6 +50,7 @@ limitations under the License.
 #include "xla/service/gpu/target_constants.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
@@ -2145,6 +2146,32 @@ ENTRY triton_computation {
       ParseTemplateAndGetInstruction(kHloTestTemplate, F32, HloOpcode::kDot));
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{16, 32},
                  DefaultDeviceForTesting());
+}
+
+TEST_F(DotTest, MixedFnuzF8DotIsSupportedOnRocmAndRejectedOnCuda) {
+  const std::string kHloTestTemplate = R"(
+triton_computation {
+  p0 = f8e4m3fnuz[128,256] parameter(0)
+  p1 = f8e5m2fnuz[256,512] parameter(1)
+  ROOT result = f32[128,512] dot(p0, p1),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0},
+    backend_config={sizes:[64]}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      TestedInstruction ti_rocm,
+      ParseTemplateAndGetInstruction(kHloTestTemplate, PRIMITIVE_TYPE_INVALID,
+                                     HloOpcode::kDot));
+  RunSupportTest(std::move(ti_rocm), /*output_tile_sizes=*/{16, 32},
+                 se::GpuComputeCapability(se::RocmComputeCapability("gfx942")));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      TestedInstruction ti_cuda,
+      ParseTemplateAndGetInstruction(kHloTestTemplate, PRIMITIVE_TYPE_INVALID,
+                                     HloOpcode::kDot));
+  RunSupportTest(std::move(ti_cuda), /*output_tile_sizes=*/{16, 32},
+                 se::GpuComputeCapability(se::CudaComputeCapability::Hopper()));
 }
 
 TEST_F(DotTest, SingleBatchDim) {


### PR DESCRIPTION
…gate

Imported from GitHub PR https://github.com/openxla/xla/pull/43522

The mixed-FP8 carve-out in IsTritonSupportedDot only listed the OCP pair (F8E5M2, F8E4M3FN). The ROCm-native FNUZ pair was rejected even though the rest of the file already accepts FNUZ FP8 inputs on ROCm.

This blocks TransformerEngine FP8 GEMM on MI300 (gfx94X), which lowers dgrad to dot_general(F8E4M3FNUZ, F8E5M2FNUZ) and gets routed to a __triton_nested_gemm_fusion. The gate then refuses it at codegen time with "INTERNAL: ... Dot operation only supports same types for lhs and rhs."

FNUZ on CUDA is already rejected upstream by IsTritonSupportedDataType, so no host guard is needed in the gate. Add a focused support test asserting the FNUZ mixed pair is accepted on ROCm and rejected on CUDA. Copybara import of the project:

--
b3c6b4aaaefc01856eeb0b06710b66f3bfa95757 by Ruturaj4 <Ruturaj.Vaidya@amd.com>:

[ROCm] Allow mixed (F8E4M3FNUZ, F8E5M2FNUZ) in Triton dot gate

The mixed-FP8 carve-out in IsTritonSupportedDot only listed the OCP pair (F8E5M2, F8E4M3FN). The ROCm-native FNUZ pair was rejected even though the rest of the file already accepts FNUZ FP8 inputs on ROCm.

This blocks TransformerEngine FP8 GEMM on MI300 (gfx94X), which lowers dgrad to dot_general(F8E4M3FNUZ, F8E5M2FNUZ) and gets routed to a __triton_nested_gemm_fusion. The gate then refuses it at codegen time with "INTERNAL: ... Dot operation only supports same types for lhs and rhs."

Add a focused support test asserting the FNUZ mixed pair is accepted on ROCm and rejected on CUDA via RunSupportTest's dual-contract check.

Addresses TODO(b/393299275).

Merging this change closes #43522

COPYBARA_INTEGRATE_REVIEW=https://github.com/openxla/xla/pull/43522 from ROCm:ruvaidya/fnuz-mixed-fp8-triton-dot b3c6b4aaaefc01856eeb0b06710b66f3bfa95757 PiperOrigin-RevId: 927257673

Adapted for rocm-jaxlib-v0.9.1:
- Textual conflict only in support_test.cc: release branch has additional NonFusionRhs/NonFusionLhs tests at the insertion point after the MixedF8DotTest instantiation; new MixedFnuzF8DotIsSupportedOnRocmAndRejectedOnCuda test was placed immediately after them. Patch shape (3 files, +32/-1) and semantics are identical to the upstream commit.

(cherry picked from commit 75566dff3038a92e117fe722414f6084d511e384)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
