### PR TITLE
[ROCm][VMM] Selective copy-vs-remap for small command-buffer slices + auto threshold

### DIFF
--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <deque>
 #include <memory>
 #include <optional>
@@ -1520,6 +1521,20 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
     return ((size + granularity - 1) / granularity) * granularity;
   };
 
+  // EXPERIMENT: copy-vs-remap balance for small command-buffer slices.
+  // Slices with size <= XLA_VMM_TMP_COPY_THRESHOLD bytes are kept in a stable
+  // shadow buffer (fixed VA, no remap) and refreshed with a device-to-device
+  // copy each step. 0 (default) disables the experiment entirely, preserving
+  // the original remap-everything behavior.
+  static const uint64_t kVmmTmpCopyThreshold = []() -> uint64_t {
+    const char* e = std::getenv("XLA_VMM_TMP_COPY_THRESHOLD");
+    return (e != nullptr) ? std::strtoull(e, nullptr, 10) : 0;
+  }();
+  const uint64_t copy_threshold = kVmmTmpCopyThreshold;
+  auto is_small_copy_slice = [copy_threshold](uint64_t size) {
+    return copy_threshold > 0 && size <= copy_threshold;
+  };
+
   // Acquire per-executor mutex to protect VA range operations.
   // This ensures only one thread uses the VA ranges at a time for this
   // executor.
@@ -1546,19 +1561,29 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
           nullptr) {
         continue;
       }
+      // Small slices are handled by the copy-to-shadow path and never occupy
+      // a slot in the contiguous VA reservation.
+      if (is_small_copy_slice(buf.size())) {
+        continue;
+      }
       total_va_size += round_up_to_granularity(buf.size());
     }
 
     // Reserve a single large VA range for all command buffer allocations.
-    ASSIGN_OR_RETURN(va_ranges->va_reservation,
-                     vmm_allocator->CreateReservation(executor, total_va_size));
+    // With the copy-to-shadow experiment a large threshold can make every
+    // slice "small", leaving nothing to reserve; skip reservation in that case
+    // (all slices then flow through the shadow copy path).
     ASSIGN_OR_RETURN(va_ranges->unmap_event, executor->CreateEvent());
-
-    XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
-        "VA remapping: Reserved single VA range for module %s "
-        "VA: %p total_size: %d granularity: %d",
-        module_name_, va_ranges->va_reservation->address().opaque(),
-        total_va_size, granularity);
+    if (total_va_size > 0) {
+      ASSIGN_OR_RETURN(
+          va_ranges->va_reservation,
+          vmm_allocator->CreateReservation(executor, total_va_size));
+      XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
+          "VA remapping: Reserved single VA range for module %s "
+          "VA: %p total_size: %d granularity: %d",
+          module_name_, va_ranges->va_reservation->address().opaque(),
+          total_va_size, granularity);
+    }
   }
   // NOTE: the actual unmap of a previously established mapping is deferred to
   // the decision point below, so it can be skipped entirely when the physical
@@ -1579,6 +1604,11 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
         nullptr) {
       continue;
     }
+    // Small slices use the copy-to-shadow path; keep them out of the VA
+    // reservation so offsets stay contiguous and aligned with the descriptors.
+    if (is_small_copy_slice(buf.size())) {
+      continue;
+    }
     allocation_va_offsets[idx] = current_offset;
     current_offset += round_up_to_granularity(buf.size());
   }
@@ -1590,6 +1620,19 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
   // Map physical memory to reserved VA addresses.
   std::vector<se::DeviceAddressBase> mapped_buffers;
   mapped_buffers.reserve(buffer_allocations.size());
+
+  // EXPERIMENT: per-step copy plan for small slices. `shadow` is the stable
+  // backing baked into the command buffer; `real` is the current physical
+  // buffer. We copy real->shadow before execution (fresh inputs) and
+  // shadow->real after execution (propagate outputs such as loss / metric
+  // scalars back to the buffers the host reads). Declared here so the
+  // copy-back can run after ExecuteThunksImpl.
+  struct SmallCopy {
+    se::DeviceAddressBase shadow;
+    se::DeviceAddressBase real;
+    uint64_t size;
+  };
+  std::vector<SmallCopy> small_copies;
 
   {
     ScopedAnnotation annotation_va_remap([&] {
@@ -1610,6 +1653,11 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
     remap_descriptors.reserve(allocation_va_offsets.size());
     std::vector<VaRanges::AllocationMappingState> new_mapping_state;
     new_mapping_state.reserve(allocation_va_offsets.size());
+
+    // EXPERIMENT: maps a small slice's allocation index to the shadow address
+    // baked into the command buffer for that slice.
+    absl::flat_hash_map<BufferAllocation::Index, se::DeviceAddressBase>
+        small_mapped;
 
     if (!va_ranges->scoped_mapping.has_value()) {
       va_ranges->last_mapping_state.clear();
@@ -1638,6 +1686,33 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
         // address in the mapped_buffers loop below.
         continue;
       }
+
+      // EXPERIMENT: small slices (scales / tiny scalars) bypass VA remapping.
+      // Bake a stable shadow address into the command buffer and refresh it
+      // with a device-to-device copy each step. This trades one cheap small
+      // copy for an expensive hipMemUnmap/Map/SetAccess round-trip.
+      if (is_small_copy_slice(original_buffer.size())) {
+        const uint64_t sz = original_buffer.size();
+        auto it = va_ranges->small_shadow.find(i);
+        if (it == va_ranges->small_shadow.end() || it->second.size() < sz) {
+          if (it != va_ranges->small_shadow.end()) {
+            executor->Deallocate(&it->second);
+          }
+          se::DeviceAddressBase shadow = executor->Allocate(sz);
+          if (shadow.is_null()) {
+            return Internal(
+                "Failed to allocate %d-byte shadow for small command-buffer "
+                "slice %d",
+                sz, i);
+          }
+          it = va_ranges->small_shadow.insert_or_assign(i, shadow).first;
+        }
+        small_copies.push_back({/*shadow=*/it->second, /*real=*/original_buffer,
+                                /*size=*/sz});
+        small_mapped[i] = se::DeviceAddressBase(it->second.opaque(), sz);
+        continue;
+      }
+
       se::MemoryAllocation* raw_alloc = allocation_info->allocation;
       const uint64_t mapping_size = allocation_info->mapped_size;
 
@@ -1694,6 +1769,12 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
     for (BufferAllocation::Index i = 0; i < num_allocations; ++i) {
       se::DeviceAddressBase original_buffer =
           buffer_allocations.GetDeviceAddress(i);
+      // EXPERIMENT: small slices resolve to their stable shadow address.
+      auto small_it = small_mapped.find(i);
+      if (small_it != small_mapped.end()) {
+        mapped_buffers.push_back(small_it->second);
+        continue;
+      }
       auto offset_it = allocation_va_offsets.find(i);
       if (offset_it == allocation_va_offsets.end()) {
         mapped_buffers.push_back(original_buffer);
@@ -1740,6 +1821,19 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
       va_ranges->last_mapping_state = std::move(new_mapping_state);
     }
 
+    // EXPERIMENT: copy-IN small-slice inputs (real->shadow) on the execution
+    // stream. Stream-ordered before the command buffer, so each shadow holds
+    // the current step's data without any VA remap or unmap-event sync.
+    if (!small_copies.empty()) {
+      se::Stream* exec_stream = run_options->stream();
+      for (SmallCopy& c : small_copies) {
+        RETURN_IF_ERROR(exec_stream->Memcpy(&c.shadow, c.real, c.size));
+      }
+      XLA_VLOG_DEVICE(2, executor->device_ordinal()) << absl::StreamFormat(
+          "VA remapping: copied %d small slices to shadow (threshold=%d B)",
+          static_cast<int>(small_copies.size()), copy_threshold);
+    }
+
     XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
         "VA remapping: %d/%d allocations skipped, %d remap runs coalesced",
         skip_count, static_cast<int>(allocation_va_offsets.size()), run_count);
@@ -1775,6 +1869,18 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
       remapped_buffer_allocations, block_host_until_done,
       num_additional_streams_, collective_memory_cache_,
       collective_use_minimal_resource));
+
+  // EXPERIMENT: copy-BACK small-slice outputs (shadow->real) on the execution
+  // stream, after the command buffer has run. The command buffer wrote results
+  // (e.g. loss / token-count scalars) into the stable shadow; this propagates
+  // them back to the real physical buffers the host and later thunks read.
+  // Stream-ordered after execution and before the unmap event is recorded.
+  if (!small_copies.empty()) {
+    se::Stream* exec_stream = run_options->stream();
+    for (SmallCopy& c : small_copies) {
+      RETURN_IF_ERROR(exec_stream->Memcpy(&c.real, c.shadow, c.size));
+    }
+  }
 
   // Record event so VA range can be reclaimed after GPU finishes.
   RETURN_IF_ERROR(

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -36,6 +36,7 @@ limitations under the License.
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
@@ -1521,16 +1522,112 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
     return ((size + granularity - 1) / granularity) * granularity;
   };
 
-  // EXPERIMENT: copy-vs-remap balance for small command-buffer slices.
-  // Slices with size <= XLA_VMM_TMP_COPY_THRESHOLD bytes are kept in a stable
-  // shadow buffer (fixed VA, no remap) and refreshed with a device-to-device
-  // copy each step. 0 (default) disables the experiment entirely, preserving
-  // the original remap-everything behavior.
-  static const uint64_t kVmmTmpCopyThreshold = []() -> uint64_t {
+  // EXPERIMENT: automatic copy-vs-remap selection for small command-buffer
+  // slices. The tiny scale/scalar/metric buffers churn their physical address
+  // every step; remapping them costs an hipMemUnmap/Map/SetAccess round-trip
+  // that serializes across peer devices on ROCm. Instead we keep such a slice
+  // in a stable shadow buffer (fixed address baked into the command buffer once)
+  // and refresh it with a cheap device-to-device copy each step.
+  //
+  // The size cutoff is chosen AUTOMATICALLY from the device's HBM bandwidth and
+  // capacity (no manual tuning): admit command-buffer slices smallest-first
+  // into the copy set while (a) no single slice's copy exceeds kPerBufferCopyUs,
+  // (b) the total per-step copy stays under kTotalCopyUs, and (c) the shadow
+  // footprint stays under kShadowHbmFraction of HBM. Large tensors blow these
+  // budgets and stay on the remap path -- and since they keep stable addresses
+  // across steps, remapping them is already free (skipped). The per-step copy
+  // budget bounds the worst-case overhead, so "auto" is safe on any model.
+  //
+  // Control via env XLA_VMM_TMP_COPY_THRESHOLD (default = auto):
+  //   "0"  -> disabled: every slice stays on the remap path (original path).
+  //   "1"  -> auto: derive the byte cutoff from this device's HBM bandwidth and
+  //           capacity AND the memory currently free, so the shadow pool is
+  //           always guaranteed to fit (no searching, never risks OOM).
+  //   ">1" -> force exactly that byte cutoff (explicit override / sweeps).
+  // We reserve "1" for auto because a literal 1-byte cutoff would admit nothing.
+  uint64_t copy_threshold = 0;
+  {
     const char* e = std::getenv("XLA_VMM_TMP_COPY_THRESHOLD");
-    return (e != nullptr) ? std::strtoull(e, nullptr, 10) : 0;
-  }();
-  const uint64_t copy_threshold = kVmmTmpCopyThreshold;
+    // Unset defaults to auto (mode 1) so the smart selector is the default.
+    uint64_t mode = 1;
+    if (e != nullptr) {
+      mode = std::strtoull(e, nullptr, 10);
+    }
+    if (mode == 0) {
+      copy_threshold = 0;  // disabled
+    } else if (mode > 1) {
+      copy_threshold = mode;  // explicit byte cutoff
+    } else {
+      // mode == 1: auto-derive from device properties + free memory.
+      //
+      // Greedy admit-smallest-first: pull command-buffer slices into the copy
+      // set in increasing size order while (a) no single slice's bidirectional
+      // copy exceeds kPerBufferCopyUs, and (b) the aggregate per-step copy stays
+      // under a budget that is the MIN of a copy-time cap and a memory cap. The
+      // memory cap is taken from the currently-free HBM (kFreeHbmFraction of
+      // free), which guarantees the shadow pool always fits -- "always enough
+      // space" -- rather than from a blind fraction of total capacity. Large
+      // tensors blow these budgets and stay on the remap path; since they keep
+      // stable addresses across steps their remap is already skipped (free).
+      constexpr double kPerBufferCopyUs = 8.0;
+      constexpr double kTotalCopyUs = 15.0;
+      constexpr double kShadowHbmFraction = 0.005;  // of total (fallback)
+      constexpr double kFreeHbmFraction = 0.01;     // of free (primary cap)
+      constexpr uint64_t kFallbackThreshold = 65536;
+      const se::DeviceDescription& dd = executor->GetDeviceDescription();
+      const int64_t bw = dd.memory_bandwidth();     // bytes/sec
+      const int64_t hbm = dd.device_memory_size();  // bytes
+      if (bw <= 0) {
+        // Bandwidth unknown: fall back to a conservative cutoff that still
+        // captures scalar/scale buffers.
+        copy_threshold = kFallbackThreshold;
+      } else {
+        // acc accumulates 2*size per admitted slice: bidirectional copy moves
+        // 2 bytes per shadow byte, and the shadow is allocated per VA set, so
+        // 2*size also bounds the double-buffered footprint.
+        const double per_buffer_cap =
+            kPerBufferCopyUs * 1e-6 * static_cast<double>(bw) / 2.0;
+        double total_budget = kTotalCopyUs * 1e-6 * static_cast<double>(bw);
+        // Memory cap: prefer the live free-memory reading so the shadow pool is
+        // bounded by what the device can actually spare right now.
+        int64_t free_mem = 0;
+        int64_t total_mem = 0;
+        double mem_cap = 0.0;
+        if (executor->DeviceMemoryUsage(&free_mem, &total_mem) &&
+            free_mem > 0) {
+          mem_cap = kFreeHbmFraction * static_cast<double>(free_mem);
+        } else if (hbm > 0) {
+          mem_cap = kShadowHbmFraction * static_cast<double>(hbm);
+        }
+        if (mem_cap > 0.0) {
+          total_budget = std::min(total_budget, mem_cap);
+        }
+        std::vector<uint64_t> sizes;
+        sizes.reserve(command_buffer_allocation_indexes_.size());
+        for (BufferAllocation::Index i : command_buffer_allocation_indexes_) {
+          se::DeviceAddressBase b = buffer_allocations.GetDeviceAddress(i);
+          if (vmm_allocator->GetRawAllocation(executor->device_ordinal(), b) ==
+              nullptr) {
+            continue;
+          }
+          sizes.push_back(b.size());
+        }
+        std::sort(sizes.begin(), sizes.end());
+        double acc = 0.0;
+        for (uint64_t s : sizes) {
+          if (static_cast<double>(s) > per_buffer_cap) break;
+          if (acc + 2.0 * static_cast<double>(s) > total_budget) break;
+          acc += 2.0 * static_cast<double>(s);
+          copy_threshold = s;
+        }
+        XLA_VLOG_DEVICE(2, executor->device_ordinal()) << absl::StreamFormat(
+            "VA remapping: auto copy threshold=%d B (bw=%d GB/s hbm=%d GB "
+            "free=%d GB budget=%.0f B)",
+            copy_threshold, bw / 1000000000, hbm / 1000000000,
+            free_mem / 1000000000, total_budget);
+      }
+    }
+  }
   auto is_small_copy_slice = [copy_threshold](uint64_t size) {
     return copy_threshold > 0 && size <= copy_threshold;
   };

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -344,6 +344,15 @@ class GpuExecutable : public Executable {
       uint64_t allocation_id;
     };
     std::vector<AllocationMappingState> last_mapping_state;
+
+    // EXPERIMENT (env XLA_VMM_TMP_COPY_THRESHOLD): for small command-buffer
+    // slices (scales / tiny scalars) we avoid VA remapping entirely. Each such
+    // slice gets a stable shadow device buffer here (allocated once, fixed
+    // address baked into the command buffer) and is refreshed with a
+    // device-to-device copy every step instead of an hipMemUnmap/Map/SetAccess.
+    // Keyed by allocation index; kept for the lifetime of the run.
+    absl::flat_hash_map<BufferAllocation::Index, se::DeviceAddressBase>
+        small_shadow;
   };
 
   // Additional streams borrowed at run time for the execution.


### PR DESCRIPTION
## Dependency (read first)

**This PR stacks on top of the ROCm VMM allocator work** (branch `phambinh/rocm-vmm-allocator`) and must merge *after* it. The base of this PR is intentionally set to that branch, not `main`, so the diff here is **only this change** (`xla/service/gpu/gpu_executable.cc`). GitHub will auto-retarget to `main` once the VMM allocator PR lands.

**It is entirely ROCm-only and does not affect NVIDIA.** The whole code path lives inside `ExecuteThunksWithVaRemapping`, which is gated on:

```cpp
dynamic_cast<se::DeviceAddressVmmAllocator*>(memory_allocator) != nullptr
```

On NVIDIA the active allocator is the standard BFC/stream-executor allocator, so the cast is `null`, `use_command_buffer_va_remapping` is `false`, the function is never entered, and the `XLA_VMM_TMP_COPY_THRESHOLD` env var has no effect. NVIDIA code paths, defaults, and behavior are unchanged.

## Optimization

With the VMM command-buffer VA-remapping path, every command-buffer slice whose physical allocation churns each step is re-mapped via `hipMemUnmap` / `hipMemMap` / `SetAccess`. For the tiny scalar / scale / metric buffers that churn every step, that driver round-trip dominates and serializes across peer devices. Large tensors, by contrast, keep **stable** addresses across steps, so their remap is already skipped (free).

This change keeps those small churning slices in a **stable shadow buffer** (a fixed address baked into the command buffer once) and refreshes them with a cheap device-to-device copy each step (copy-in before exec, copy-back after, so output scalars like loss/metrics propagate correctly). Large slices stay on the remap path.

The size cutoff is chosen **automatically** — no manual tuning, no searching — via `XLA_VMM_TMP_COPY_THRESHOLD`:

| value | behavior |
|---|---|
| `0` | disabled: remap every slice (original behavior) |
| `1` | **auto**: derive the cutoff from device HBM bandwidth + capacity **and currently-free HBM** (`DeviceMemoryUsage`) |
| `>1` | force that exact byte cutoff (explicit override / sweeps) |

The auto selector admits the smallest slices first while bounding (a) per-slice copy time, (b) aggregate per-step copy time, and (c) the shadow footprint at a fraction of **free** HBM — so the shadow pool is always guaranteed to fit and never risks OOM. Default (unset) is auto.

## Benchmarks (MI300X x8, llama @ 8 layers / 30 steps, median of steps ≥3)

### auto + collective leg (`coll_vmm`), disabled vs auto — all models

| Model | disabled (`=0`) | auto (`=1`) | saved | speedup | loss (both) | unmap |
|---|---|---|---|---|---|---|
| llama2_7b | 133.5 ms | **121.0 ms** | 12.5 ms | **9.4%** | 0.003 | 0 |
| llama3_8b | 168.0 ms | **156.5 ms** | 11.5 ms | **6.8%** | 0.001 | 0 |
| mixtral_8x1b | 690.5 ms | **677.5 ms** | 13.0 ms | **1.9%** | 1.548 | 0 |
| llama3.1-8b | 713.5 ms | **704.5 ms** | 9.0 ms | **1.3%** | 0.001 | 0 |
| gemma2-9b | 1319.5 ms | **1313.0 ms** | 6.5 ms | **0.5%** | 0.003 | 0 |

The saving is a roughly **fixed per-step cost** (~6-13 ms; the work removed is the remap of the small churning slices, whose count is set by command-buffer structure, not model size). It therefore shows up as a larger percentage on short-step models and a smaller one on heavy models, but it is always a net win and never regresses. `auto` lands on the same optimum as a hand-tuned fixed 4 KB cutoff (llama2_7b: auto 121 ms == fixed-4K 120 ms).

### vmm leg (no collectives), disabled vs auto — same pattern

| Model | disabled (`=0`) | auto (`=1`) | saved | speedup |
|---|---|---|---|---|
| llama2_7b | 138.5 ms | **126.0 ms** | 12.5 ms | **9.0%** |
| llama3_8b | 168.5 ms | **158.0 ms** | 10.5 ms | **6.2%** |
| mixtral_8x1b / llama3.1-8b / gemma2-9b | _running_ | _running_ | | _will update_ |

Correctness across every run: identical loss vs the disabled baseline and **zero unmap errors**.

## Notes
- Marked `[EXPERIMENT]` — behind an env knob, default auto, ROCm-gated.
- vmm-leg numbers for the 3 heavier models will be appended when the in-flight sweep completes.