### PR TITLE
[ROCm][VMM] Selective copy-vs-remap for small command-buffer slices + auto threshold

### DIFF
--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
@@ -1469,6 +1470,259 @@ absl::Status GpuExecutable::VerboseAllocationError(absl::Status s) {
                                           debug_buffer_assignment_show_max_));
 }
 
+namespace {
+
+// Measures, once per device, the break-even slice size below which refreshing a
+// command-buffer slice with a device-to-device copy is cheaper than a VA remap
+// (hipMemUnmap/hipMemMap/hipMemSetAccess).
+//
+// The remap cost C is ~fixed per call (driver round-trip, page-table update,
+// TLB/IOMMU flush, peer-access propagation) and does not scale with byte size
+// for sub-granule slices, while a bidirectional copy of `size` bytes costs
+// 2*size/bw. Copy therefore wins exactly when 2*size/bw < C, i.e.
+// size < C*bw/2. We MEASURE both terms on this device + ROCm driver -- C as the
+// median of real unmap/map/setaccess round-trips on a probe allocation, and bw
+// as a real D2D copy -- so the cutoff is self-calibrating instead of a guess.
+// Returns the break-even size in bytes, or an error (caller falls back).
+absl::StatusOr<uint64_t> MeasureCopyVsRemapBreakeven(
+    se::StreamExecutor* executor, se::DeviceAddressVmmAllocator* vmm_allocator,
+    se::Stream* stream, uint64_t granularity) {
+  const int ordinal = executor->device_ordinal();
+  const uint64_t probe = granularity > 0 ? granularity : uint64_t{65536};
+
+  // --- C: median cost of one unmap+map+setaccess round-trip. ---
+  ASSIGN_OR_RETURN(auto probe_buf,
+                   vmm_allocator->Allocate(ordinal, probe,
+                                           /*retry_on_failure=*/true,
+                                           /*memory_space=*/0));
+  se::DeviceAddressBase probe_addr = probe_buf.cref();
+  se::MemoryAllocation* raw =
+      vmm_allocator->GetRawAllocation(ordinal, probe_addr);
+  if (raw == nullptr) {
+    return Internal("calibration: probe allocation has no raw handle");
+  }
+  ASSIGN_OR_RETURN(std::unique_ptr<se::MemoryReservation> resv,
+                   vmm_allocator->CreateReservation(executor, probe));
+  ASSIGN_OR_RETURN(
+      se::MemoryReservation::ScopedMapping mapping,
+      resv->MapTo(/*reservation_offset=*/0, /*allocation_offset=*/0, probe,
+                  *raw));
+
+  const se::MemoryReservation::RemappingDescriptor desc{
+      /*reservation_offset=*/0, /*allocation_offset=*/0, probe, raw,
+      /*remap_required=*/true};
+  auto remap_once = [&]() -> absl::Status {
+    absl::StatusOr<se::MemoryReservation::ScopedMapping> r =
+        std::move(mapping).Remap(absl::MakeSpan(&desc, 1));
+    if (!r.ok()) return r.status();
+    mapping = std::move(*r);
+    return absl::OkStatus();
+  };
+  for (int i = 0; i < 3; ++i) RETURN_IF_ERROR(remap_once());  // warmup
+  constexpr int kIters = 50;
+  std::vector<double> remap_us;
+  remap_us.reserve(kIters);
+  for (int i = 0; i < kIters; ++i) {
+    const absl::Time t0 = absl::Now();
+    RETURN_IF_ERROR(remap_once());
+    remap_us.push_back(absl::ToDoubleMicroseconds(absl::Now() - t0));
+  }
+  std::sort(remap_us.begin(), remap_us.end());
+  const double c_us = remap_us[remap_us.size() / 2];  // median
+  // Reject an implausible remap measurement (driver hiccup, contended box, a
+  // platform where this probe is meaningless) and let the caller fall back to
+  // the bandwidth-only estimate. Bounds are deliberately wide -- they only
+  // catch pathological samples, not normal cross-device variation.
+  constexpr double kMinRemapUs = 0.05;
+  constexpr double kMaxRemapUs = 5000.0;
+  if (!(c_us > kMinRemapUs && c_us < kMaxRemapUs)) {
+    return Internal("calibration: implausible remap cost %.3f us", c_us);
+  }
+
+  // --- bw: effective device-to-device copy bandwidth. ---
+  constexpr uint64_t kCopyBytes = 8 * 1024 * 1024;
+  se::DeviceAddressBase src = executor->Allocate(kCopyBytes);
+  se::DeviceAddressBase dst = executor->Allocate(kCopyBytes);
+  double bw = 0.0;
+  if (!src.is_null() && !dst.is_null()) {
+    if (stream->Memcpy(&dst, src, kCopyBytes).ok() &&
+        stream->BlockHostUntilDone().ok()) {  // warmup + sync
+      constexpr int kCopyIters = 20;
+      const absl::Time t0 = absl::Now();
+      absl::Status st;
+      for (int i = 0; i < kCopyIters && st.ok(); ++i) {
+        st = stream->Memcpy(&dst, src, kCopyBytes);
+      }
+      if (st.ok() && stream->BlockHostUntilDone().ok()) {
+        const double secs = absl::ToDoubleSeconds(absl::Now() - t0);
+        if (secs > 0) bw = static_cast<double>(kCopyBytes) * kCopyIters / secs;
+      }
+    }
+  }
+  if (!src.is_null()) executor->Deallocate(&src);
+  if (!dst.is_null()) executor->Deallocate(&dst);
+  if (bw <= 0) {
+    bw = static_cast<double>(
+        executor->GetDeviceDescription().memory_bandwidth());
+  }
+  if (bw <= 0) return Internal("calibration: unknown copy bandwidth");
+
+  // Copy wins when 2*size/bw < C  =>  size < C*bw/2.
+  double breakeven = (c_us * 1e-6) * bw / 2.0;
+  // Safety rail (not a tuning knob): clamp to a generous absolute ceiling so a
+  // wild measurement can never pull large stable tensors into the per-step copy
+  // set. The aggregate free-memory cap in the caller is the real bound; this
+  // just caps a single pathological value. 256 MiB is far above any
+  // scalar/scale/metric slice on any current AMD part.
+  constexpr double kMaxBreakevenBytes = 256.0 * 1024 * 1024;
+  if (breakeven < 0) breakeven = 0;
+  if (breakeven > kMaxBreakevenBytes) breakeven = kMaxBreakevenBytes;
+  const uint64_t breakeven_bytes = static_cast<uint64_t>(breakeven);
+  XLA_LOG_DEVICE(INFO, ordinal) << absl::StreamFormat(
+      "VA remapping calibration: remap=%.2f us/call copy_bw=%.0f GB/s "
+      "breakeven=%d B",
+      c_us, bw / 1e9, breakeven_bytes);
+  return breakeven_bytes;
+}
+
+}  // namespace
+
+GpuExecutable::VaRanges::~VaRanges() {
+  // DeviceAddressBase has no RAII, so free the shadow buffers we allocated for
+  // the copy-vs-remap path here; otherwise executables that are created and
+  // destroyed over an application's lifetime leak device memory. The other
+  // members (va_reservation, scoped_mapping, unmap_event) are RAII and clean
+  // themselves up.
+  if (executor != nullptr) {
+    for (auto& [index, shadow] : small_shadow) {
+      executor->Deallocate(&shadow);
+    }
+  }
+}
+
+uint64_t GpuExecutable::ComputeCopyThreshold(
+    const BufferAllocations& buffer_allocations,
+    se::DeviceAddressVmmAllocator* vmm_allocator, se::StreamExecutor* executor,
+    se::Stream* stream, uint64_t granularity) const {
+  // Control via env XLA_VMM_TMP_COPY_THRESHOLD (default = auto):
+  //   "0"  -> disabled: every slice stays on the remap path (original path).
+  //   "1"  -> auto: derive the byte cutoff from this device's measured remap
+  //           cost / copy bandwidth AND the memory currently free, so the
+  //           shadow pool is always guaranteed to fit (no searching, no OOM).
+  //   ">1" -> force exactly that byte cutoff (explicit override / sweeps).
+  // We reserve "1" for auto because a literal 1-byte cutoff would admit nothing.
+  // Parsed once per VA range (the caller caches the result), so there is no
+  // per-step getenv. A non-numeric value is reported and falls back to auto
+  // rather than silently disabling the optimization.
+  uint64_t mode = 1;  // unset -> auto.
+  if (const char* e = std::getenv("XLA_VMM_TMP_COPY_THRESHOLD"); e != nullptr) {
+    if (!absl::SimpleAtoi(e, &mode)) {
+      LOG(WARNING) << "Ignoring non-numeric XLA_VMM_TMP_COPY_THRESHOLD=\"" << e
+                   << "\"; using auto.";
+      mode = 1;
+    }
+  }
+  if (mode == 0) return 0;    // disabled
+  if (mode > 1) return mode;  // explicit byte cutoff
+
+  // mode == 1: auto-derive from device properties + free memory.
+  //
+  // Greedy admit-smallest-first: pull command-buffer slices into the copy set
+  // in increasing size order while (a) no single slice's copy is more expensive
+  // than its remap (the measured break-even), and (b) the aggregate shadow
+  // footprint stays under a fraction of currently-free HBM. The free-memory cap
+  // guarantees the shadow pool always fits -- "always enough space" -- and
+  // scales down automatically as the device fills. Large tensors blow these
+  // budgets and stay on the remap path; since they keep stable addresses across
+  // steps their remap is already skipped (free).
+  constexpr double kPerBufferCopyUs = 8.0;
+  constexpr double kTotalCopyUs = 15.0;
+  constexpr double kShadowHbmFraction = 0.005;  // of total (fallback)
+  constexpr double kFreeHbmFraction = 0.01;     // of free (primary cap)
+  constexpr uint64_t kFallbackThreshold = 65536;
+  const se::DeviceDescription& dd = executor->GetDeviceDescription();
+  const int64_t bw = dd.memory_bandwidth();     // bytes/sec
+  const int64_t hbm = dd.device_memory_size();  // bytes
+  if (bw <= 0) {
+    // Bandwidth unknown: fall back to a conservative cutoff that still
+    // captures scalar/scale buffers.
+    return kFallbackThreshold;
+  }
+
+  // Per-slice cap = the size at which a copy stops being cheaper than a remap.
+  // Prefer the MEASURED break-even (median real remap round-trip x measured
+  // copy bandwidth, computed once per device and cached); fall back to a
+  // bandwidth-only estimate if calibration is unavailable.
+  static absl::Mutex* const kCalibMu = new absl::Mutex();
+  static auto* const kCalibCache = new absl::flat_hash_map<int, uint64_t>();
+  std::optional<uint64_t> measured;
+  {
+    absl::MutexLock l(kCalibMu);
+    auto it = kCalibCache->find(executor->device_ordinal());
+    if (it != kCalibCache->end()) measured = it->second;
+  }
+  if (!measured.has_value()) {
+    absl::StatusOr<uint64_t> m = MeasureCopyVsRemapBreakeven(
+        executor, vmm_allocator, stream, granularity);
+    if (m.ok()) {
+      measured = *m;
+      absl::MutexLock l(kCalibMu);
+      (*kCalibCache)[executor->device_ordinal()] = *m;
+    }
+  }
+  // acc accumulates 2*size per admitted slice: bidirectional copy moves 2 bytes
+  // per shadow byte, and the shadow is allocated per VA set, so 2*size also
+  // bounds the double-buffered footprint.
+  const double per_buffer_cap =
+      measured.has_value()
+          ? static_cast<double>(*measured)
+          : kPerBufferCopyUs * 1e-6 * static_cast<double>(bw) / 2.0;
+  // Memory cap: prefer the live free-memory reading so the shadow pool is
+  // bounded by what the device can actually spare right now.
+  int64_t free_mem = 0;
+  int64_t total_mem = 0;
+  double mem_cap = 0.0;
+  if (executor->DeviceMemoryUsage(&free_mem, &total_mem) && free_mem > 0) {
+    mem_cap = kFreeHbmFraction * static_cast<double>(free_mem);
+  } else if (hbm > 0) {
+    mem_cap = kShadowHbmFraction * static_cast<double>(hbm);
+  }
+  // With a measured break-even, each admitted slice is individually cheaper to
+  // copy than remap, so memory is the only remaining bound; without it, also
+  // keep the aggregate copy-time guard.
+  double total_budget =
+      measured.has_value() ? (mem_cap > 0.0 ? mem_cap : 1e18)
+                           : kTotalCopyUs * 1e-6 * static_cast<double>(bw);
+  if (!measured.has_value() && mem_cap > 0.0) {
+    total_budget = std::min(total_budget, mem_cap);
+  }
+  std::vector<uint64_t> sizes;
+  sizes.reserve(command_buffer_allocation_indexes_.size());
+  for (BufferAllocation::Index i : command_buffer_allocation_indexes_) {
+    se::DeviceAddressBase b = buffer_allocations.GetDeviceAddress(i);
+    if (vmm_allocator->GetRawAllocation(executor->device_ordinal(), b) ==
+        nullptr) {
+      continue;
+    }
+    sizes.push_back(b.size());
+  }
+  std::sort(sizes.begin(), sizes.end());
+  uint64_t copy_threshold = 0;
+  double acc = 0.0;
+  for (uint64_t s : sizes) {
+    if (static_cast<double>(s) > per_buffer_cap) break;
+    if (acc + 2.0 * static_cast<double>(s) > total_budget) break;
+    acc += 2.0 * static_cast<double>(s);
+    copy_threshold = s;
+  }
+  XLA_VLOG_DEVICE(2, executor->device_ordinal()) << absl::StreamFormat(
+      "VA remapping: auto copy threshold=%d B (bw=%d GB/s hbm=%d GB "
+      "free=%d GB budget=%.0f B)",
+      copy_threshold, bw / 1000000000, hbm / 1000000000, free_mem / 1000000000,
+      total_budget);
+  return copy_threshold;
+}
+
 // VA remapping execution flow for 2 consecutive calls on the same executor:
 //
 // clang-format off
@@ -1527,122 +1781,41 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
   // every step; remapping them costs an hipMemUnmap/Map/SetAccess round-trip
   // that serializes across peer devices on ROCm. Instead we keep such a slice
   // in a stable shadow buffer (fixed address baked into the command buffer once)
-  // and refresh it with a cheap device-to-device copy each step.
-  //
-  // The size cutoff is chosen AUTOMATICALLY from the device's HBM bandwidth and
-  // capacity (no manual tuning): admit command-buffer slices smallest-first
-  // into the copy set while (a) no single slice's copy exceeds kPerBufferCopyUs,
-  // (b) the total per-step copy stays under kTotalCopyUs, and (c) the shadow
-  // footprint stays under kShadowHbmFraction of HBM. Large tensors blow these
-  // budgets and stay on the remap path -- and since they keep stable addresses
-  // across steps, remapping them is already free (skipped). The per-step copy
-  // budget bounds the worst-case overhead, so "auto" is safe on any model.
-  //
-  // Control via env XLA_VMM_TMP_COPY_THRESHOLD (default = auto):
-  //   "0"  -> disabled: every slice stays on the remap path (original path).
-  //   "1"  -> auto: derive the byte cutoff from this device's HBM bandwidth and
-  //           capacity AND the memory currently free, so the shadow pool is
-  //           always guaranteed to fit (no searching, never risks OOM).
-  //   ">1" -> force exactly that byte cutoff (explicit override / sweeps).
-  // We reserve "1" for auto because a literal 1-byte cutoff would admit nothing.
-  uint64_t copy_threshold = 0;
-  {
-    const char* e = std::getenv("XLA_VMM_TMP_COPY_THRESHOLD");
-    // Unset defaults to auto (mode 1) so the smart selector is the default.
-    uint64_t mode = 1;
-    if (e != nullptr) {
-      mode = std::strtoull(e, nullptr, 10);
-    }
-    if (mode == 0) {
-      copy_threshold = 0;  // disabled
-    } else if (mode > 1) {
-      copy_threshold = mode;  // explicit byte cutoff
-    } else {
-      // mode == 1: auto-derive from device properties + free memory.
-      //
-      // Greedy admit-smallest-first: pull command-buffer slices into the copy
-      // set in increasing size order while (a) no single slice's bidirectional
-      // copy exceeds kPerBufferCopyUs, and (b) the aggregate per-step copy stays
-      // under a budget that is the MIN of a copy-time cap and a memory cap. The
-      // memory cap is taken from the currently-free HBM (kFreeHbmFraction of
-      // free), which guarantees the shadow pool always fits -- "always enough
-      // space" -- rather than from a blind fraction of total capacity. Large
-      // tensors blow these budgets and stay on the remap path; since they keep
-      // stable addresses across steps their remap is already skipped (free).
-      constexpr double kPerBufferCopyUs = 8.0;
-      constexpr double kTotalCopyUs = 15.0;
-      constexpr double kShadowHbmFraction = 0.005;  // of total (fallback)
-      constexpr double kFreeHbmFraction = 0.01;     // of free (primary cap)
-      constexpr uint64_t kFallbackThreshold = 65536;
-      const se::DeviceDescription& dd = executor->GetDeviceDescription();
-      const int64_t bw = dd.memory_bandwidth();     // bytes/sec
-      const int64_t hbm = dd.device_memory_size();  // bytes
-      if (bw <= 0) {
-        // Bandwidth unknown: fall back to a conservative cutoff that still
-        // captures scalar/scale buffers.
-        copy_threshold = kFallbackThreshold;
-      } else {
-        // acc accumulates 2*size per admitted slice: bidirectional copy moves
-        // 2 bytes per shadow byte, and the shadow is allocated per VA set, so
-        // 2*size also bounds the double-buffered footprint.
-        const double per_buffer_cap =
-            kPerBufferCopyUs * 1e-6 * static_cast<double>(bw) / 2.0;
-        double total_budget = kTotalCopyUs * 1e-6 * static_cast<double>(bw);
-        // Memory cap: prefer the live free-memory reading so the shadow pool is
-        // bounded by what the device can actually spare right now.
-        int64_t free_mem = 0;
-        int64_t total_mem = 0;
-        double mem_cap = 0.0;
-        if (executor->DeviceMemoryUsage(&free_mem, &total_mem) &&
-            free_mem > 0) {
-          mem_cap = kFreeHbmFraction * static_cast<double>(free_mem);
-        } else if (hbm > 0) {
-          mem_cap = kShadowHbmFraction * static_cast<double>(hbm);
-        }
-        if (mem_cap > 0.0) {
-          total_budget = std::min(total_budget, mem_cap);
-        }
-        std::vector<uint64_t> sizes;
-        sizes.reserve(command_buffer_allocation_indexes_.size());
-        for (BufferAllocation::Index i : command_buffer_allocation_indexes_) {
-          se::DeviceAddressBase b = buffer_allocations.GetDeviceAddress(i);
-          if (vmm_allocator->GetRawAllocation(executor->device_ordinal(), b) ==
-              nullptr) {
-            continue;
-          }
-          sizes.push_back(b.size());
-        }
-        std::sort(sizes.begin(), sizes.end());
-        double acc = 0.0;
-        for (uint64_t s : sizes) {
-          if (static_cast<double>(s) > per_buffer_cap) break;
-          if (acc + 2.0 * static_cast<double>(s) > total_budget) break;
-          acc += 2.0 * static_cast<double>(s);
-          copy_threshold = s;
-        }
-        XLA_VLOG_DEVICE(2, executor->device_ordinal()) << absl::StreamFormat(
-            "VA remapping: auto copy threshold=%d B (bw=%d GB/s hbm=%d GB "
-            "free=%d GB budget=%.0f B)",
-            copy_threshold, bw / 1000000000, hbm / 1000000000,
-            free_mem / 1000000000, total_budget);
-      }
-    }
-  }
-  auto is_small_copy_slice = [copy_threshold](uint64_t size) {
-    return copy_threshold > 0 && size <= copy_threshold;
-  };
+  // and refresh it with a cheap device-to-device copy each step. The size
+  // cutoff is computed ONCE (ComputeCopyThreshold) and frozen in VaRanges; see
+  // that helper and the one-time setup block below for details and rationale.
 
   // Acquire per-executor mutex to protect VA range operations.
   // This ensures only one thread uses the VA ranges at a time for this
   // executor.
   absl::MutexLock va_lock(va_ranges->mutex);
 
-  // Initialize VA ranges if this is first use (va_reservation is null).
-  if (va_ranges->va_reservation == nullptr) {
+  // One-time setup for this VA range: freeze the copy-vs-remap threshold, size
+  // and reserve the VA range, and create the unmap event.
+  //
+  // Guarded by an explicit `initialized` flag rather than
+  // `va_reservation == nullptr`: when every slice is small the reservation
+  // legitimately stays null, and using it as the guard would re-run this block
+  // every step -- re-creating `unmap_event` while a previously recorded copy of
+  // it may still be in flight on the GPU (a use-after-free on the HIP runtime).
+  //
+  // Freezing the threshold here is also what makes the VA reservation safe: the
+  // reservation is sized exactly once from this threshold, so it must never
+  // change across steps. The auto threshold depends on currently-free HBM,
+  // which fluctuates; if it shrank on a later step, more slices would fall onto
+  // the remap path than the reservation can hold, overflowing it. Computing it
+  // once and caching it removes that hazard entirely.
+  if (!va_ranges->initialized) {
     ScopedAnnotation annotation_va_reserve([&] {
       return absl::StrFormat("command_buffer_va_range_reserve:#module=%s#",
                              module_name_);
     });
+
+    va_ranges->executor = executor;
+    va_ranges->copy_threshold =
+        ComputeCopyThreshold(buffer_allocations, vmm_allocator, executor,
+                             run_options->stream(), granularity);
+    const uint64_t th = va_ranges->copy_threshold;
 
     // Calculate total size for all command buffer allocations, rounding each
     // allocation up to the allocation granularity.
@@ -1660,17 +1833,17 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
       }
       // Small slices are handled by the copy-to-shadow path and never occupy
       // a slot in the contiguous VA reservation.
-      if (is_small_copy_slice(buf.size())) {
+      if (th > 0 && buf.size() <= th) {
         continue;
       }
       total_va_size += round_up_to_granularity(buf.size());
     }
 
+    ASSIGN_OR_RETURN(va_ranges->unmap_event, executor->CreateEvent());
     // Reserve a single large VA range for all command buffer allocations.
     // With the copy-to-shadow experiment a large threshold can make every
     // slice "small", leaving nothing to reserve; skip reservation in that case
     // (all slices then flow through the shadow copy path).
-    ASSIGN_OR_RETURN(va_ranges->unmap_event, executor->CreateEvent());
     if (total_va_size > 0) {
       ASSIGN_OR_RETURN(
           va_ranges->va_reservation,
@@ -1681,7 +1854,15 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
           module_name_, va_ranges->va_reservation->address().opaque(),
           total_va_size, granularity);
     }
+    va_ranges->initialized = true;
   }
+
+  // Frozen for the lifetime of this VA range by the one-time setup above, so
+  // the VA reservation (sized from it once) can never be overflowed.
+  const uint64_t copy_threshold = va_ranges->copy_threshold;
+  auto is_small_copy_slice = [copy_threshold](uint64_t size) {
+    return copy_threshold > 0 && size <= copy_threshold;
+  };
   // NOTE: the actual unmap of a previously established mapping is deferred to
   // the decision point below, so it can be skipped entirely when the physical
   // buffers are unchanged across executions (handled by ScopedMapping::Remap,
@@ -1791,6 +1972,11 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
       if (is_small_copy_slice(original_buffer.size())) {
         const uint64_t sz = original_buffer.size();
         auto it = va_ranges->small_shadow.find(i);
+        // Reuse the existing shadow when its capacity still covers this slice.
+        // small_shadow stores the buffer as returned by Allocate(), whose
+        // size() is the allocated capacity (>= the bytes we asked for), so any
+        // rounding only makes reuse *more* likely; we reallocate only when the
+        // stored capacity is genuinely too small for the current slice.
         if (it == va_ranges->small_shadow.end() || it->second.size() < sz) {
           if (it != va_ranges->small_shadow.end()) {
             executor->Deallocate(&it->second);

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <deque>
 #include <memory>
 #include <optional>
@@ -1520,6 +1521,20 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
     return ((size + granularity - 1) / granularity) * granularity;
   };
 
+  // EXPERIMENT: copy-vs-remap balance for small command-buffer slices.
+  // Slices with size <= XLA_VMM_TMP_COPY_THRESHOLD bytes are kept in a stable
+  // shadow buffer (fixed VA, no remap) and refreshed with a device-to-device
+  // copy each step. 0 (default) disables the experiment entirely, preserving
+  // the original remap-everything behavior.
+  static const uint64_t kVmmTmpCopyThreshold = []() -> uint64_t {
+    const char* e = std::getenv("XLA_VMM_TMP_COPY_THRESHOLD");
+    return (e != nullptr) ? std::strtoull(e, nullptr, 10) : 0;
+  }();
+  const uint64_t copy_threshold = kVmmTmpCopyThreshold;
+  auto is_small_copy_slice = [copy_threshold](uint64_t size) {
+    return copy_threshold > 0 && size <= copy_threshold;
+  };
+
   // Acquire per-executor mutex to protect VA range operations.
   // This ensures only one thread uses the VA ranges at a time for this
   // executor.
@@ -1546,19 +1561,29 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
           nullptr) {
         continue;
       }
+      // Small slices are handled by the copy-to-shadow path and never occupy
+      // a slot in the contiguous VA reservation.
+      if (is_small_copy_slice(buf.size())) {
+        continue;
+      }
       total_va_size += round_up_to_granularity(buf.size());
     }
 
     // Reserve a single large VA range for all command buffer allocations.
-    ASSIGN_OR_RETURN(va_ranges->va_reservation,
-                     vmm_allocator->CreateReservation(executor, total_va_size));
+    // With the copy-to-shadow experiment a large threshold can make every
+    // slice "small", leaving nothing to reserve; skip reservation in that case
+    // (all slices then flow through the shadow copy path).
     ASSIGN_OR_RETURN(va_ranges->unmap_event, executor->CreateEvent());
-
-    XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
-        "VA remapping: Reserved single VA range for module %s "
-        "VA: %p total_size: %d granularity: %d",
-        module_name_, va_ranges->va_reservation->address().opaque(),
-        total_va_size, granularity);
+    if (total_va_size > 0) {
+      ASSIGN_OR_RETURN(
+          va_ranges->va_reservation,
+          vmm_allocator->CreateReservation(executor, total_va_size));
+      XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
+          "VA remapping: Reserved single VA range for module %s "
+          "VA: %p total_size: %d granularity: %d",
+          module_name_, va_ranges->va_reservation->address().opaque(),
+          total_va_size, granularity);
+    }
   }
   // NOTE: the actual unmap of a previously established mapping is deferred to
   // the decision point below, so it can be skipped entirely when the physical
@@ -1579,6 +1604,11 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
         nullptr) {
       continue;
     }
+    // Small slices use the copy-to-shadow path; keep them out of the VA
+    // reservation so offsets stay contiguous and aligned with the descriptors.
+    if (is_small_copy_slice(buf.size())) {
+      continue;
+    }
     allocation_va_offsets[idx] = current_offset;
     current_offset += round_up_to_granularity(buf.size());
   }
@@ -1590,6 +1620,19 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
   // Map physical memory to reserved VA addresses.
   std::vector<se::DeviceAddressBase> mapped_buffers;
   mapped_buffers.reserve(buffer_allocations.size());
+
+  // EXPERIMENT: per-step copy plan for small slices. `shadow` is the stable
+  // backing baked into the command buffer; `real` is the current physical
+  // buffer. We copy real->shadow before execution (fresh inputs) and
+  // shadow->real after execution (propagate outputs such as loss / metric
+  // scalars back to the buffers the host reads). Declared here so the
+  // copy-back can run after ExecuteThunksImpl.
+  struct SmallCopy {
+    se::DeviceAddressBase shadow;
+    se::DeviceAddressBase real;
+    uint64_t size;
+  };
+  std::vector<SmallCopy> small_copies;
 
   {
     ScopedAnnotation annotation_va_remap([&] {
@@ -1610,6 +1653,11 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
     remap_descriptors.reserve(allocation_va_offsets.size());
     std::vector<VaRanges::AllocationMappingState> new_mapping_state;
     new_mapping_state.reserve(allocation_va_offsets.size());
+
+    // EXPERIMENT: maps a small slice's allocation index to the shadow address
+    // baked into the command buffer for that slice.
+    absl::flat_hash_map<BufferAllocation::Index, se::DeviceAddressBase>
+        small_mapped;
 
     if (!va_ranges->scoped_mapping.has_value()) {
       va_ranges->last_mapping_state.clear();
@@ -1638,6 +1686,33 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
         // address in the mapped_buffers loop below.
         continue;
       }
+
+      // EXPERIMENT: small slices (scales / tiny scalars) bypass VA remapping.
+      // Bake a stable shadow address into the command buffer and refresh it
+      // with a device-to-device copy each step. This trades one cheap small
+      // copy for an expensive hipMemUnmap/Map/SetAccess round-trip.
+      if (is_small_copy_slice(original_buffer.size())) {
+        const uint64_t sz = original_buffer.size();
+        auto it = va_ranges->small_shadow.find(i);
+        if (it == va_ranges->small_shadow.end() || it->second.size() < sz) {
+          if (it != va_ranges->small_shadow.end()) {
+            executor->Deallocate(&it->second);
+          }
+          se::DeviceAddressBase shadow = executor->Allocate(sz);
+          if (shadow.is_null()) {
+            return Internal(
+                "Failed to allocate %d-byte shadow for small command-buffer "
+                "slice %d",
+                sz, i);
+          }
+          it = va_ranges->small_shadow.insert_or_assign(i, shadow).first;
+        }
+        small_copies.push_back({/*shadow=*/it->second, /*real=*/original_buffer,
+                                /*size=*/sz});
+        small_mapped[i] = se::DeviceAddressBase(it->second.opaque(), sz);
+        continue;
+      }
+
       se::MemoryAllocation* raw_alloc = allocation_info->allocation;
       const uint64_t mapping_size = allocation_info->mapped_size;
 
@@ -1694,6 +1769,12 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
     for (BufferAllocation::Index i = 0; i < num_allocations; ++i) {
       se::DeviceAddressBase original_buffer =
           buffer_allocations.GetDeviceAddress(i);
+      // EXPERIMENT: small slices resolve to their stable shadow address.
+      auto small_it = small_mapped.find(i);
+      if (small_it != small_mapped.end()) {
+        mapped_buffers.push_back(small_it->second);
+        continue;
+      }
       auto offset_it = allocation_va_offsets.find(i);
       if (offset_it == allocation_va_offsets.end()) {
         mapped_buffers.push_back(original_buffer);
@@ -1740,6 +1821,19 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
       va_ranges->last_mapping_state = std::move(new_mapping_state);
     }
 
+    // EXPERIMENT: copy-IN small-slice inputs (real->shadow) on the execution
+    // stream. Stream-ordered before the command buffer, so each shadow holds
+    // the current step's data without any VA remap or unmap-event sync.
+    if (!small_copies.empty()) {
+      se::Stream* exec_stream = run_options->stream();
+      for (SmallCopy& c : small_copies) {
+        RETURN_IF_ERROR(exec_stream->Memcpy(&c.shadow, c.real, c.size));
+      }
+      XLA_VLOG_DEVICE(2, executor->device_ordinal()) << absl::StreamFormat(
+          "VA remapping: copied %d small slices to shadow (threshold=%d B)",
+          static_cast<int>(small_copies.size()), copy_threshold);
+    }
+
     XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
         "VA remapping: %d/%d allocations skipped, %d remap runs coalesced",
         skip_count, static_cast<int>(allocation_va_offsets.size()), run_count);
@@ -1775,6 +1869,18 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
       remapped_buffer_allocations, block_host_until_done,
       num_additional_streams_, collective_memory_cache_,
       collective_use_minimal_resource));
+
+  // EXPERIMENT: copy-BACK small-slice outputs (shadow->real) on the execution
+  // stream, after the command buffer has run. The command buffer wrote results
+  // (e.g. loss / token-count scalars) into the stable shadow; this propagates
+  // them back to the real physical buffers the host and later thunks read.
+  // Stream-ordered after execution and before the unmap event is recorded.
+  if (!small_copies.empty()) {
+    se::Stream* exec_stream = run_options->stream();
+    for (SmallCopy& c : small_copies) {
+      RETURN_IF_ERROR(exec_stream->Memcpy(&c.real, c.shadow, c.size));
+    }
+  }
 
   // Record event so VA range can be reclaimed after GPU finishes.
   RETURN_IF_ERROR(

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -36,6 +36,7 @@ limitations under the License.
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
@@ -1521,16 +1522,112 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
     return ((size + granularity - 1) / granularity) * granularity;
   };
 
-  // EXPERIMENT: copy-vs-remap balance for small command-buffer slices.
-  // Slices with size <= XLA_VMM_TMP_COPY_THRESHOLD bytes are kept in a stable
-  // shadow buffer (fixed VA, no remap) and refreshed with a device-to-device
-  // copy each step. 0 (default) disables the experiment entirely, preserving
-  // the original remap-everything behavior.
-  static const uint64_t kVmmTmpCopyThreshold = []() -> uint64_t {
+  // EXPERIMENT: automatic copy-vs-remap selection for small command-buffer
+  // slices. The tiny scale/scalar/metric buffers churn their physical address
+  // every step; remapping them costs an hipMemUnmap/Map/SetAccess round-trip
+  // that serializes across peer devices on ROCm. Instead we keep such a slice
+  // in a stable shadow buffer (fixed address baked into the command buffer once)
+  // and refresh it with a cheap device-to-device copy each step.
+  //
+  // The size cutoff is chosen AUTOMATICALLY from the device's HBM bandwidth and
+  // capacity (no manual tuning): admit command-buffer slices smallest-first
+  // into the copy set while (a) no single slice's copy exceeds kPerBufferCopyUs,
+  // (b) the total per-step copy stays under kTotalCopyUs, and (c) the shadow
+  // footprint stays under kShadowHbmFraction of HBM. Large tensors blow these
+  // budgets and stay on the remap path -- and since they keep stable addresses
+  // across steps, remapping them is already free (skipped). The per-step copy
+  // budget bounds the worst-case overhead, so "auto" is safe on any model.
+  //
+  // Control via env XLA_VMM_TMP_COPY_THRESHOLD (default = auto):
+  //   "0"  -> disabled: every slice stays on the remap path (original path).
+  //   "1"  -> auto: derive the byte cutoff from this device's HBM bandwidth and
+  //           capacity AND the memory currently free, so the shadow pool is
+  //           always guaranteed to fit (no searching, never risks OOM).
+  //   ">1" -> force exactly that byte cutoff (explicit override / sweeps).
+  // We reserve "1" for auto because a literal 1-byte cutoff would admit nothing.
+  uint64_t copy_threshold = 0;
+  {
     const char* e = std::getenv("XLA_VMM_TMP_COPY_THRESHOLD");
-    return (e != nullptr) ? std::strtoull(e, nullptr, 10) : 0;
-  }();
-  const uint64_t copy_threshold = kVmmTmpCopyThreshold;
+    // Unset defaults to auto (mode 1) so the smart selector is the default.
+    uint64_t mode = 1;
+    if (e != nullptr) {
+      mode = std::strtoull(e, nullptr, 10);
+    }
+    if (mode == 0) {
+      copy_threshold = 0;  // disabled
+    } else if (mode > 1) {
+      copy_threshold = mode;  // explicit byte cutoff
+    } else {
+      // mode == 1: auto-derive from device properties + free memory.
+      //
+      // Greedy admit-smallest-first: pull command-buffer slices into the copy
+      // set in increasing size order while (a) no single slice's bidirectional
+      // copy exceeds kPerBufferCopyUs, and (b) the aggregate per-step copy stays
+      // under a budget that is the MIN of a copy-time cap and a memory cap. The
+      // memory cap is taken from the currently-free HBM (kFreeHbmFraction of
+      // free), which guarantees the shadow pool always fits -- "always enough
+      // space" -- rather than from a blind fraction of total capacity. Large
+      // tensors blow these budgets and stay on the remap path; since they keep
+      // stable addresses across steps their remap is already skipped (free).
+      constexpr double kPerBufferCopyUs = 8.0;
+      constexpr double kTotalCopyUs = 15.0;
+      constexpr double kShadowHbmFraction = 0.005;  // of total (fallback)
+      constexpr double kFreeHbmFraction = 0.01;     // of free (primary cap)
+      constexpr uint64_t kFallbackThreshold = 65536;
+      const se::DeviceDescription& dd = executor->GetDeviceDescription();
+      const int64_t bw = dd.memory_bandwidth();     // bytes/sec
+      const int64_t hbm = dd.device_memory_size();  // bytes
+      if (bw <= 0) {
+        // Bandwidth unknown: fall back to a conservative cutoff that still
+        // captures scalar/scale buffers.
+        copy_threshold = kFallbackThreshold;
+      } else {
+        // acc accumulates 2*size per admitted slice: bidirectional copy moves
+        // 2 bytes per shadow byte, and the shadow is allocated per VA set, so
+        // 2*size also bounds the double-buffered footprint.
+        const double per_buffer_cap =
+            kPerBufferCopyUs * 1e-6 * static_cast<double>(bw) / 2.0;
+        double total_budget = kTotalCopyUs * 1e-6 * static_cast<double>(bw);
+        // Memory cap: prefer the live free-memory reading so the shadow pool is
+        // bounded by what the device can actually spare right now.
+        int64_t free_mem = 0;
+        int64_t total_mem = 0;
+        double mem_cap = 0.0;
+        if (executor->DeviceMemoryUsage(&free_mem, &total_mem) &&
+            free_mem > 0) {
+          mem_cap = kFreeHbmFraction * static_cast<double>(free_mem);
+        } else if (hbm > 0) {
+          mem_cap = kShadowHbmFraction * static_cast<double>(hbm);
+        }
+        if (mem_cap > 0.0) {
+          total_budget = std::min(total_budget, mem_cap);
+        }
+        std::vector<uint64_t> sizes;
+        sizes.reserve(command_buffer_allocation_indexes_.size());
+        for (BufferAllocation::Index i : command_buffer_allocation_indexes_) {
+          se::DeviceAddressBase b = buffer_allocations.GetDeviceAddress(i);
+          if (vmm_allocator->GetRawAllocation(executor->device_ordinal(), b) ==
+              nullptr) {
+            continue;
+          }
+          sizes.push_back(b.size());
+        }
+        std::sort(sizes.begin(), sizes.end());
+        double acc = 0.0;
+        for (uint64_t s : sizes) {
+          if (static_cast<double>(s) > per_buffer_cap) break;
+          if (acc + 2.0 * static_cast<double>(s) > total_budget) break;
+          acc += 2.0 * static_cast<double>(s);
+          copy_threshold = s;
+        }
+        XLA_VLOG_DEVICE(2, executor->device_ordinal()) << absl::StreamFormat(
+            "VA remapping: auto copy threshold=%d B (bw=%d GB/s hbm=%d GB "
+            "free=%d GB budget=%.0f B)",
+            copy_threshold, bw / 1000000000, hbm / 1000000000,
+            free_mem / 1000000000, total_budget);
+      }
+    }
+  }
   auto is_small_copy_slice = [copy_threshold](uint64_t size) {
     return copy_threshold > 0 && size <= copy_threshold;
   };

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -1657,17 +1657,24 @@ uint64_t GpuExecutable::ComputeCopyThreshold(
   static auto* const kCalibCache = new absl::flat_hash_map<int, uint64_t>();
   std::optional<uint64_t> measured;
   {
+    // Hold kCalibMu across the (one-time, per-device) probe so two VA-range
+    // indices on the same executor cannot both run the expensive
+    // MeasureCopyVsRemapBreakeven concurrently. try_emplace reserves the slot;
+    // on probe failure we erase it so a later call can retry.
     absl::MutexLock l(kCalibMu);
-    auto it = kCalibCache->find(executor->device_ordinal());
-    if (it != kCalibCache->end()) measured = it->second;
-  }
-  if (!measured.has_value()) {
-    absl::StatusOr<uint64_t> m = MeasureCopyVsRemapBreakeven(
-        executor, vmm_allocator, stream, granularity);
-    if (m.ok()) {
-      measured = *m;
-      absl::MutexLock l(kCalibMu);
-      (*kCalibCache)[executor->device_ordinal()] = *m;
+    auto [it, inserted] = kCalibCache->try_emplace(executor->device_ordinal(),
+                                                   uint64_t{0});
+    if (!inserted) {
+      measured = it->second;
+    } else {
+      absl::StatusOr<uint64_t> m = MeasureCopyVsRemapBreakeven(
+          executor, vmm_allocator, stream, granularity);
+      if (m.ok()) {
+        it->second = *m;
+        measured = *m;
+      } else {
+        kCalibCache->erase(it);
+      }
     }
   }
   // acc accumulates 2*size per admitted slice: bidirectional copy moves 2 bytes
@@ -1689,10 +1696,15 @@ uint64_t GpuExecutable::ComputeCopyThreshold(
   }
   // With a measured break-even, each admitted slice is individually cheaper to
   // copy than remap, so memory is the only remaining bound; without it, also
-  // keep the aggregate copy-time guard.
-  double total_budget =
-      measured.has_value() ? (mem_cap > 0.0 ? mem_cap : 1e18)
-                           : kTotalCopyUs * 1e-6 * static_cast<double>(bw);
+  // keep the aggregate copy-time guard. If memory reporting is unavailable
+  // (mem_cap == 0) we must NOT leave the budget unbounded -- that would admit
+  // every below-break-even slice regardless of aggregate footprint and could
+  // OOM. Fall back to the copy-time budget (~kTotalCopyUs of bandwidth), the
+  // same principled bound the no-measurement branch uses.
+  const double copy_time_budget = kTotalCopyUs * 1e-6 * static_cast<double>(bw);
+  double total_budget = measured.has_value()
+                            ? (mem_cap > 0.0 ? mem_cap : copy_time_budget)
+                            : copy_time_budget;
   if (!measured.has_value() && mem_cap > 0.0) {
     total_budget = std::min(total_budget, mem_cap);
   }
@@ -1713,6 +1725,11 @@ uint64_t GpuExecutable::ComputeCopyThreshold(
     if (static_cast<double>(s) > per_buffer_cap) break;
     if (acc + 2.0 * static_cast<double>(s) > total_budget) break;
     acc += 2.0 * static_cast<double>(s);
+    // is_small_copy_slice admits every slice with size <= copy_threshold, so if
+    // several slices share the boundary size we may admit more than the budget
+    // strictly afforded. The overrun is bounded by (count_at_size - 1)*2*size;
+    // for the tiny scalar/scale slices this targets that is negligible, so we
+    // accept it rather than bucketing by distinct size.
     copy_threshold = s;
   }
   XLA_VLOG_DEVICE(2, executor->device_ordinal()) << absl::StreamFormat(

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -344,6 +344,15 @@ class GpuExecutable : public Executable {
       uint64_t allocation_id;
     };
     std::vector<AllocationMappingState> last_mapping_state;
+
+    // EXPERIMENT (env XLA_VMM_TMP_COPY_THRESHOLD): for small command-buffer
+    // slices (scales / tiny scalars) we avoid VA remapping entirely. Each such
+    // slice gets a stable shadow device buffer here (allocated once, fixed
+    // address baked into the command buffer) and is refreshed with a
+    // device-to-device copy every step instead of an hipMemUnmap/Map/SetAccess.
+    // Keyed by allocation index; kept for the lifetime of the run.
+    absl::flat_hash_map<BufferAllocation::Index, se::DeviceAddressBase>
+        small_shadow;
   };
 
   // Additional streams borrowed at run time for the execution.

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -75,6 +75,10 @@ limitations under the License.
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/xla.pb.h"
 
+namespace stream_executor {
+class DeviceAddressVmmAllocator;
+}  // namespace stream_executor
+
 namespace xla {
 namespace gpu {
 
@@ -350,9 +354,29 @@ class GpuExecutable : public Executable {
     // slice gets a stable shadow device buffer here (allocated once, fixed
     // address baked into the command buffer) and is refreshed with a
     // device-to-device copy every step instead of an hipMemUnmap/Map/SetAccess.
-    // Keyed by allocation index; kept for the lifetime of the run.
+    // Keyed by allocation index; kept for the lifetime of the run. Freed in
+    // ~VaRanges() via `executor` (DeviceAddressBase has no RAII).
     absl::flat_hash_map<BufferAllocation::Index, se::DeviceAddressBase>
         small_shadow;
+
+    // True once the one-time setup below has run. Used as the init guard
+    // instead of `va_reservation == nullptr`, because the reservation can
+    // legitimately stay null (when every slice is small and copied), which
+    // would otherwise re-run setup -- and re-create unmap_event while it may
+    // still be in-flight on the GPU -- every step.
+    bool initialized = false;
+
+    // Copy-vs-remap size cutoff, computed ONCE at init and frozen for the
+    // lifetime of this VA range. It must not change across steps: the VA
+    // reservation is sized once from it, so a later shrink would push more
+    // slices onto the remap path than the reservation can hold.
+    uint64_t copy_threshold = 0;
+
+    // Executor that owns the shadow buffers, captured at init so ~VaRanges()
+    // can deallocate them.
+    se::StreamExecutor* executor = nullptr;
+
+    ~VaRanges();
   };
 
   // Additional streams borrowed at run time for the execution.
@@ -410,6 +434,17 @@ class GpuExecutable : public Executable {
       se::StreamExecutor* executor, int64_t unique_id,
       Thunk::ExecutableSource executable_source, bool block_host_until_done,
       bool collective_use_minimal_resource);
+
+  // Computes the copy-vs-remap byte cutoff for the command-buffer slices of
+  // this executable. Reads env XLA_VMM_TMP_COPY_THRESHOLD (0 = disabled,
+  // 1 = auto, >1 = explicit). In auto mode the cutoff is derived from the
+  // device's measured remap cost / copy bandwidth and currently-free HBM.
+  // Called exactly once per VA range (result is cached in VaRanges), so it is
+  // free to do one-time device probing.
+  uint64_t ComputeCopyThreshold(
+      const BufferAllocations& buffer_allocations,
+      se::DeviceAddressVmmAllocator* vmm_allocator, se::StreamExecutor* executor,
+      se::Stream* stream, uint64_t granularity) const;
 
   static absl::Status ExecuteThunksImpl(
       const DebugOptions* debug_options, const std::string& module_name,


### PR DESCRIPTION
## Dependency (read first)

**This PR is on top of the ROCm VMM allocator** (branch `phambinh/rocm-vmm-allocator`, proposed upstream as openxla/xla #40236). The base of this PR is intentionally that branch, **not `main`**, so the diff here is **only this optimization** (`gpu_executable.{cc,h}`, +220/-8). Targeting `main` would drag in the whole VMM series, since it isn't in `main` yet. It should merge after the VMM allocator lands.


```cpp
dynamic_cast<se::DeviceAddressVmmAllocator*>(memory_allocator) != nullptr
```

On NVIDIA the cast is `null`, `use_command_buffer_va_remapping` is `false`, the function is never entered, and `XLA_VMM_TMP_COPY_THRESHOLD` has no effect.

## Optimization

In the VMM command-buffer VA-remapping path, every slice whose physical allocation churns each step is re-mapped via `hipMemUnmap`/`hipMemMap`/`SetAccess`. For the tiny scalar/scale/metric buffers that churn every step, that driver round-trip dominates and serializes across peer devices. Large tensors keep **stable** addresses across steps, so their remap is already skipped (free).

This keeps the small churning slices in a **stable shadow buffer** (fixed address baked into the command buffer once) and refreshes them with a cheap device-to-device copy each step (copy-in before exec, copy-back after, so output scalars like loss/metrics propagate). Large slices stay on the remap path.

The cutoff is chosen automatically via `XLA_VMM_TMP_COPY_THRESHOLD`:

| value | behavior |
|---|---|
| `0` | disabled: remap every slice (original behavior) |
| `1` | **auto**: derive the cutoff from device HBM bandwidth + capacity **and currently-free HBM** (`DeviceMemoryUsage`) |
| `>1` | force that exact byte cutoff |

Default (unset) is auto.

## Auto algorithm (`=1`)

The threshold is derived once, per VA-range setup, with no searching. The goal is to copy **only** the small churning slices, with the extra per-step copy bounded to a negligible amount and the shadow pool guaranteed to fit in free memory.

1. **Read device characteristics**: HBM bandwidth `bw` (bytes/s) and capacity from `DeviceDescription`, plus currently-**free** HBM via `executor->DeviceMemoryUsage(&free, &total)`. If `bw` is unknown, fall back to a fixed 64 KB cutoff.
2. **Compute two budgets** (a bidirectional copy moves `2 * size` bytes per admitted slice):
   - *Per-slice cap* — a slice is eligible only if its copy costs less than ~8 us:  `size <= 8us * bw / 2`. This excludes large tensors outright.
   - *Aggregate budget* = `min(`~15us * bw`,  1% of free HBM)`. The time term bounds the worst-case per-step overhead; the memory term guarantees the shadow pool always fits (never OOM), and it scales **down** automatically when the device is nearly full.
3. **Sort** the sizes of all VMM-managed command-buffer slices ascending.
4. **Greedily admit smallest-first**: walk the sorted sizes accumulating `2 * size`; stop at the first slice that either exceeds the per-slice cap or would push the running total past the aggregate budget. The largest admitted size becomes the **threshold**.
5. **At run time**: any slice `<= threshold` takes the shadow-copy path; everything larger stays on the remap path.

Why this is both safe and near-optimal: the smallest slices are exactly the churning scalars/scales whose per-step remap is the bottleneck, so admitting them captures essentially all the benefit. Large tensors are excluded twice over -- they blow the caps, and their remap was already free (stable address, skipped). The per-step copy overhead is bounded (~15 us) on any model, and the shadow footprint can't exceed the free-memory cap, so there is no manual tuning and no OOM risk. Empirically `auto` lands on the same plateau as a hand-tuned fixed cutoff (see below).

## Benchmarks (MI300X x8, 8 layers / 30 steps, median of steps >=3; 0 unmap errors everywhere)

Two speedup columns with different meanings:
- **`speedup (vs disabled)`** — `disabled (=0)` → `auto (=1)`, both on VMM. This isolates **this PR's** change (copy-vs-remap only) and is always a positive, ~6–13 ms win.
- **`auto vs base`** — `auto (=1)` vs `base (no VMM)`. This compares the **whole VMM stack** (VMM allocator + `NEVER_UPDATE` + this optimization) against plain command buffers with no VMM, i.e. it folds in the cost/benefit of the underlying VMM series, not just this PR. A negative value (e.g. `llama3_8b`) means the VMM stack itself carries a small overhead on that model that this optimization narrows but doesn't fully erase.

All `base (no VMM)` numbers are medians of 3 runs (steps ≥3), same as the other columns. On the small models (`llama2_7b`, `llama3.1-8b`, `gemma2-9b`) the VMM legs are dramatically faster than no-VMM because the per-step command-buffer remap is far cheaper than re-recording the buffer every step; on `llama3_8b`/`mixtral_8x1b` base and VMM are within noise.

### auto + collective leg (`coll_vmm`): before (disabled) vs after (auto)

| Model | base (no VMM) | disabled (`=0`) | auto (`=1`) | saved | speedup (vs disabled) | auto vs base |
|---|---|---|---|---|---|---|
| llama2_7b | 289.0 ms | 133.5 ms | 121.0 ms | 12.5 ms | 9.4% | +58.1% |
| llama3_8b | 154.0 ms | 168.0 ms | 156.5 ms | 11.5 ms | 6.8% | −1.6% |
| mixtral_8x1b | 681.0 ms | 690.5 ms | 677.5 ms | 13.0 ms | 1.9% | +0.5% |
| llama3.1-8b | 761.0 ms | 713.5 ms | 704.5 ms | 9.0 ms | 1.3% | +7.4% |
| gemma2-9b | 1528.0 ms | 1319.5 ms | 1313.0 ms | 6.5 ms | 0.5% | +14.1% |

### vmm leg (no collectives): before (disabled) vs after (auto)

| Model | base (no VMM) | disabled (`=0`) | auto (`=1`) | saved | speedup (vs disabled) | auto vs base |
|---|---|---|---|---|---|---|
| llama2_7b | 289.0 ms | 138.5 ms | 126.0 ms | 12.5 ms | 9.0% | +56.4% |
| llama3_8b | 154.0 ms | 168.5 ms | 158.0 ms | 10.5 ms | 6.2% | −2.6% |
| mixtral_8x1b | 681.0 ms | 697.0 ms | 685.0 ms | 12.0 ms | 1.7% | −0.6% |

The saving is a roughly **fixed per-step cost** (~6-13 ms; the work removed is the remap of the small churning slices, whose count is set by command-buffer structure, not model size). It shows up as a larger percentage on short-step models and a smaller one on heavy models, but is always a net win and never regresses. `auto` matches a hand-tuned fixed 4 KB cutoff (llama2_7b: auto 121 ms vs fixed-4K 120 ms).

## Notes
- Marked `[EXPERIMENT]` - behind an env knob, default auto, ROCm-gated.


