### PR TITLE
[ROCm][VMM] Layer 1/4: RocmRawMemoryAllocation (hipMemCreate/hipMemRelease RAII)

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1383,3 +1383,51 @@ rocm_library(
     ],
     alwayslink = 1,
 )
+
+cc_library(
+    name = "rocm_raw_memory_allocation",
+    srcs = ["rocm_raw_memory_allocation.cc"],
+    hdrs = ["rocm_raw_memory_allocation.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        ":rocm_status",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_raw_memory_allocation_test",
+    srcs = ["rocm_raw_memory_allocation_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_platform",
+        ":rocm_platform_id",
+        ":rocm_raw_memory_allocation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+    ],
+)

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation.cc
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation.cc
@@ -1,0 +1,87 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/log/log.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/device_address.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+absl::StatusOr<std::unique_ptr<RocmRawMemoryAllocation>>
+RocmRawMemoryAllocation::Create(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  hipDevice_t device;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
+
+  hipMemAllocationProp props = {};
+  props.type = hipMemAllocationTypePinned;
+  props.location.type = hipMemLocationTypeDevice;
+  props.location.id = device;
+  props.requestedHandleTypes = hipMemHandleTypeNone;
+
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+      &granularity, &props, hipMemAllocationGranularityRecommended)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+
+  hipMemGenericAllocationHandle_t handle;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipMemCreate(&handle, padded_size, &props, 0ULL)));
+
+  return std::unique_ptr<RocmRawMemoryAllocation>(
+      new RocmRawMemoryAllocation(executor, handle, padded_size));
+}
+
+RocmRawMemoryAllocation::RocmRawMemoryAllocation(
+    StreamExecutor* executor, hipMemGenericAllocationHandle_t handle,
+    uint64_t size)
+    : executor_(executor), handle_(handle), size_(size) {}
+
+DeviceAddressBase RocmRawMemoryAllocation::address() const {
+  // handle_ is an opaque allocation handle, not a device pointer. We expose it
+  // as a DeviceAddressBase so the base class can use opaque() for identity
+  // tracking; callers never dereference this address.
+  return DeviceAddressBase(static_cast<void*>(handle_), size_);
+}
+
+RocmRawMemoryAllocation::~RocmRawMemoryAllocation() {
+  if (handle_ == nullptr) {
+    return;
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  auto status =
+      ToStatus(hipMemRelease(handle_), "Error releasing ROCm memory");
+  if (!status.ok()) {
+    LOG(ERROR) << status.message();
+  }
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation.h
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation.h
@@ -1,0 +1,65 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// RAII wrapper for a physical memory allocation created via hipMemCreate.
+// The handle is not mapped to any virtual address; this class only manages
+// the lifetime of the hipMemGenericAllocationHandle_t.
+class RocmRawMemoryAllocation : public MemoryAllocation {
+ public:
+  // Creates a physical memory allocation of at least `size` bytes using
+  // hipMemCreate. StreamExecutor is used only for context activation.
+  static absl::StatusOr<std::unique_ptr<RocmRawMemoryAllocation>> Create(
+      StreamExecutor* executor, uint64_t size);
+
+  // Returns a DeviceAddressBase whose opaque() holds the raw
+  // hipMemGenericAllocationHandle_t cast to void*, and size() is the
+  // padded allocation size.
+  DeviceAddressBase address() const override;
+
+  hipMemGenericAllocationHandle_t GetHandle() const { return handle_; }
+
+  ~RocmRawMemoryAllocation() override;
+  RocmRawMemoryAllocation(const RocmRawMemoryAllocation&) = delete;
+  RocmRawMemoryAllocation& operator=(const RocmRawMemoryAllocation&) = delete;
+  RocmRawMemoryAllocation(RocmRawMemoryAllocation&&) = delete;
+  RocmRawMemoryAllocation& operator=(RocmRawMemoryAllocation&&) = delete;
+
+ private:
+  explicit RocmRawMemoryAllocation(StreamExecutor* executor,
+                                   hipMemGenericAllocationHandle_t handle,
+                                   uint64_t size);
+
+  StreamExecutor* executor_;
+  hipMemGenericAllocationHandle_t handle_;
+  uint64_t size_;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation_test.cc
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation_test.cc
@@ -1,0 +1,80 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+
+#include <cstdint>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "absl/status/status_matchers.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+using absl_testing::IsOk;
+
+static constexpr uint64_t kTestSize = 1024 * 1024;
+
+class RocmRawMemoryAllocationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    auto executor_or = platform_or.value()->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+TEST_F(RocmRawMemoryAllocationTest, CreateAllocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+
+  EXPECT_NE(alloc->GetHandle(), nullptr);
+  EXPECT_GE(alloc->address().size(), kTestSize);
+}
+
+TEST_F(RocmRawMemoryAllocationTest, AddressReflectsHandle) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+
+  EXPECT_EQ(alloc->address().opaque(),
+            static_cast<void*>(alloc->GetHandle()));
+  EXPECT_GE(alloc->address().size(), kTestSize);
+}
+
+TEST_F(RocmRawMemoryAllocationTest, SizeIsAtLeastRequested) {
+  TF_ASSERT_OK_AND_ASSIGN(auto alloc,
+                          RocmRawMemoryAllocation::Create(executor_, 1));
+
+  EXPECT_NE(alloc->GetHandle(), nullptr);
+  EXPECT_GE(alloc->address().size(), 1u);
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu


### PR DESCRIPTION
## Series (one PR per VMM layer)

This is the **first in a series of four** that splits the ROCm VMM allocator into small, reviewable layers (the combined work was previously one large branch, proposed upstream as openxla/xla#40236). Splitting per layer keeps each PR well under the "large CL" threshold and lets each layer be reviewed independently, bottom-up.

- **PR 1/4: RocmRawMemoryAllocation** — `hipMemCreate` / `hipMemRelease` RAII  ⟸ **This PR**
- PR 2/4: RocmMemoryReservation — `hipMemAddressReserve` / `hipMemMap` / `hipMemSetAccess` / `hipMemUnmap` RAII
- PR 3/4: RocmVmmAllocator — all-in-one allocator (create + reserve + map + setAccess)
- PR 4/4: RocmDeviceAddressVmmAllocator — GPU timeline-based deferred deallocation + PJRT wiring

(The selective copy-vs-remap optimization continues to live in #926, which stacks on top of this series.)

## What this PR adds

The lowest layer of the VMM stack: a standalone RAII handle around a **single physical VMM allocation**.

- `RocmRawMemoryAllocation` owns the `hipMemGenericAllocationHandle_t` returned by `hipMemCreate` and releases it via `hipMemRelease` on destruction (move-only, no copy).
- No dependency on any higher layer, so it builds and is testable on its own.

## Tests

`rocm_raw_memory_allocation_test.cc` — allocate/release and move-semantics coverage.

## Notes

- ROCm-only target (`tags = ["gpu", "rocm-only"]`); no CUDA/NVIDIA impact.
- +280 lines total.