### PR TITLE
[GPU] Fix TritonEmitterTest.ScaledDotIsSupportedByReferencePlatform

### DIFF
--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -1571,7 +1571,7 @@ CHECK-COUNT-1: xtile.insert
 TEST_F(WarpSpecializationTritonEmitterTest,
        DotAccumulationLoopUsesWarpSpecialization) {
   if (auto cc = GpuComputeCapability().cuda_compute_capability();
-      cc && cc->IsAtLeastBlackwell()) {
+      cc && !cc->IsAtLeastBlackwell()) {
     GTEST_SKIP() << "Currently only supported on Blackwell and newer.";
   }
 
@@ -2274,7 +2274,7 @@ ENTRY e {
 TEST_P(TritonScaledDotGemmTest, FP8ScaledDotGetsFusedAndExecutesCorrectly) {
   const ScaleDotTestParams& params = GetParam();
   if (auto cc = GpuComputeCapability().cuda_compute_capability();
-      cc && cc->IsAtLeastBlackwell()) {
+      cc && !cc->IsAtLeastBlackwell()) {
     GTEST_SKIP() << "Skipping test for pre-Blackwell GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(
@@ -2341,7 +2341,7 @@ class TritonScaledDotTest : public TritonEmitterTest {
 TEST_F(TritonScaledDotTest,
        ScaledDotWithOmmittedLhsScaleGetFusedAndExecutedCorrectly) {
   if (auto cc = GpuComputeCapability().cuda_compute_capability();
-      cc && cc->IsAtLeastHopper()) {
+      cc && !cc->IsAtLeastHopper()) {
     GTEST_SKIP() << "Scaled dot isn't supported by Triton for pre-Hopper GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(
@@ -2396,7 +2396,7 @@ ENTRY e {
 
 TEST_F(TritonScaledDotTest, ScaledDotWithBatchGetFusedAndExecutedCorrectly) {
   if (auto cc = GpuComputeCapability().cuda_compute_capability();
-      cc && cc->IsAtLeastHopper()) {
+      cc && !cc->IsAtLeastHopper()) {
     GTEST_SKIP() << "Scaled dot isn't supported by Triton for pre-Hopper GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(
@@ -2444,7 +2444,7 @@ ENTRY e {
 
 TEST_F(TritonScaledDotTest, BroadcastAndReshapeGetFused) {
   if (auto cc = GpuComputeCapability().cuda_compute_capability();
-      cc && cc->IsAtLeastHopper()) {
+      cc && !cc->IsAtLeastHopper()) {
     GTEST_SKIP() << "Scaled dot isn't supported by Triton for pre-Hopper GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(

--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -1570,7 +1570,8 @@ CHECK-COUNT-1: xtile.insert
 
 TEST_F(WarpSpecializationTritonEmitterTest,
        DotAccumulationLoopUsesWarpSpecialization) {
-  if (!GetCudaComputeCapability().IsAtLeastBlackwell()) {
+  if (auto cc = GpuComputeCapability().cuda_compute_capability();
+      cc && cc->IsAtLeastBlackwell()) {
     GTEST_SKIP() << "Currently only supported on Blackwell and newer.";
   }
 
@@ -2272,7 +2273,8 @@ ENTRY e {
 
 TEST_P(TritonScaledDotGemmTest, FP8ScaledDotGetsFusedAndExecutesCorrectly) {
   const ScaleDotTestParams& params = GetParam();
-  if (!GetCudaComputeCapability().IsAtLeastBlackwell()) {
+  if (auto cc = GpuComputeCapability().cuda_compute_capability();
+      cc && cc->IsAtLeastBlackwell()) {
     GTEST_SKIP() << "Skipping test for pre-Blackwell GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(
@@ -2338,7 +2340,8 @@ class TritonScaledDotTest : public TritonEmitterTest {
 
 TEST_F(TritonScaledDotTest,
        ScaledDotWithOmmittedLhsScaleGetFusedAndExecutedCorrectly) {
-  if (!GetCudaComputeCapability().IsAtLeastHopper()) {
+  if (auto cc = GpuComputeCapability().cuda_compute_capability();
+      cc && cc->IsAtLeastHopper()) {
     GTEST_SKIP() << "Scaled dot isn't supported by Triton for pre-Hopper GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(
@@ -2392,7 +2395,8 @@ ENTRY e {
 }
 
 TEST_F(TritonScaledDotTest, ScaledDotWithBatchGetFusedAndExecutedCorrectly) {
-  if (!GetCudaComputeCapability().IsAtLeastHopper()) {
+  if (auto cc = GpuComputeCapability().cuda_compute_capability();
+      cc && cc->IsAtLeastHopper()) {
     GTEST_SKIP() << "Scaled dot isn't supported by Triton for pre-Hopper GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(
@@ -2439,7 +2443,8 @@ ENTRY e {
 }
 
 TEST_F(TritonScaledDotTest, BroadcastAndReshapeGetFused) {
-  if (!GetCudaComputeCapability().IsAtLeastHopper()) {
+  if (auto cc = GpuComputeCapability().cuda_compute_capability();
+      cc && cc->IsAtLeastHopper()) {
     GTEST_SKIP() << "Scaled dot isn't supported by Triton for pre-Hopper GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(

--- a/xla/codegen/xtile/codegen/dot_algorithms.cc
+++ b/xla/codegen/xtile/codegen/dot_algorithms.cc
@@ -109,8 +109,7 @@ Value DequantizeOperand(mlir::ImplicitLocOpBuilder& b, Value operand,
   if (scale_elem_type != elem_type) {
     auto converted_type =
         mlir::RankedTensorType::get(scale_type.getShape(), elem_type);
-    typed_scale =
-        mlir::stablehlo::ConvertOp::create(b, converted_type, scale);
+    typed_scale = mlir::stablehlo::ConvertOp::create(b, converted_type, scale);
   }
 
   int64_t rank = operand_type.getRank();
@@ -124,8 +123,8 @@ Value DequantizeOperand(mlir::ImplicitLocOpBuilder& b, Value operand,
     int64_t op_dim = operand_type.getShape()[i];
     int64_t sc_dim = scale_type.getShape()[i];
     CHECK_EQ(op_dim % sc_dim, 0)
-        << "operand dim " << op_dim << " not divisible by scale dim "
-        << sc_dim << " at index " << i;
+        << "operand dim " << op_dim << " not divisible by scale dim " << sc_dim
+        << " at index " << i;
     expanded_shape.push_back(sc_dim);
     broadcast_dims.push_back(result_idx);
     if (op_dim != sc_dim) {
@@ -135,8 +134,7 @@ Value DequantizeOperand(mlir::ImplicitLocOpBuilder& b, Value operand,
   }
   auto expanded_type = mlir::RankedTensorType::get(expanded_shape, elem_type);
   Value expanded = mlir::stablehlo::BroadcastInDimOp::create(
-      b, expanded_type, typed_scale,
-      b.getDenseI64ArrayAttr(broadcast_dims));
+      b, expanded_type, typed_scale, b.getDenseI64ArrayAttr(broadcast_dims));
 
   auto reshape_type =
       mlir::RankedTensorType::get(operand_type.getShape(), elem_type);
@@ -157,9 +155,10 @@ absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
     Value lhs = DequantizeOperand(b, operands.lhs, operands.lhs_scale);
     Value rhs = DequantizeOperand(b, operands.rhs, operands.rhs_scale);
     const PrecisionConfig& pc = scaled_dot.precision_config();
-    PrecisionSpec prec{pc.algorithm(),
-                       XlaPrecisionToStableHloPrecision(pc.operand_precision(0)),
-                       XlaPrecisionToStableHloPrecision(pc.operand_precision(1))};
+    PrecisionSpec prec{
+        pc.algorithm(),
+        XlaPrecisionToStableHloPrecision(pc.operand_precision(0)),
+        XlaPrecisionToStableHloPrecision(pc.operand_precision(1))};
     return EmitStableHloDotAndAdd(b, lhs, rhs, operands.accumulator, prec,
                                   operands.dot_dimension_numbers);
   }

--- a/xla/codegen/xtile/codegen/dot_algorithms.cc
+++ b/xla/codegen/xtile/codegen/dot_algorithms.cc
@@ -75,52 +75,6 @@ mlir::stablehlo::Precision XlaPrecisionToStableHloPrecision(
 
 namespace {
 
-absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
-                                ScaledDotOperands& operands) {
-  mlir::Type lhs_dot_elem_type = getElementTypeOrSelf(operands.lhs.getType());
-  mlir::Type rhs_dot_elem_type = getElementTypeOrSelf(operands.rhs.getType());
-
-  Value lhs_scale;
-  if (lhs_dot_elem_type != b.getBF16Type()) {
-    lhs_scale = Bitcast(b, operands.lhs_scale, b.getI8Type());
-  }
-  Value rhs_scale;
-  if (rhs_dot_elem_type != b.getBF16Type()) {
-    rhs_scale = Bitcast(b, operands.rhs_scale, b.getI8Type());
-    auto rhs_scale_type = mlir::cast<mlir::ShapedType>(rhs_scale.getType());
-    int64_t rank = rhs_scale_type.getRank();
-    CHECK_GE(rank, 2) << "RHS scale must be at least rank 2 for scaled dot.";
-
-    std::vector<int64_t> permutation(rank);
-    for (int64_t i = 0; i < rank; ++i) {
-      permutation[i] = i;
-    }
-    std::swap(permutation[rank - 2], permutation[rank - 1]);
-    rhs_scale = mlir::stablehlo::TransposeOp::create(
-        b, rhs_scale, b.getDenseI64ArrayAttr(permutation));
-  }
-
-  // When operand type is subbyte size then it is packed along minor dim and for
-  // RHS minor dim is not K.
-  const auto& lhs_shaped_type =
-      mlir::dyn_cast<ShapedType>(operands.lhs.getType());
-  const bool rhs_k_pack = lhs_shaped_type.getElementType() !=
-                          mlir::Float4E2M1FNType::get(b.getContext());
-  auto dot_scaled_op = xtile::DotScaledOp::create(
-      b, operands.accumulator.getType(), operands.lhs, operands.rhs, lhs_scale,
-      rhs_scale, /*fastMath=*/true, /*lhs_k_pack=*/true, rhs_k_pack,
-      operands.dot_dimension_numbers);
-
-  auto add_result =
-      mlir::isa<mlir::IntegerType>(
-          dot_scaled_op.getResult().getType().getElementType())
-          ? mlir::arith::AddIOp::create(b, operands.accumulator, dot_scaled_op)
-          : mlir::arith::AddFOp::create(b, operands.accumulator, dot_scaled_op);
-  return add_result->getResult(0);
-}
-
-namespace {
-
 Value EmitStableHloDotAndAdd(mlir::ImplicitLocOpBuilder& b, Value lhs,
                              Value rhs, Value acc, PrecisionSpec precision_spec,
                              mlir::stablehlo::DotDimensionNumbersAttr dims) {
@@ -141,6 +95,107 @@ Value EmitStableHloDotAndAdd(mlir::ImplicitLocOpBuilder& b, Value lhs,
 }
 
 }  // namespace
+
+namespace {
+
+Value DequantizeOperand(mlir::ImplicitLocOpBuilder& b, Value operand,
+                        Value scale) {
+  auto operand_type = mlir::cast<mlir::RankedTensorType>(operand.getType());
+  auto scale_type = mlir::cast<mlir::RankedTensorType>(scale.getType());
+  mlir::Type elem_type = operand_type.getElementType();
+  mlir::Type scale_elem_type = scale_type.getElementType();
+
+  Value typed_scale = scale;
+  if (scale_elem_type != elem_type) {
+    auto converted_type =
+        mlir::RankedTensorType::get(scale_type.getShape(), elem_type);
+    typed_scale =
+        mlir::stablehlo::ConvertOp::create(b, converted_type, scale);
+  }
+
+  int64_t rank = operand_type.getRank();
+  CHECK_EQ(rank, scale_type.getRank())
+      << "operand and scale must have the same rank";
+  llvm::SmallVector<int64_t> expanded_shape;
+  llvm::SmallVector<int64_t> broadcast_dims;
+  expanded_shape.reserve(2 * rank);
+  broadcast_dims.reserve(rank);
+  for (int64_t result_idx = 0, i = 0; i < rank; ++i, ++result_idx) {
+    int64_t op_dim = operand_type.getShape()[i];
+    int64_t sc_dim = scale_type.getShape()[i];
+    CHECK_EQ(op_dim % sc_dim, 0)
+        << "operand dim " << op_dim << " not divisible by scale dim "
+        << sc_dim << " at index " << i;
+    expanded_shape.push_back(sc_dim);
+    broadcast_dims.push_back(result_idx);
+    if (op_dim != sc_dim) {
+      result_idx++;
+      expanded_shape.push_back(op_dim / sc_dim);
+    }
+  }
+  auto expanded_type = mlir::RankedTensorType::get(expanded_shape, elem_type);
+  Value expanded = mlir::stablehlo::BroadcastInDimOp::create(
+      b, expanded_type, typed_scale,
+      b.getDenseI64ArrayAttr(broadcast_dims));
+
+  auto reshape_type =
+      mlir::RankedTensorType::get(operand_type.getShape(), elem_type);
+  Value reshaped =
+      mlir::stablehlo::ReshapeOp::create(b, reshape_type, expanded);
+
+  return mlir::stablehlo::MulOp::create(b, operand, reshaped);
+}
+
+absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
+                                const HloScaledDotInstruction& scaled_dot,
+                                ScaledDotOperands& operands) {
+  mlir::Type lhs_dot_elem_type = getElementTypeOrSelf(operands.lhs.getType());
+  mlir::Type rhs_dot_elem_type = getElementTypeOrSelf(operands.rhs.getType());
+
+  if (lhs_dot_elem_type == b.getBF16Type() ||
+      rhs_dot_elem_type == b.getBF16Type()) {
+    Value lhs = DequantizeOperand(b, operands.lhs, operands.lhs_scale);
+    Value rhs = DequantizeOperand(b, operands.rhs, operands.rhs_scale);
+    const PrecisionConfig& pc = scaled_dot.precision_config();
+    PrecisionSpec prec{pc.algorithm(),
+                       XlaPrecisionToStableHloPrecision(pc.operand_precision(0)),
+                       XlaPrecisionToStableHloPrecision(pc.operand_precision(1))};
+    return EmitStableHloDotAndAdd(b, lhs, rhs, operands.accumulator, prec,
+                                  operands.dot_dimension_numbers);
+  }
+
+  Value lhs_scale = Bitcast(b, operands.lhs_scale, b.getI8Type());
+  Value rhs_scale = Bitcast(b, operands.rhs_scale, b.getI8Type());
+  auto rhs_scale_type = mlir::cast<mlir::ShapedType>(rhs_scale.getType());
+  int64_t rank = rhs_scale_type.getRank();
+  CHECK_GE(rank, 2) << "RHS scale must be at least rank 2 for scaled dot.";
+
+  std::vector<int64_t> permutation(rank);
+  for (int64_t i = 0; i < rank; ++i) {
+    permutation[i] = i;
+  }
+  std::swap(permutation[rank - 2], permutation[rank - 1]);
+  rhs_scale = mlir::stablehlo::TransposeOp::create(
+      b, rhs_scale, b.getDenseI64ArrayAttr(permutation));
+
+  // When operand type is subbyte size then it is packed along minor dim and for
+  // RHS minor dim is not K.
+  const auto& lhs_shaped_type =
+      mlir::dyn_cast<ShapedType>(operands.lhs.getType());
+  const bool rhs_k_pack = lhs_shaped_type.getElementType() !=
+                          mlir::Float4E2M1FNType::get(b.getContext());
+  auto dot_scaled_op = xtile::DotScaledOp::create(
+      b, operands.accumulator.getType(), operands.lhs, operands.rhs, lhs_scale,
+      rhs_scale, /*fastMath=*/true, /*lhs_k_pack=*/true, rhs_k_pack,
+      operands.dot_dimension_numbers);
+
+  auto add_result =
+      mlir::isa<mlir::IntegerType>(
+          dot_scaled_op.getResult().getType().getElementType())
+          ? mlir::arith::AddIOp::create(b, operands.accumulator, dot_scaled_op)
+          : mlir::arith::AddFOp::create(b, operands.accumulator, dot_scaled_op);
+  return add_result->getResult(0);
+}
 
 absl::StatusOr<Type> GetAlgUnsetAccumulatorType(mlir::ImplicitLocOpBuilder& b,
                                                 const HloDotInstruction& dot) {
@@ -318,7 +373,7 @@ absl::StatusOr<Value> EmitSingleTileScaledDot(
   dot_operands.dot_dimension_numbers =
       ::xla::stablehlo::ConvertDotDimensionNumbers(
           scaled_dot.dot_dimension_numbers(), &b);
-  return ScaledDot(b, dot_operands);
+  return ScaledDot(b, scaled_dot, dot_operands);
 }
 
 }  // namespace xtile

--- a/xla/codegen/xtile/codegen/dot_algorithms.cc
+++ b/xla/codegen/xtile/codegen/dot_algorithms.cc
@@ -150,7 +150,7 @@ absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
   mlir::Type lhs_dot_elem_type = getElementTypeOrSelf(operands.lhs.getType());
   mlir::Type rhs_dot_elem_type = getElementTypeOrSelf(operands.rhs.getType());
 
-  if (lhs_dot_elem_type == b.getBF16Type() ||
+  if (lhs_dot_elem_type == b.getBF16Type() &&
       rhs_dot_elem_type == b.getBF16Type()) {
     Value lhs = DequantizeOperand(b, operands.lhs, operands.lhs_scale);
     Value rhs = DequantizeOperand(b, operands.rhs, operands.rhs_scale);
@@ -162,21 +162,27 @@ absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
     return EmitStableHloDotAndAdd(b, lhs, rhs, operands.accumulator, prec,
                                   operands.dot_dimension_numbers);
   }
-
-  Value lhs_scale = Bitcast(b, operands.lhs_scale, b.getI8Type());
-  Value rhs_scale = Bitcast(b, operands.rhs_scale, b.getI8Type());
-  auto rhs_scale_type = mlir::cast<mlir::ShapedType>(rhs_scale.getType());
-  int64_t rank = rhs_scale_type.getRank();
-  CHECK_GE(rank, 2) << "RHS scale must be at least rank 2 for scaled dot.";
-
-  std::vector<int64_t> permutation(rank);
-  for (int64_t i = 0; i < rank; ++i) {
-    permutation[i] = i;
+  
+  Value lhs_scale;
+  if (lhs_dot_elem_type != b.getBF16Type()) {
+    lhs_scale = Bitcast(b, operands.lhs_scale, b.getI8Type());
   }
-  std::swap(permutation[rank - 2], permutation[rank - 1]);
-  rhs_scale = mlir::stablehlo::TransposeOp::create(
+  Value rhs_scale;
+  if (rhs_dot_elem_type != b.getBF16Type()) {
+    rhs_scale = Bitcast(b, operands.rhs_scale, b.getI8Type());
+    auto rhs_scale_type = mlir::cast<mlir::ShapedType>(rhs_scale.getType());
+    int64_t rank = rhs_scale_type.getRank();
+    CHECK_GE(rank, 2) << "RHS scale must be at least rank 2 for scaled dot.";
+    
+    std::vector<int64_t> permutation(rank);
+    for (int64_t i = 0; i < rank; ++i) {
+      permutation[i] = i;
+    }
+    std::swap(permutation[rank - 2], permutation[rank - 1]);
+    rhs_scale = mlir::stablehlo::TransposeOp::create(
       b, rhs_scale, b.getDenseI64ArrayAttr(permutation));
-
+      
+  }
   // When operand type is subbyte size then it is packed along minor dim and for
   // RHS minor dim is not K.
   const auto& lhs_shaped_type =

--- a/xla/codegen/xtile/codegen/dot_algorithms.cc
+++ b/xla/codegen/xtile/codegen/dot_algorithms.cc
@@ -102,6 +102,9 @@ Value DequantizeOperand(mlir::ImplicitLocOpBuilder& b, Value operand,
                         Value scale) {
   auto operand_type = mlir::cast<mlir::RankedTensorType>(operand.getType());
   auto scale_type = mlir::cast<mlir::RankedTensorType>(scale.getType());
+  if (scale_type.getRank() == 0) {
+    return operand;
+  }
   mlir::Type elem_type = operand_type.getElementType();
   mlir::Type scale_elem_type = scale_type.getElementType();
 
@@ -162,7 +165,7 @@ absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
     return EmitStableHloDotAndAdd(b, lhs, rhs, operands.accumulator, prec,
                                   operands.dot_dimension_numbers);
   }
-  
+
   Value lhs_scale;
   if (lhs_dot_elem_type != b.getBF16Type()) {
     lhs_scale = Bitcast(b, operands.lhs_scale, b.getI8Type());

--- a/xla/codegen/xtile/codegen/dot_algorithms.cc
+++ b/xla/codegen/xtile/codegen/dot_algorithms.cc
@@ -176,15 +176,14 @@ absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
     auto rhs_scale_type = mlir::cast<mlir::ShapedType>(rhs_scale.getType());
     int64_t rank = rhs_scale_type.getRank();
     CHECK_GE(rank, 2) << "RHS scale must be at least rank 2 for scaled dot.";
-    
+
     std::vector<int64_t> permutation(rank);
     for (int64_t i = 0; i < rank; ++i) {
       permutation[i] = i;
     }
     std::swap(permutation[rank - 2], permutation[rank - 1]);
     rhs_scale = mlir::stablehlo::TransposeOp::create(
-      b, rhs_scale, b.getDenseI64ArrayAttr(permutation));
-      
+        b, rhs_scale, b.getDenseI64ArrayAttr(permutation));
   }
   // When operand type is subbyte size then it is packed along minor dim and for
   // RHS minor dim is not K.

--- a/xla/service/gpu/autotuning/autotuner_pass.cc
+++ b/xla/service/gpu/autotuning/autotuner_pass.cc
@@ -331,6 +331,7 @@ AutotunerPass::GetGpuAutotunerBackends(
     disabled_autotune_backends.push_back(autotuner::Backend::HIPBLASLT);
     disabled_autotune_backends.push_back(autotuner::Backend::MIOPEN);
     disabled_autotune_backends.push_back(autotuner::Backend::HIPBLASLT_FISSION);
+    disabled_autotune_backends.push_back(autotuner::Backend::CUBLASLT_FISSION);
   }
 
   if (!debug_options.xla_gpu_experimental_autotune_post_fusion() ||


### PR DESCRIPTION
## Motivation

This PR fixes `TritonEmitterTest.ScaledDotIsSupportedByReferencePlatform` subtest from `//xla/backends/gpu/codegen/triton/tests:fusion_emitter_device_test`.

Test started falling on ROCm after https://github.com/openxla/xla/commit/80931bbe05b8e6e9dbb6dc8fbd8416f4131db0bd enforced Triton backend via:
```
debug_options.set_xla_gpu_experimental_disable_binary_libraries(true);
```

Until this point, the subtest was using hipblaslt instead of Triton.  The only reason it was still passing on CUDA side was that `CUBLASLT_FISSION` was not added to the list of disabled backends. After changing that subtest consistently failed with mismatch errors on both platforms.

Failing log:
```
Mismatch count 256 (100.0000%) in shape bf16[16,16] (256 elements), abs bound 0.001, rel bound 0.001
Top relative error mismatches:
  actual       0.2617, expected   -6.407e-07, index {7,10}, rel error 4.08e+05, abs error    0.262
  actual       0.3223, expected   -2.205e-06, index {10,8}, rel error 1.46e+05, abs error    0.322
  actual       0.4082, expected    6.407e-06, index {2,11}, rel error 6.37e+04, abs error    0.408
  actual       0.2139, expected   -4.262e-06, index {8,12}, rel error 5.02e+04, abs error    0.214
  actual       0.3574, expected   -7.749e-06, index {8,6}, rel error 4.61e+04, abs error    0.357
Absolute magnitude breakdown of actual values:
  0      <= x < 0.0001 :       0 (  0.0000%)
  0.0001 <= x < 0.001  :       0 (  0.0000%)
  0.001  <= x < 0.01   :       0 (  0.0000%)
  0.01   <= x < 0.1    :       8 (  3.1250%), mismatches 8
  0.1    <= x < 1      :     248 ( 96.8750%), mismatches 248
  1      <= x < inf    :       0 (  0.0000%)
Elements exceeding abs error bound 0.001: 256 (100.0000%)
Relative error breakdown of elements exceeding abs error bound:
  <  0.0001 :       0 (0.0000%)
  >= 0.0001 :     256 (100.0000%)
  >= 0.001  :     256 (100.0000%)
  >= 0.01   :     256 (100.0000%)
  >= 0.1    :     256 (100.0000%)
  >= 1      :     256 (100.0000%)
Elements exceeding rel error bound 0.001: 256 (100.0000%)
Absolute error breakdown of elements exceeding rel error bound:
  <  0.0001 :       0 (0.0000%)
  >= 0.0001 :     256 (100.0000%)
  >= 0.001  :     256 (100.0000%)
  >= 0.01   :     256 (100.0000%)
  >= 0.1    :     248 (96.8750%)
  >= 1      :       0 (0.0000%)
```

## Technical Details

XLA does not set scales for BF16 type https://github.com/openxla/xla/blob/111f921748b0643e70693b6b2a53a0d76b2af37a/xla/codegen/xtile/codegen/dot_algorithms.cc#L78-L120:
```
  Value lhs_scale;
  if (lhs_dot_elem_type != b.getBF16Type()) {
    lhs_scale = Bitcast(b, operands.lhs_scale, b.getI8Type());
  }
  Value rhs_scale;
  if (rhs_dot_elem_type != b.getBF16Type()) {
  ...
```

and it also skips ScaledDotRewriter for Triton https://github.com/openxla/xla/blob/111f921748b0643e70693b6b2a53a0d76b2af37a/xla/service/gpu/gpu_compiler.cc#L704-L706:
```
if (!debug_options.xla_gpu_experimental_scaled_dot_with_triton()) {
    pipeline.AddPass<ScaledDotRewriter>();
  }
```

So it emits a `dot_scaled` with no scales, which explains the accuracy issues. This PR modifies `ScaledDot` function so that for bf16 it converts scale to operand type, broadcasts + reshapes it to operand shape, multiplies, then emits a plain `stablehlo.dot_general` via `EmitStableHloDotAndAdd`. This follows the logic from `ScaledDotRewriter::RewriteComputation` (https://github.com/openxla/xla/blob/9e1e4f3a8d7db8c626cd4079058353ce87d4f941/xla/backends/gpu/transforms/scaled_dot_rewriter.cc#L166-L192)


## Test Result

Problematic test now passes. After inspecting Triton dumps confirmed that instead of `tt.dot_scaled`, it now emits `tt.dot`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
