### PR TITLE
[ROCm] Fix null error_handler dereference in CompileTritonToLLVM

### DIFF
--- a/xla/backends/gpu/codegen/triton/xtile_compiler.cc
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.cc
@@ -487,7 +487,9 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
   VLOG(2) << "Global scratch memory usage: " << global_scratch_memory_size
           << " B";
   if (shared_mem_bytes > device_info.shared_memory_per_block_optin()) {
-    error_handler();
+    if (error_handler) {
+      error_handler();
+    }
     return absl::ResourceExhaustedError(absl::StrFormat(
         "Shared memory size limit exceeded: requested %d, available: %d",
         shared_mem_bytes, device_info.shared_memory_per_block_optin()));


### PR DESCRIPTION
## Summary

- `CompileTritonToLLVM` calls `error_handler()` unconditionally at the shared memory limit check (line 490), unlike the two other call sites (lines 467, 473) which guard with `if (error_handler)`.
- When called from the Pallas path (`thunk_emitter.cc:1314`), `error_handler` defaults to `nullptr`, causing a segfault whenever a kernel exceeds the per-block LDS limit.
- Fix: add the same `if (error_handler)` guard at line 490.

## Reproducer

`tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd8` on MI300X — the `mha_backward` kernel requests 81920 bytes of shared memory, exceeding the 65536 byte hardware limit. Before this fix: segfault in `backend_compile_and_load`. After: clean `RESOURCE_EXHAUSTED` error propagated to Python.

## Test plan

- [ ] Reproduce crash: `python -m pytest tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd8 -v` on MI300X without fix → segfault
- [ ] Verify fix: same test with patched wheels → `JaxRuntimeError: RESOURCE_EXHAUSTED: Shared memory size limit exceeded: requested 81920, available: 65536`