### PR TITLE
Scaled dot fixes: triton backend and 4D tensor handling

### DIFF
--- a/xla/backends/gpu/autotuner/hipblaslt.cc
+++ b/xla/backends/gpu/autotuner/hipblaslt.cc
@@ -118,15 +118,6 @@ bool IsValidMxScaledDot(const HloInstruction* scaled_dot) {
     return false;
   }
 
-  int64_t batch_size = 1;
-  for (int64_t dim : dot_dims.lhs_batch_dimensions()) {
-    batch_size *= lhs_shape.dimensions(dim);
-  }
-  if (batch_size != 1) {
-    VLOG(2) << "hipBLASLt MX: batch_size > 1 not supported, got " << batch_size;
-    return false;
-  }
-
   int64_t m = 1;
   for (int64_t i = 0; i < lhs_shape.dimensions_size(); ++i) {
     if (!absl::c_linear_search(dot_dims.lhs_batch_dimensions(), i) &&
@@ -261,6 +252,7 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
     TF_RET_CHECK(scaled_dot != nullptr);
 
     if (!IsValidMxScaledDot(scaled_dot)) {
+      LOG(WARNING) << "hipBLASLt MX: IsValidMxScaledDot failed";
       return std::vector<std::unique_ptr<BackendConfig>>();
     }
 
@@ -280,8 +272,8 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
         /*grad_y=*/false, /*scale_mode=*/se::gpu::ScaleMode::kBlockScaling,
         target_config().device_description.gpu_compute_capability());
     if (!gemm_config_or.ok()) {
-      VLOG(2) << "hipBLASLt MX: GemmConfig::For failed: "
-              << gemm_config_or.status();
+      LOG(WARNING) << "hipBLASLt MX: GemmConfig::For failed: "
+                   << gemm_config_or.status();
       return std::vector<std::unique_ptr<BackendConfig>>();
     }
 
@@ -290,7 +282,8 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
     auto plan_or = se::gpu::BlasLt::GetMatmulPlan(stream.get(), *gemm_config_or,
                                                   BlasLt::Epilogue::kDefault);
     if (!plan_or.ok()) {
-      VLOG(2) << "hipBLASLt MX: GetMatmulPlan failed: " << plan_or.status();
+      LOG(WARNING) << "hipBLASLt MX: GetMatmulPlan failed: "
+                   << plan_or.status();
       return std::vector<std::unique_ptr<BackendConfig>>();
     }
 
@@ -300,7 +293,7 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
         (*plan_or)->GetAlgorithms(stream.get(), GemmConfig::kNumAlgorithms,
                                   workspace_size));
     if (algorithms.empty()) {
-      VLOG(2) << "hipBLASLt MX: no algorithms found for scaled dot.";
+      LOG(WARNING) << "hipBLASLt MX: no algorithms found for scaled dot.";
       return std::vector<std::unique_ptr<BackendConfig>>();
     }
 
@@ -367,18 +360,46 @@ absl::Status HipblasLtBackend::ApplyConfig(HloInstruction& instr,
       }
     }
     return absl::OkStatus();
-  } else if (IsScaledDotFusion(instr)) {
+  }
+
+  if (IsScaledDotFusion(instr)) {
     const HloInstruction* scaled_dot = hlo_query::GetFirstInstructionWithOpcode(
         *instr.fused_instructions_computation(), HloOpcode::kScaledDot);
     TF_RET_CHECK(scaled_dot != nullptr);
     HloComputation* parent = instr.parent();
 
     TF_RET_CHECK(instr.operand_count() == 4);
-    HloInstruction* lhs = instr.mutable_operand(0);
-    HloInstruction* rhs = instr.mutable_operand(1);
-    HloInstruction* lhs_scale = instr.mutable_operand(2);
-    HloInstruction* rhs_scale = instr.mutable_operand(3);
 
+    // The fusion's external operands may have a different rank than the
+    // scaled-dot operands: when quantization happens in-graph the operand is in
+    // block-scaled [..., K/block, block] form and is only flattened to
+    // [..., K] by a bitcast/reshape inside the fusion.
+    auto external_operand_like =
+        [&](int64_t k) -> absl::StatusOr<HloInstruction*> {
+      // return instr.mutable_operand(k);
+      const HloInstruction* inner = scaled_dot->operand(k);
+      const HloInstruction* cur = inner;
+      // Walk back to the parameter that feeds this particular scaled-dot
+      // operand.
+      while (cur->opcode() != HloOpcode::kParameter) {
+        TF_RET_CHECK(cur->opcode() == HloOpcode::kBitcast ||
+                     cur->opcode() == HloOpcode::kReshape)
+            << "Unexpected op feeding scaled-dot operand: " << cur->ToString();
+        cur = cur->operand(0);
+      }
+      HloInstruction* ext = instr.mutable_operand(cur->parameter_number());
+      if (ShapeUtil::Equal(ext->shape(), inner->shape())) {
+        return ext;
+      }
+      return parent->AddInstruction(
+          HloInstruction::CreateBitcast(inner->shape(), ext));
+    };
+
+    absl::InlinedVector<HloInstruction*, 4> operands;
+    for (int64_t k = 0; k < 4; ++k) {
+      TF_ASSIGN_OR_RETURN(HloInstruction * operand, external_operand_like(k));
+      operands.push_back(operand);
+    }
     const Shape& result_shape = scaled_dot->shape();
     int64_t workspace_size = gemm_key.autotune_workspace_size();
     Shape workspace_shape = ShapeUtil::MakeShape(S8, {workspace_size});
@@ -400,8 +421,7 @@ absl::Status HipblasLtBackend::ApplyConfig(HloInstruction& instr,
 
     HloInstruction* custom_call =
         parent->AddInstruction(HloInstruction::CreateCustomCall(
-            output_shape, {lhs, rhs, lhs_scale, rhs_scale},
-            kCublasLtMatmulMxCallTarget));
+            output_shape, operands, kCublasLtMatmulMxCallTarget));
     TF_RETURN_IF_ERROR(custom_call->set_backend_config(gpu_backend_config));
     HloInstruction* gte = parent->AddInstruction(
         HloInstruction::CreateGetTupleElement(result_shape, custom_call, 0));

--- a/xla/backends/gpu/autotuner/hipblaslt.cc
+++ b/xla/backends/gpu/autotuner/hipblaslt.cc
@@ -178,16 +178,17 @@ bool IsValidMxScaledDot(const HloInstruction* scaled_dot) {
   return true;
 }
 
-bool IsScaledDotFusion(const HloInstruction& instr) {
-  if (instr.opcode() != HloOpcode::kFusion) return false;
+// Returns the scaled-dot instruction inside a Triton GEMM fusion, or nullptr
+// if `instr` is not such a fusion.
+const HloInstruction* GetScaledDotFromFusion(const HloInstruction& instr) {
+  if (instr.opcode() != HloOpcode::kFusion) return nullptr;
   auto gpu_config = instr.backend_config<GpuBackendConfig>();
-  if (!gpu_config.ok()) return false;
+  if (!gpu_config.ok()) return nullptr;
   if (gpu_config->fusion_backend_config().kind() != kTritonGemmFusionKind) {
-    return false;
+    return nullptr;
   }
   return hlo_query::GetFirstInstructionWithOpcode(
-             *instr.fused_instructions_computation(), HloOpcode::kScaledDot) !=
-         nullptr;
+      *instr.fused_instructions_computation(), HloOpcode::kScaledDot);
 }
 
 }  // namespace
@@ -196,7 +197,7 @@ bool HipblasLtBackend::IsSupported(const HloInstruction& instr) {
   if (IsCublasLtMatmul(instr) || IsCublasLtMatmulF8(instr)) {
     return true;
   }
-  if (IsScaledDotFusion(instr)) {
+  if (GetScaledDotFromFusion(instr) != nullptr) {
     const auto& gpu_cc =
         target_config().device_description.gpu_compute_capability();
     const auto* rocm_cc = gpu_cc.rocm_compute_capability();
@@ -255,11 +256,9 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
       configs.push_back(std::move(any));
     }
     return configs;
-  } else if (IsScaledDotFusion(instr)) {
-    const HloInstruction* scaled_dot = hlo_query::GetFirstInstructionWithOpcode(
-        *instr.fused_instructions_computation(), HloOpcode::kScaledDot);
-    TF_RET_CHECK(scaled_dot != nullptr);
+  }
 
+  if (const auto* scaled_dot = GetScaledDotFromFusion(instr)) {
     if (!IsValidMxScaledDot(scaled_dot)) {
       LOG(WARNING) << "hipBLASLt MX: IsValidMxScaledDot failed";
       return std::vector<std::unique_ptr<BackendConfig>>();
@@ -371,42 +370,53 @@ absl::Status HipblasLtBackend::ApplyConfig(HloInstruction& instr,
     return absl::OkStatus();
   }
 
-  if (IsScaledDotFusion(instr)) {
-    const HloInstruction* scaled_dot = hlo_query::GetFirstInstructionWithOpcode(
-        *instr.fused_instructions_computation(), HloOpcode::kScaledDot);
-    TF_RET_CHECK(scaled_dot != nullptr);
+  if (const auto* scaled_dot = GetScaledDotFromFusion(instr)) {
+    HloComputation* fused = instr.fused_instructions_computation();
     HloComputation* parent = instr.parent();
 
     TF_RET_CHECK(instr.operand_count() == 4);
+    // The scaled-dot must be the root of the fusion, otherwise we would drop
+    // any instructions that consume the scaled-dot result.
+    TF_RET_CHECK(scaled_dot == fused->root_instruction())
+        << "Scaled-dot is not the root of the fusion; lowering to hipBLASLt "
+           "matmul would drop instructions: "
+        << fused->root_instruction()->ToString();
 
-    // The fusion's external operands may have a different rank than the
+    // Walk forward from each fusion parameter to the scaled-dot operand it
+    // feeds. The fusion's external operands may have a different rank than the
     // scaled-dot operands: when quantization happens in-graph the operand is in
-    // block-scaled [..., K/block, block] form and is only flattened to
-    // [..., K] by a bitcast/reshape inside the fusion.
-    auto external_operand_like =
-        [&](int64_t k) -> absl::StatusOr<HloInstruction*> {
-      const HloInstruction* inner = scaled_dot->operand(k);
-      const HloInstruction* cur = inner;
-      // Walk back to the parameter that feeds this particular scaled-dot
-      // operand.
-      while (cur->opcode() != HloOpcode::kParameter) {
-        TF_RET_CHECK(cur->opcode() == HloOpcode::kBitcast ||
-                     cur->opcode() == HloOpcode::kReshape)
-            << "Unexpected op feeding scaled-dot operand: " << cur->ToString();
-        cur = cur->operand(0);
+    // block-scaled [..., K/block, block] form and is only flattened to [..., K]
+    // by a bitcast/reshape inside the fusion. Only such trivial rank-changing
+    // ops are allowed on the path.
+    absl::InlinedVector<HloInstruction*, 4> operands(4, nullptr);
+    for (HloInstruction* param : fused->parameter_instructions()) {
+      const HloInstruction* cur = param;
+      while (cur->user_count() == 1 && cur->users()[0] != scaled_dot) {
+        HloInstruction* user = cur->users()[0];
+        TF_RET_CHECK(user->opcode() == HloOpcode::kBitcast ||
+                     user->opcode() == HloOpcode::kReshape)
+            << "Unexpected op between fusion parameter and scaled-dot: "
+            << user->ToString();
+        cur = user;
       }
-      HloInstruction* ext = instr.mutable_operand(cur->parameter_number());
-      if (ShapeUtil::Equal(ext->shape(), inner->shape())) {
-        return ext;
-      }
-      return parent->AddInstruction(
-          HloInstruction::CreateBitcast(inner->shape(), ext));
-    };
+      TF_RET_CHECK(cur->user_count() == 1 && cur->users()[0] == scaled_dot)
+          << "Fusion parameter " << param->parameter_number()
+          << " does not feed directly into the scaled-dot.";
 
-    absl::InlinedVector<HloInstruction*, 4> operands;
-    for (int64_t k = 0; k < 4; ++k) {
-      TF_ASSIGN_OR_RETURN(HloInstruction * operand, external_operand_like(k));
-      operands.push_back(operand);
+      int64_t dot_index = scaled_dot->operand_index(cur);
+      const Shape& inner_shape = scaled_dot->operand(dot_index)->shape();
+      HloInstruction* ext = instr.mutable_operand(param->parameter_number());
+      if (!ShapeUtil::Equal(ext->shape(), inner_shape)) {
+        ext = parent->AddInstruction(
+            HloInstruction::CreateBitcast(inner_shape, ext));
+      }
+      TF_RET_CHECK(operands[dot_index] == nullptr)
+          << "Multiple fusion parameters feed scaled-dot operand " << dot_index;
+      operands[dot_index] = ext;
+    }  // for
+    for (HloInstruction* op : operands) {
+      TF_RET_CHECK(op != nullptr)
+          << "Not all scaled-dot operands are fed by a fusion parameter.";
     }
     const Shape& result_shape = scaled_dot->shape();
     int64_t workspace_size = gemm_key.autotune_workspace_size();

--- a/xla/backends/gpu/autotuner/hipblaslt.cc
+++ b/xla/backends/gpu/autotuner/hipblaslt.cc
@@ -118,6 +118,15 @@ bool IsValidMxScaledDot(const HloInstruction* scaled_dot) {
     return false;
   }
 
+  int64_t batch_size = 1;
+  for (int64_t dim : dot_dims.lhs_batch_dimensions()) {
+    batch_size *= lhs_shape.dimensions(dim);
+  }
+  if (batch_size != 1) {
+    VLOG(2) << "hipBLASLt MX: batch_size > 1 not supported, got " << batch_size;
+    return false;
+  }
+
   int64_t m = 1;
   for (int64_t i = 0; i < lhs_shape.dimensions_size(); ++i) {
     if (!absl::c_linear_search(dot_dims.lhs_batch_dimensions(), i) &&
@@ -376,7 +385,6 @@ absl::Status HipblasLtBackend::ApplyConfig(HloInstruction& instr,
     // [..., K] by a bitcast/reshape inside the fusion.
     auto external_operand_like =
         [&](int64_t k) -> absl::StatusOr<HloInstruction*> {
-      // return instr.mutable_operand(k);
       const HloInstruction* inner = scaled_dot->operand(k);
       const HloInstruction* cur = inner;
       // Walk back to the parameter that feeds this particular scaled-dot

--- a/xla/backends/gpu/autotuner/hipblaslt_mx_execution_test.cc
+++ b/xla/backends/gpu/autotuner/hipblaslt_mx_execution_test.cc
@@ -44,21 +44,20 @@ class HipblasLtMxExecutionTest : public HloPjRtGpuTestBase {
                             const ErrorSpec& error_spec) {
     TF_ASSERT_OK_AND_ASSIGN(auto reference_module,
                             ParseAndReturnUnverifiedModule(hlo_string));
-    reference_module->mutable_config()
-        .mutable_debug_options()
-        .set_xla_gpu_experimental_scaled_dot_with_triton(false);
-    reference_module->mutable_config()
-        .mutable_debug_options()
-        .set_xla_gpu_enable_triton_gemm(false);
+    auto& ref_opts = reference_module->mutable_config().mutable_debug_options();
+    ref_opts.set_xla_gpu_experimental_scaled_dot_with_triton(false);
+    ref_opts.set_xla_gpu_enable_triton_gemm(false);
 
     TF_ASSERT_OK_AND_ASSIGN(auto test_module,
                             ParseAndReturnUnverifiedModule(hlo_string));
-    test_module->mutable_config()
-        .mutable_debug_options()
-        .set_xla_gpu_experimental_scaled_dot_with_triton(true);
-    test_module->mutable_config()
-        .mutable_debug_options()
-        .set_xla_gpu_enable_triton_gemm(true);
+    auto& test_opts = test_module->mutable_config().mutable_debug_options();
+    test_opts.set_xla_gpu_experimental_scaled_dot_with_triton(true);
+    test_opts.set_xla_gpu_enable_triton_gemm(true);
+    test_opts.clear_xla_gpu_experimental_autotune_backends();
+    test_opts.add_xla_gpu_experimental_autotune_backends(
+        autotuner::Backend::HIPBLASLT);
+    test_opts.add_xla_gpu_experimental_autotune_backends(
+        autotuner::Backend::HIPBLASLT_FISSION);
 
     EXPECT_TRUE(RunAndCompareTwoModules(std::move(test_module),
                                         std::move(reference_module), error_spec,
@@ -182,6 +181,32 @@ ENTRY main {
 
 TEST_F(HipblasLtMxExecutionTest, MxFp4Fp8MixedBatchedCorrectness) {
   RunMxCorrectnessTest(kMxFp4Fp8MixedBatchedHlo,
+                       ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5));
+}
+
+// The scaled-dot operands are reshapes of higher-rank parameters, mimicking the
+// in-graph block-scaled quantization case where the fp8 operand is produced in
+// [batch, M, K/block, block] form and only flattened to [batch, M, K] by a
+// reshape/bitcast that gets absorbed into the gemm fusion. This exercises the
+// path where the fusion's external operands have a different rank than the
+// scaled-dot operands; the MX rewrite must re-bitcast them back so the custom
+// call operands stay consistent with the dot dimension numbers.
+constexpr absl::string_view kMxFp8ReshapedOperandsHlo = R"(
+HloModule mx_fp8_reshaped_operands_test
+ENTRY main {
+  %lhs_blocked = f8e4m3fn[1,32,8,32] parameter(0)
+  %rhs_blocked = f8e4m3fn[1,16,8,32] parameter(1)
+  %lhs_scale = f8e8m0fnu[1,32,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[1,16,8] parameter(3)
+  %lhs = f8e4m3fn[1,32,256] reshape(%lhs_blocked)
+  %rhs = f8e4m3fn[1,16,256] reshape(%rhs_blocked)
+  ROOT %result = f32[1,32,16] scaled-dot(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      lhs_batch_dims={0}, rhs_batch_dims={0},
+      lhs_contracting_dims={2}, rhs_contracting_dims={2}
+})";
+
+TEST_F(HipblasLtMxExecutionTest, MxFp8ReshapedOperandsCorrectness) {
+  RunMxCorrectnessTest(kMxFp8ReshapedOperandsHlo,
                        ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5));
 }
 

--- a/xla/backends/gpu/autotuner/triton.cc
+++ b/xla/backends/gpu/autotuner/triton.cc
@@ -115,13 +115,6 @@ TritonBackend::GetSupportedConfigs(const HloInstruction& instr) {
       hlo_query::GetFirstInstructionWithOpcode(
           *instr.fused_instructions_computation(), HloOpcode::kScaledDot);
   if (scaled_dot_instr != nullptr) {
-    // Triton scaled dot emitter is not supported on ROCm; skip to allow
-    // other backends (e.g. HipblasLtBackend) to handle kScaledDot.
-    const auto& gpu_cc =
-        target_config().device_description.gpu_compute_capability();
-    if (gpu_cc.IsRocm()) {
-      return std::vector<std::unique_ptr<BackendConfig>>();
-    }
     return GetSupportedConfigsForScaledDot(scaled_dot_instr);
   }
   return std::vector<std::unique_ptr<BackendConfig>>();

--- a/xla/backends/gpu/autotuner/triton_test.cc
+++ b/xla/backends/gpu/autotuner/triton_test.cc
@@ -166,9 +166,6 @@ TEST_F(TritonBackendTest, GetSupportedConfigs) {
 }
 
 TEST_F(TritonBackendTest, GetSupportedConfigsForScaledDot) {
-  if (target_config_.device_description.gpu_compute_capability().IsRocm()) {
-    GTEST_SKIP() << "Triton scaled dot not supported on ROCm.";
-  }
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(kScaledDotHlo));
   HloInstruction* fusion_instr =
@@ -180,9 +177,6 @@ TEST_F(TritonBackendTest, GetSupportedConfigsForScaledDot) {
 }
 
 TEST_F(TritonBackendTest, GetAndApplyConfigForScaledDot) {
-  if (target_config_.device_description.gpu_compute_capability().IsRocm()) {
-    GTEST_SKIP() << "Triton scaled dot not supported on ROCm.";
-  }
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(kScaledDotHlo));
   HloInstruction* fusion_instr =
@@ -449,10 +443,6 @@ TEST_F(TritonBackendTest, VerifyHopperConfigsAreDifferentFromBlackwell) {
 }
 
 TEST_F(TritonBackendTest, ScaledDotConfigsAreGenerated) {
-  if (target_config_.device_description.gpu_compute_capability().IsRocm()) {
-    GTEST_SKIP() << "Not supported on ROCm.";
-  }
-
   se::CudaComputeCapability blackwell_cap{se::CudaComputeCapability::kBlackwell,
                                           /*minor=*/0};
   target_config_.device_description.set_gpu_compute_capability(

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_convert_unsupported_types.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_convert_unsupported_types.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include "llvm/Support/Casting.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/Transforms/Patterns.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -52,6 +53,29 @@ struct GenericOpConversionPattern final : public OpConversionPattern<OpType> {
       result.setType(converter->convertType(result.getType()));
     }
     rewriter.replaceOp(op, replacement);
+    return success();
+  }
+};
+
+struct ConstantOpConversionPattern final
+    : public OpConversionPattern<arith::ConstantOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      arith::ConstantOp op, arith::ConstantOp::Adaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Type new_type = getTypeConverter()->convertType(op.getType());
+    if (new_type == op.getType()) {
+      return failure();
+    }
+    auto dense_attr = llvm::dyn_cast<DenseElementsAttr>(op.getValue());
+    if (!dense_attr) {
+      return failure();
+    }
+    auto new_shaped_type = llvm::cast<ShapedType>(new_type);
+    auto new_attr = DenseElementsAttr::getFromRawBuffer(
+        new_shaped_type, dense_attr.getRawData());
+    rewriter.replaceOpWithNewOp<arith::ConstantOp>(op, new_attr);
     return success();
   }
 };
@@ -127,14 +151,18 @@ class TritonXLAConvertUnsupportedTypesPass
     RewritePatternSet patterns(ctx);
     patterns.add<
         // go/keep-sorted start
+        ConstantOpConversionPattern,
         GenericOpConversionPattern<::xla::xtile::ExtractTileOp>,
         GenericOpConversionPattern<::xla::xtile::InsertTileOp>,
         GenericOpConversionPattern<BroadcastOp>,
         GenericOpConversionPattern<DotScaledOp>,
         GenericOpConversionPattern<ExpandDimsOp>,
         GenericOpConversionPattern<ReshapeOp>,
+        GenericOpConversionPattern<SplatOp>,
         GenericOpConversionPattern<TransOp>,
-        GenericOpConversionPattern<arith::BitcastOp>
+        GenericOpConversionPattern<arith::BitcastOp>,
+        GenericOpConversionPattern<arith::SelectOp>,
+        GenericOpConversionPattern<tensor::ExtractOp>
         // go/keep-sorted end
         >(converter, ctx);
     scf::populateSCFStructuralTypeConversions(converter, patterns);

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
@@ -35,8 +35,8 @@ limitations under the License.
 #include "xla/stream_executor/gpu/gpu_blas_lt.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "xla/tsl/platform/statusor.h"
 
 namespace xla {
 namespace gpu {

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk_test.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk_test.cc
@@ -366,7 +366,7 @@ TEST_F(GpuBlasLtMatmulThunkTest, CacheUnitTest) {
         });
       }
     }  // for j
-  }  // end block
+  }    // end block
   for (auto& res : results) {
     TF_ASSERT_OK(res);
   }
@@ -447,8 +447,8 @@ TEST_F(GpuBlasLtMatmulThunkTest, ThunkProtoSerialization) {
   thunk_info.execution_stream_id = 0;
 
   CublasLtMatmulThunkProto proto;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kCublasLtMatmulThunkProtoText,
-                                                  &proto));
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      kCublasLtMatmulThunkProtoText, &proto));
 
   std::vector<BufferAllocation> allocations = {
       BufferAllocation(/*index=*/0, /*size=*/4, /*color=*/0),  // UNUSED

--- a/xla/stream_executor/cuda/cuda_blas_lt.cc
+++ b/xla/stream_executor/cuda/cuda_blas_lt.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "xla/stream_executor/cuda/cuda_blas_lt.h"
 
-#include <Eigen/Core>
 #include <algorithm>
 #include <any>
 #include <climits>
@@ -37,6 +36,7 @@ limitations under the License.
 #include "third_party/gpus/cuda/include/cublas_v2.h"
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "third_party/gpus/cuda/include/library_types.h"
+#include <Eigen/Core>
 #include "xla/primitive_util.h"
 #include "xla/status_macros.h"
 #include "xla/stream_executor/activate_context.h"
@@ -177,7 +177,8 @@ absl::Status BlasLt::Init() {
 
   VLOG(2) << "MatrixLayout::Create: num_rows: " << m.num_rows
           << " num_cols:" << (int)m.num_cols << ", order: " << (int)m.order
-          << "," << " batchsz " << m.batch_size
+          << ","
+          << " batchsz " << m.batch_size
           << " leaddimstride: " << m.leading_dim_stride
           << " batch_stride: " << m.batch_stride;
 

--- a/xla/stream_executor/cuda/cuda_blas_lt.h
+++ b/xla/stream_executor/cuda/cuda_blas_lt.h
@@ -128,7 +128,7 @@ class BlasLt : public gpu::BlasLt {
     double beta_;
     bool must_swap_operands_;
     std::optional<MatmulAlgorithm> algorithm_;  // selected algorithm
-  };  // class MatmulPlan
+  };                                            // class MatmulPlan
 
   explicit BlasLt(StreamExecutor* parent)
       : parent_(parent), blas_lt_(nullptr, cublasLtDestroy) {}

--- a/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/xla/stream_executor/rocm/hip_blas_lt.h
@@ -136,7 +136,7 @@ class BlasLt : public gpu::BlasLt {
     double beta_;
     bool must_swap_operands_;
     std::optional<MatmulAlgorithm> algorithm_;  // selected algorithm
-  };  // class MatmulPlan
+  };                                            // class MatmulPlan
 
   explicit BlasLt(StreamExecutor* parent)
       : parent_(parent), blas_lt_(nullptr, hipblasLtDestroy) {}

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -34,10 +34,10 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
 #include "Eigen/Core"
-#include "unsupported/Eigen/CXX11/Tensor"
 #include "rocm/include/hip/amd_detail/hip_fp16_gcc.h"
 #include "rocm/include/hipblas/hipblas.h"
 #include "rocm/rocm_config.h"
+#include "unsupported/Eigen/CXX11/Tensor"
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/device_address.h"
@@ -123,17 +123,17 @@ extern void rocm_Broadcast_fp32(void *stream, float *dst, int dst_stride,
                                 int size);
 
 template <class T>
-const RocBlasType_t<T>* const* complex_cast(const DeviceAddress<T*>& a) {
+const RocBlasType_t<T> *const *complex_cast(const DeviceAddress<T *> &a) {
   return reinterpret_cast<const RocBlasType_t<T> *const *>(GpuMemory(a));
 }
 
 template <class T>
-RocBlasType_t<T>* const* complex_cast(DeviceAddress<T*>& a) {
+RocBlasType_t<T> *const *complex_cast(DeviceAddress<T *> &a) {
   return reinterpret_cast<RocBlasType_t<T> *const *>(GpuMemory(a));
 }
 
 template <class T>
-const RocBlasType_t<T>* complex_cast(const DeviceAddress<T>& a) {
+const RocBlasType_t<T> *complex_cast(const DeviceAddress<T> &a) {
   return reinterpret_cast<const RocBlasType_t<T> *>(GpuMemory(a));
 }
 
@@ -142,7 +142,7 @@ const RocBlasType_t<T> *complex_cast(const T &a) {
   return reinterpret_cast<const RocBlasType_t<T> *>(&a);
 }
 template <class T>
-RocBlasType_t<T>* complex_cast(DeviceAddress<T>* a) {
+RocBlasType_t<T> *complex_cast(DeviceAddress<T> *a) {
   return reinterpret_cast<RocBlasType_t<T> *>(GpuMemoryMutable(a));
 }
 
@@ -466,8 +466,8 @@ absl::Status ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
 }
 
 #define Impl_DoBlasScal(Fun, T, Ta)                                         \
-  bool ROCMBlas::DoBlasScal(Stream* stream, uint64_t elem_count, Ta alpha,  \
-                            DeviceAddress<T>* x, int incx) {                \
+  bool ROCMBlas::DoBlasScal(Stream *stream, uint64_t elem_count, Ta alpha,  \
+                            DeviceAddress<T> *x, int incx) {                \
     return DoBlasInternal(Fun, stream, /* pointer_mode_host = */ true,      \
                           elem_count, complex_cast(alpha), complex_cast(x), \
                           incx);                                            \
@@ -482,10 +482,10 @@ Impl_DoBlasScal(wrap::rocblas_sscal, float, float)
                     Impl_DoBlasScal(wrap::rocblas_zscal, std::complex<double>,
                                     std::complex<double>)
 #define Impl_DoBlasGemv(fun, T)                                                \
-  bool ROCMBlas::DoBlasGemv(Stream* stream, blas::Transpose trans, uint64_t m, \
-                            uint64_t n, T alpha, const DeviceAddress<T>& a,    \
-                            int lda, const DeviceAddress<T>& x, int incx,      \
-                            T beta, DeviceAddress<T>* y, int incy) {           \
+  bool ROCMBlas::DoBlasGemv(Stream *stream, blas::Transpose trans, uint64_t m, \
+                            uint64_t n, T alpha, const DeviceAddress<T> &a,    \
+                            int lda, const DeviceAddress<T> &x, int incx,      \
+                            T beta, DeviceAddress<T> *y, int incy) {           \
     return DoBlasInternal(fun, stream, /* pointer_mode_host = */ true,         \
                           ROCMBlasTranspose(trans), m, n, complex_cast(alpha), \
                           complex_cast(a), lda, complex_cast(x), incx,         \
@@ -523,13 +523,13 @@ void ROCMBlas::MaybeLogGemmOp(GemmCallTrace::GemmType op,
       parent_->RecordApiTrace(GemmCallTrace{op, (int)context, size1, size2});
 }
 
-absl::Status ROCMBlas::DoBlasGemm(Stream* stream, blas::Transpose transa,
+absl::Status ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
                                   blas::Transpose transb, uint64_t m,
                                   uint64_t n, uint64_t k, blas::DataType dtype,
-                                  const void* alpha, const DeviceAddressBase& a,
-                                  int lda, const DeviceAddressBase& b, int ldb,
-                                  const void* beta, DeviceAddressBase* c,
-                                  int ldc, const EngineOptions& engine_options,
+                                  const void *alpha, const DeviceAddressBase &a,
+                                  int lda, const DeviceAddressBase &b, int ldb,
+                                  const void *beta, DeviceAddressBase *c,
+                                  int ldc, const EngineOptions &engine_options,
                                   blas::CallContext context) {
   MaybeLogGemmOp(GemmCallTrace::GemmType::kPlain, context,
                  m * k * DtypeSize(dtype), n * k * DtypeSize(dtype));
@@ -611,13 +611,13 @@ absl::Status ROCMBlas::DoBlasGemm(Stream* stream, blas::Transpose transa,
 }
 
 absl::Status ROCMBlas::DoBlasGemmWithAlgorithm(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64_t k, const void* alpha, const DeviceAddressBase& a,
-    blas::DataType type_a, int lda, const DeviceAddressBase& b,
-    blas::DataType type_b, int ldb, const void* beta, DeviceAddressBase* c,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    uint64_t n, uint64_t k, const void *alpha, const DeviceAddressBase &a,
+    blas::DataType type_a, int lda, const DeviceAddressBase &b,
+    blas::DataType type_b, int ldb, const void *beta, DeviceAddressBase *c,
     blas::DataType type_c, int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, const EngineOptions& engine_options,
-    blas::ProfileResult* profile_result, blas::CallContext context) {
+    blas::AlgorithmType algorithm, const EngineOptions &engine_options,
+    blas::ProfileResult *profile_result, blas::CallContext context) {
   if (type_a != type_b) {
     return absl::InternalError(absl::StrFormat(
         "DoBlasGemmWithAlgorithm: different "
@@ -671,14 +671,14 @@ absl::Status ROCMBlas::DoBlasGemmWithAlgorithm(
 }
 
 absl::Status ROCMBlas::DoBlasGemmStridedBatchedWithAlgorithm(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64_t k, const void* alpha, const DeviceAddressBase& a,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    uint64_t n, uint64_t k, const void *alpha, const DeviceAddressBase &a,
     blas::DataType type_a, int lda, int64_t stride_a,
-    const DeviceAddressBase& b, blas::DataType type_b, int ldb,
-    int64_t stride_b, const void* beta, DeviceAddressBase* c,
+    const DeviceAddressBase &b, blas::DataType type_b, int ldb,
+    int64_t stride_b, const void *beta, DeviceAddressBase *c,
     blas::DataType type_c, int ldc, int64_t stride_c, int batch_count,
     blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    const EngineOptions& engine_options, blas::ProfileResult* profile_result,
+    const EngineOptions &engine_options, blas::ProfileResult *profile_result,
     blas::CallContext context) {
   if (type_a != type_b) {
     return absl::InternalError(absl::StrFormat(
@@ -872,9 +872,9 @@ bool MemCopyOpsFold(MemoryCopyOp &y, const MemoryCopyOp &x) {
 // The below algorithm tries to minimize the number of memcpy by consolidating
 // neighboring memcpy into a single request.
 template <typename MAPPED_T>
-absl::Status ReorganizeMemory(Stream* stream,
-                              DeviceAddress<MAPPED_T>* device_memory,
-                              const std::vector<MAPPED_T*>& raw_ptrs,
+absl::Status ReorganizeMemory(Stream *stream,
+                              DeviceAddress<MAPPED_T> *device_memory,
+                              const std::vector<MAPPED_T *> &raw_ptrs,
                               int batch_count, uint64_t batch_stride,
                               bool gather) {
   if (gather == false) {
@@ -985,12 +985,12 @@ absl::StatusOr<AllocateStridedResult<T>> AllocateStridedBuffer(
 
 template <typename T, typename FuncT>
 absl::Status ROCMBlas::DoBlasGemmBatchedInternal(
-    FuncT rocblas_func, Stream* stream, blas::Transpose transa,
+    FuncT rocblas_func, Stream *stream, blas::Transpose transa,
     blas::Transpose transb, uint64_t m, uint64_t n, uint64_t k, T alpha,
     DeviceAddressSlice<T> a_ptrs_to_wrappers, int lda,
     DeviceAddressSlice<T> b_ptrs_to_wrappers, int ldb, T beta,
     DeviceAddressSlice<T> c_ptrs_to_wrappers, int ldc, int batch_count,
-    ScratchAllocator* scratch_allocator) {
+    ScratchAllocator *scratch_allocator) {
   using MAPPED_T = RocBlasType_t<T>;
 
   // Sanity checks before making any further progress
@@ -1124,11 +1124,11 @@ class rocblas_gemm_strided_batched_bf16 {
 const char *rocblas_gemm_strided_batched_bf16::kName =
     "rocblas_gemm_strided_batched_bf16";
 bool ROCMBlas::DoBlasGemmBatched(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
     uint64_t n, uint64_t k, float alpha, DeviceAddressSlice<Eigen::half> a,
     int lda, DeviceAddressSlice<Eigen::half> b, int ldb, float beta,
     DeviceAddressSlice<Eigen::half> c, int ldc, int batch_count,
-    const EngineOptions& engine_options, ScratchAllocator* scratch_allocator,
+    const EngineOptions &engine_options, ScratchAllocator *scratch_allocator,
     blas::CallContext context) {
   MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a.size(),
                  b.size());
@@ -1159,12 +1159,12 @@ bool ROCMBlas::DoBlasGemmBatched(
 }
 
 bool ROCMBlas::DoBlasGemmBatched(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
     uint64_t n, uint64_t k, float alpha,
     DeviceAddressSlice<Eigen::bfloat16> a_array, int lda,
     DeviceAddressSlice<Eigen::bfloat16> b_array, int ldb, float beta,
     DeviceAddressSlice<Eigen::bfloat16> c_array, int ldc, int batch_count,
-    const EngineOptions& engine_options, ScratchAllocator* scratch_allocator,
+    const EngineOptions &engine_options, ScratchAllocator *scratch_allocator,
     blas::CallContext context) {
   MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a_array.size(),
                  b_array.size());
@@ -1183,12 +1183,12 @@ bool ROCMBlas::DoBlasGemmBatched(
 
 #define IMPL_DoBlasGemmBatched(T, Fun)                                         \
   bool ROCMBlas::DoBlasGemmBatched(                                            \
-      Stream* stream, blas::Transpose transa, blas::Transpose transb,          \
+      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64_t m, uint64_t n, uint64_t k, T alpha,                             \
       DeviceAddressSlice<T> a_array, int lda, DeviceAddressSlice<T> b_array,   \
       int ldb, T beta, DeviceAddressSlice<T> c_array, int ldc,                 \
-      int batch_count, const EngineOptions& engine_options,                    \
-      ScratchAllocator* scratch_allocator, blas::CallContext context) {        \
+      int batch_count, const EngineOptions &engine_options,                    \
+      ScratchAllocator *scratch_allocator, blas::CallContext context) {        \
     MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a_array.size(), \
                    b_array.size());                                            \
     absl::Status status = DoBlasGemmBatchedInternal(                           \
@@ -1206,29 +1206,29 @@ IMPL_DoBlasGemmBatched(float, wrap::rocblas_sgemm_strided_batched)
                                wrap::rocblas_cgemm_strided_batched)
             IMPL_DoBlasGemmBatched(std::complex<double>,
                                    wrap::rocblas_zgemm_strided_batched)
-#define IMPL_DoBlasTrsm(T, Fun, Fun2)                                        \
-  bool ROCMBlas::DoBlasTrsm(Stream* stream, blas::Side side,                 \
-                            blas::UpperLower uplo, blas::Transpose transa,   \
-                            blas::Diagonal diag, uint64_t m, uint64_t n,     \
-                            T alpha, const DeviceAddress<T>& a, int lda,     \
-                            DeviceAddress<T>* b, int ldb) {                  \
-    return DoBlasInternal(Fun, stream, /* pointer_mode_host = */ true,       \
-                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),      \
-                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag), \
-                          m, n, complex_cast(alpha), complex_cast(a), lda,   \
-                          complex_cast(b), ldb);                             \
-  }                                                                          \
-                                                                             \
-  bool ROCMBlas::DoBlasTrsmBatched(                                          \
-      Stream* stream, blas::Side side, blas::UpperLower uplo,                \
-      blas::Transpose transa, blas::Diagonal diag, uint64_t m, uint64_t n,   \
-      T alpha, const DeviceAddress<T*>& as, int lda, DeviceAddress<T*>* bs,  \
-      int ldb, int batch_count) {                                            \
-    return DoBlasInternal(Fun2, stream, true /* = pointer_mode_host */,      \
-                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),      \
-                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag), \
-                          m, n, complex_cast(alpha), complex_cast(as), lda,  \
-                          complex_cast(*bs), ldb, batch_count);              \
+#define IMPL_DoBlasTrsm(T, Fun, Fun2)                                         \
+  bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,                  \
+                            blas::UpperLower uplo, blas::Transpose transa,    \
+                            blas::Diagonal diag, uint64_t m, uint64_t n,      \
+                            T alpha, const DeviceAddress<T> &a, int lda,      \
+                            DeviceAddress<T> *b, int ldb) {                   \
+    return DoBlasInternal(Fun, stream, /* pointer_mode_host = */ true,        \
+                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),       \
+                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag),  \
+                          m, n, complex_cast(alpha), complex_cast(a), lda,    \
+                          complex_cast(b), ldb);                              \
+  }                                                                           \
+                                                                              \
+  bool ROCMBlas::DoBlasTrsmBatched(                                           \
+      Stream *stream, blas::Side side, blas::UpperLower uplo,                 \
+      blas::Transpose transa, blas::Diagonal diag, uint64_t m, uint64_t n,    \
+      T alpha, const DeviceAddress<T *> &as, int lda, DeviceAddress<T *> *bs, \
+      int ldb, int batch_count) {                                             \
+    return DoBlasInternal(Fun2, stream, true /* = pointer_mode_host */,       \
+                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),       \
+                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag),  \
+                          m, n, complex_cast(alpha), complex_cast(as), lda,   \
+                          complex_cast(*bs), ldb, batch_count);               \
   }
 
                 IMPL_DoBlasTrsm(float, wrap::rocblas_strsm,
@@ -1244,12 +1244,12 @@ IMPL_DoBlasGemmBatched(float, wrap::rocblas_sgemm_strided_batched)
 
                                 absl::Status
     ROCMBlas::DoBlasGemmStridedBatched(
-        Stream* stream, blas::Transpose transa, blas::Transpose transb,
+        Stream *stream, blas::Transpose transa, blas::Transpose transb,
         uint64_t m, uint64_t n, uint64_t k, blas::DataType dtype,
-        const void* alpha, const DeviceAddressBase& a, int lda,
-        int64_t stride_a, const DeviceAddressBase& b, int ldb, int64_t stride_b,
-        const void* beta, DeviceAddressBase* c, int ldc, int64_t stride_c,
-        int batch_count, const EngineOptions& engine_options,
+        const void *alpha, const DeviceAddressBase &a, int lda,
+        int64_t stride_a, const DeviceAddressBase &b, int ldb, int64_t stride_b,
+        const void *beta, DeviceAddressBase *c, int ldc, int64_t stride_c,
+        int batch_count, const EngineOptions &engine_options,
         blas::CallContext context) {
   VLOG(1) << absl::StreamFormat(
       "doing rocBLAS GEMM Strided Batched: at=%d bt=%d m=%u n=%u "

--- a/xla/stream_executor/rocm/rocm_blas.h
+++ b/xla/stream_executor/rocm/rocm_blas.h
@@ -170,12 +170,12 @@ class ROCMBlas : public blas::BlasSupport {
   // reallocate the memory layout to be strided batched.
   template <typename T, typename FuncT>
   absl::Status DoBlasGemmBatchedInternal(
-      FuncT rocblas_func, Stream* stream, blas::Transpose transa,
+      FuncT rocblas_func, Stream *stream, blas::Transpose transa,
       blas::Transpose transb, uint64_t m, uint64_t n, uint64_t k, T alpha,
       DeviceAddressSlice<T> a_ptrs_to_wrappers, int lda,
       DeviceAddressSlice<T> b_ptrs_to_wrappers, int ldb, T beta,
       DeviceAddressSlice<T> c_ptrs_to_wrappers, int ldc, int batch_count,
-      ScratchAllocator* scratch_allocator);
+      ScratchAllocator *scratch_allocator);
 
   // mutex that guards the rocBLAS handle for this device.
   mutable absl::Mutex mu_;


### PR DESCRIPTION
## Summary
Enables the Triton scaled-dot path on ROCm (cherry-picked from upstream) and hardens the hipBLASLt MX scaled-dot rewrite so it handles fusions whose external operands have a different rank than the scaled-dot operands. Adds the type-conversion patterns needed for the Triton scaled-dot emitter to lower correctly on ROCm.

## Changes
- Remove the ROCm guards/skips that previously bypassed the Triton scaled-dot emitter (`triton.cc`, `triton_test.cc`).
- In the hipBLASLt MX rewrite, walk back from the scaled-dot operands to their feeding parameters and re-bitcast as needed so the custom-call operands stay consistent with the dot dimension numbers; also drop the `batch_size == 1` restriction.
- Promote MX scaled-dot rejection logs from `VLOG(2)` to `LOG(WARNING)` for easier diagnosis.
- Add `arith::ConstantOp`, `SplatOp`, `arith::SelectOp`, and `tensor::ExtractOp` conversion patterns to `triton_xla_convert_unsupported_types` so unsupported element types are converted correctly.
- Add `MxFp8ReshapedOperandsCorrectness` test covering reshaped higher-rank operands, and route the MX execution test through the HIPBLASLT/HIPBLASLT_FISSION autotune backends.
- Minor clang-format/clang-tidy cleanups across cuda/rocm BlasLt files.

## Test plan
- Run `hipblaslt_mx_execution_test` (including the new `MxFp8ReshapedOperandsCorrectness` case) on a ROCm GPU.
- Run `triton_test` on ROCm to confirm the scaled-dot configs are now generated.

## Notes: 
- rocm_blas.* changes are due to clang-format precommit hook