### PR TITLE
Remove script fetching from rocm-dev-infra

### DIFF
--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -53,11 +53,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
-      - name: Fetch execute_ci_build.sh from rocm-dev-infram
-        run: |
-          wget -O build_tools/rocm/execute_ci_build.sh https://raw.githubusercontent.com/ROCm/xla/refs/heads/rocm-dev-infra/build_tools/rocm/execute_ci_build.sh
-          chmod +x build_tools/rocm/execute_ci_build.sh
-
       - name: Get RBE cluster keys
         env:
           RBE_CI_CERT: ${{ secrets.RBE_CI_CERT }}

--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Test XLA [${{ matrix.mode.name }}] [single_gpu]
         run: |
-          build_tools/rocm/execute_ci_build.sh \
+          build_tools/rocm/run_xla_ci_build.sh \
             ${{ join(matrix.mode.configs, ' ') }} \
             --config=ci_single_gpu \
             --local_test_jobs=4 \
@@ -85,7 +85,7 @@ jobs:
       - name: Test XLA [${{ matrix.mode.name }}] [multi_gpu]
         if: always() && !cancelled()
         run: |
-          build_tools/rocm/execute_ci_build.sh \
+          build_tools/rocm/run_xla_ci_build.sh \
             ${{ join(matrix.mode.configs, ' ') }} \
             --config=ci_multi_gpu \
             --local_test_jobs=1 \


### PR DESCRIPTION
Do not use infra wrapper to execute release branch PR checks