### PR TITLE
Remove patch for ROCm MGPU target labels

### DIFF
--- a/.github/workflows/rocm_xla_ci_nightly.yml
+++ b/.github/workflows/rocm_xla_ci_nightly.yml
@@ -69,14 +69,6 @@ jobs:
           git -C "$tmpdir" sparse-checkout set build_tools/rocm
           cp -a "$tmpdir/build_tools/rocm/." build_tools/rocm/
 
-      - name: Patch stale upstream ROCm MGPU target labels
-        run: |
-          sed -i \
-            -e 's#//xla/tests:collective_ops_e2e_test#//xla/backends/gpu/tests:collective_ops_e2e_test#' \
-            -e 's#//xla/tests:collective_pipeline_parallelism_test#//xla/backends/gpu/tests:collective_pipeline_parallelism_test#' \
-            -e 's#//xla/tests:replicated_io_feed_test#//xla/backends/gpu/tests:replicated_io_feed_test#' \
-            build_tools/rocm/rocm_xla.bazelrc
-
       - name: Fetch execute_ci_build.sh from rocm-dev-infra
         run: |
           wget -O build_tools/rocm/execute_ci_build.sh https://raw.githubusercontent.com/ROCm/xla/refs/heads/rocm-dev-infra/build_tools/rocm/execute_ci_build.sh

--- a/.github/workflows/rocm_xla_ci_nightly.yml
+++ b/.github/workflows/rocm_xla_ci_nightly.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Fetch execute_ci_build.sh from rocm-dev-infra
         run: |
-          wget -O build_tools/rocm/execute_ci_build.sh https://raw.githubusercontent.com/ROCm/xla/refs/heads/rocm-dev-infra/build_tools/rocm/execute_ci_build.sh
+          wget -O build_tools/rocm/execute_ci_build.sh https://raw.githubusercontent.com/ROCm/xla/refs/heads/rocm-dev-infra/build_tools/rocm/execute_ci_build_upstream.sh
           chmod +x build_tools/rocm/execute_ci_build.sh
 
       - name: Get RBE cluster keys


### PR DESCRIPTION
Removed patching of stale upstream ROCm MGPU target labels from CI workflow.