### PR TITLE
[ROCm] Fix cross-stream race between H2D transfers and compute kernels

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -2208,6 +2208,14 @@ StreamExecutorGpuClient::RunAsync(
     RETURN_IF_ERROR(set_result({}, 0));
   }
 
+  // Wait for all input buffers to be ready on the compute stream before
+  // dispatching the kernel.  H2D-produced buffers carry a producer_event on
+  // host_to_device_stream; WaitForAllocation enqueues hipStreamWaitEvent so
+  // the kernel cannot start before the transfer completes.
+  for (const auto& arg : flat_arguments) {
+    RETURN_IF_ERROR(WaitForAllocation(run_options->stream(), *arg));
+  }
+
   RETURN_IF_ERROR(gpu_exec->ExecuteThunks(buffer_allocations, run_options));
 
   RETURN_IF_ERROR(buffer_allocations.TearDown(buffers_in_result,

--- a/xla/pjrt/se_raw_buffer.cc
+++ b/xla/pjrt/se_raw_buffer.cc
@@ -107,54 +107,60 @@ PjRtStreamExecutorRawBuffer::CopyRawHostToDeviceAndReturnEvent(
   auto device_event =
       BufferSequencingEvent::Create(client_->async_work_runner());
   device_event.AndThen([device_buffer = device_buffer_]() {});
-  client_->async_work_runner()->Schedule([client = client_, device_event,
-                                          local_device = local_device_, stream,
-                                          src, offset, transfer_size,
-                                          buf = tsl::FormRef(this)]() mutable {
-    se::DeviceAddressBase sub_buffer = buf->device_buffer_->mem();
-    if (transfer_size < sub_buffer.size()) {
-      sub_buffer = sub_buffer.GetByteSlice(offset, transfer_size);
-    }
-    std::shared_ptr<void> staging_buffer;
-    auto status = [&]() -> absl::Status {
-      RETURN_IF_ERROR(client->WaitForAllocation(stream, *buf));
-      if (transfer_size > 0) {
-        if (client->ShouldStageHostToDeviceTransfers(src, transfer_size)) {
-          if (client->GetHostMemoryAllocator() == nullptr) {
-            return absl::InvalidArgumentError(
-                "host_memory_allocator should be initialized for "
-                "staging buffer transfer.");
-          }
-          HostMemoryAllocator::AllocateOptions alloc_opts;
-          alloc_opts.numa_node = stream->parent()->numa_node();
-          alloc_opts.local_device_id = local_device->local_device_id();
-          staging_buffer = client->GetHostMemoryAllocator()->Allocate(
-              transfer_size, alloc_opts);
-          auto copy_to_staging_buffer = [src, transfer_size,
-                                         staging_buffer]() mutable {
-            std::memcpy(staging_buffer.get(), src, transfer_size);
-          };
-          RETURN_IF_ERROR(stream->DoHostCallback(copy_to_staging_buffer));
-          RETURN_IF_ERROR(
-              stream->Memcpy(&sub_buffer, staging_buffer.get(), transfer_size));
-        } else {
-          RETURN_IF_ERROR(stream->Memcpy(&sub_buffer, src, transfer_size));
+
+  // Bind the pre-created event to this buffer before scheduling the async
+  // task.  This ensures that any consumer calling GetDefinitionEvent after
+  // this point sees an event on host_to_device_stream rather than the
+  // compute-stream sync_point, closing the cross-stream race in RunAsync.
+  device_buffer_->SetProducerEvent(device_event);
+
+  client_->async_work_runner()->Schedule(
+      [client = client_, device_event, local_device = local_device_, stream,
+       src, offset, transfer_size, buf = tsl::FormRef(this)]() mutable {
+        se::DeviceAddressBase sub_buffer = buf->device_buffer_->mem();
+        if (transfer_size < sub_buffer.size()) {
+          sub_buffer = sub_buffer.GetByteSlice(offset, transfer_size);
         }
-      }
-      return absl::OkStatus();
-    }();
-    if (status.ok()) {
-      status = client->AllocateAndRecordEvent(
-          device_event, local_device, stream,
-          "PjRtStreamExecutorRawBuffer::CopyRawHostToDevice",
-          [staging_buffer = std::move(staging_buffer)]() mutable {
-            staging_buffer.reset();
-          });
-    }
-    if (!status.ok()) {
-      client->SetEventAsError(device_event, status);
-    }
-  });
+        std::shared_ptr<void> staging_buffer;
+        auto status = [&]() -> absl::Status {
+          RETURN_IF_ERROR(client->WaitForAllocation(stream, *buf));
+          if (transfer_size > 0) {
+            if (client->ShouldStageHostToDeviceTransfers(src, transfer_size)) {
+              if (client->GetHostMemoryAllocator() == nullptr) {
+                return absl::InvalidArgumentError(
+                    "host_memory_allocator should be initialized for "
+                    "staging buffer transfer.");
+              }
+              HostMemoryAllocator::AllocateOptions alloc_opts;
+              alloc_opts.numa_node = stream->parent()->numa_node();
+              alloc_opts.local_device_id = local_device->local_device_id();
+              staging_buffer = client->GetHostMemoryAllocator()->Allocate(
+                  transfer_size, alloc_opts);
+              auto copy_to_staging_buffer = [src, transfer_size,
+                                             staging_buffer]() mutable {
+                std::memcpy(staging_buffer.get(), src, transfer_size);
+              };
+              RETURN_IF_ERROR(stream->DoHostCallback(copy_to_staging_buffer));
+              RETURN_IF_ERROR(stream->Memcpy(&sub_buffer, staging_buffer.get(),
+                                             transfer_size));
+            } else {
+              RETURN_IF_ERROR(stream->Memcpy(&sub_buffer, src, transfer_size));
+            }
+          }
+          return absl::OkStatus();
+        }();
+        if (status.ok()) {
+          status = client->AllocateAndRecordEvent(
+              device_event, local_device, stream,
+              "PjRtStreamExecutorRawBuffer::CopyRawHostToDevice",
+              [staging_buffer = std::move(staging_buffer)]() mutable {
+                staging_buffer.reset();
+              });
+        }
+        if (!status.ok()) {
+          client->SetEventAsError(device_event, status);
+        }
+      });
   return PjRtDeviceEventRef(std::move(device_event));
 }
 
@@ -165,55 +171,54 @@ PjRtStreamExecutorRawBuffer::CopyRawDeviceToHostAndReturnEvent(
   auto device_event =
       BufferSequencingEvent::Create(client_->async_work_runner());
   device_event.AndThen([device_buffer = device_buffer_]() {});
-  client_->async_work_runner()->Schedule([client = client_, device_event,
-                                          local_device = local_device_, stream,
-                                          dst, offset, transfer_size,
-                                          buf = tsl::FormRef(this)]() mutable {
-    se::DeviceAddressBase sub_buffer = buf->device_buffer_->mem();
-    if (transfer_size < sub_buffer.size()) {
-      sub_buffer = sub_buffer.GetByteSlice(offset, transfer_size);
-    }
-    std::shared_ptr<void> staging_buffer;
-    auto status = [&]() -> absl::Status {
-      RETURN_IF_ERROR(client->WaitForAllocation(stream, *buf));
-      if (transfer_size > 0) {
-        if (client->ShouldStageHostToDeviceTransfers(dst, transfer_size)) {
-          if (client->GetHostMemoryAllocator() == nullptr) {
-            return absl::InvalidArgumentError(
-                "host_memory_allocator should be initialized for "
-                "staging buffer transfer.");
-          }
-          HostMemoryAllocator::AllocateOptions alloc_opts;
-          alloc_opts.numa_node = stream->parent()->numa_node();
-          alloc_opts.local_device_id = local_device->local_device_id();
-          staging_buffer = client->GetHostMemoryAllocator()->Allocate(
-              transfer_size, alloc_opts);
-          RETURN_IF_ERROR(
-              stream->Memcpy(staging_buffer.get(), sub_buffer, transfer_size));
-          auto copy_from_staging_buffer = [dst, transfer_size,
-                                           staging_buffer]() mutable {
-            std::memcpy(dst, staging_buffer.get(), transfer_size);
-          };
-          // TODO(parkers): This failing maybe consitutes a race.
-          RETURN_IF_ERROR(stream->DoHostCallback(copy_from_staging_buffer));
-        } else {
-          RETURN_IF_ERROR(stream->Memcpy(dst, sub_buffer, transfer_size));
+  client_->async_work_runner()->Schedule(
+      [client = client_, device_event, local_device = local_device_, stream,
+       dst, offset, transfer_size, buf = tsl::FormRef(this)]() mutable {
+        se::DeviceAddressBase sub_buffer = buf->device_buffer_->mem();
+        if (transfer_size < sub_buffer.size()) {
+          sub_buffer = sub_buffer.GetByteSlice(offset, transfer_size);
         }
-      }
-      return absl::OkStatus();
-    }();
-    if (status.ok()) {
-      status = client->AllocateAndRecordEvent(
-          device_event, local_device, stream,
-          "PjRtStreamExecutorRawBuffer::CopyRawDeviceToHost",
-          [staging_buffer = std::move(staging_buffer)]() mutable {
-            staging_buffer.reset();
-          });
-    }
-    if (!status.ok()) {
-      client->SetEventAsError(device_event, status);
-    }
-  });
+        std::shared_ptr<void> staging_buffer;
+        auto status = [&]() -> absl::Status {
+          RETURN_IF_ERROR(client->WaitForAllocation(stream, *buf));
+          if (transfer_size > 0) {
+            if (client->ShouldStageHostToDeviceTransfers(dst, transfer_size)) {
+              if (client->GetHostMemoryAllocator() == nullptr) {
+                return absl::InvalidArgumentError(
+                    "host_memory_allocator should be initialized for "
+                    "staging buffer transfer.");
+              }
+              HostMemoryAllocator::AllocateOptions alloc_opts;
+              alloc_opts.numa_node = stream->parent()->numa_node();
+              alloc_opts.local_device_id = local_device->local_device_id();
+              staging_buffer = client->GetHostMemoryAllocator()->Allocate(
+                  transfer_size, alloc_opts);
+              RETURN_IF_ERROR(stream->Memcpy(staging_buffer.get(), sub_buffer,
+                                             transfer_size));
+              auto copy_from_staging_buffer = [dst, transfer_size,
+                                               staging_buffer]() mutable {
+                std::memcpy(dst, staging_buffer.get(), transfer_size);
+              };
+              // TODO(parkers): This failing maybe consitutes a race.
+              RETURN_IF_ERROR(stream->DoHostCallback(copy_from_staging_buffer));
+            } else {
+              RETURN_IF_ERROR(stream->Memcpy(dst, sub_buffer, transfer_size));
+            }
+          }
+          return absl::OkStatus();
+        }();
+        if (status.ok()) {
+          status = client->AllocateAndRecordEvent(
+              device_event, local_device, stream,
+              "PjRtStreamExecutorRawBuffer::CopyRawDeviceToHost",
+              [staging_buffer = std::move(staging_buffer)]() mutable {
+                staging_buffer.reset();
+              });
+        }
+        if (!status.ok()) {
+          client->SetEventAsError(device_event, status);
+        }
+      });
   return PjRtDeviceEventRef(std::move(device_event));
 }
 

--- a/xla/pjrt/tracked_device_buffer.cc
+++ b/xla/pjrt/tracked_device_buffer.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
+#include "absl/synchronization/mutex.h"
 #include "xla/future.h"
 #include "xla/pjrt/abstract_tracked_device_buffer.h"
 #include "xla/pjrt/async_work_runner.h"
@@ -88,8 +89,25 @@ class AllocatedRawSEDeviceMemory : public RawSEDeviceMemory {
 
   void UnsafeReleaseMemory() override { allocator_ = nullptr; }
 
+  // Binds a producer-stream event to this buffer, replacing the default
+  // compute-stream sync_point.  Must be called before the buffer is visible to
+  // consumers (i.e. before the async producer task is scheduled).
+  void SetProducerEvent(BufferSequencingEventRef event) override {
+    absl::MutexLock l(&producer_event_mu_);
+    producer_event_ = std::move(event);
+  }
+
   absl::StatusOr<BufferSequencingEventRef> GetDefinitionEvent(
       AsyncWorkRunner* async_work_runner, bool nullptr_if_past) const override {
+    {
+      absl::MutexLock l(&producer_event_mu_);
+      if (producer_event_) {
+        if (nullptr_if_past && producer_event_->IsComplete()) {
+          return BufferSequencingEventRef();
+        }
+        return producer_event_;
+      }
+    }
     if (sync_point_ != std::numeric_limits<size_t>::max()) {
       return local_device_->GetEventForComputeStreamSyncPoint(
           sync_point_, async_work_runner, nullptr_if_past);
@@ -101,6 +119,9 @@ class AllocatedRawSEDeviceMemory : public RawSEDeviceMemory {
   se::DeviceAddressAllocator* allocator_;
   LocalDeviceState* local_device_;
   size_t sync_point_ = std::numeric_limits<size_t>::max();
+
+  mutable absl::Mutex producer_event_mu_;
+  BufferSequencingEventRef producer_event_ ABSL_GUARDED_BY(producer_event_mu_);
 };
 
 tsl::AsyncValueRef<RawSEDeviceMemory> RawSEDeviceMemory::Create(
@@ -173,7 +194,5 @@ tsl::AsyncValueRef<RawSEDeviceMemory> RawSEDeviceMemory::CreateSlice(
       absl::StrFormat("Error when slicing: [%d,%d) in array of size %d", offset,
                       offset + size, src_size)));
 }
-
-
 
 }  // namespace xla

--- a/xla/pjrt/tracked_device_buffer.h
+++ b/xla/pjrt/tracked_device_buffer.h
@@ -91,11 +91,14 @@ class RawSEDeviceMemory {
     return BufferSequencingEventRef();
   }
 
+  // Overrides the definition event with one tied to the actual producer stream.
+  // Must be called before the buffer is made visible to consumers.
+  // The default is a no-op; only AllocatedRawSEDeviceMemory overrides this.
+  virtual void SetProducerEvent(BufferSequencingEventRef /*event*/) {}
+
  private:
   se::DeviceAddressBase value_;
 };
-
-
 
 }  // namespace xla
 


### PR DESCRIPTION
## Summary

Hunting a flaky CI failure in `tests/batching_test.py::BatchingTest::testConvGeneralDilated` on the ROCm 4-GPU MI350X runner, where `per_example_direct` (the Python loop reference) was all zeros while the vmap result was correct.

### What Could Happen

In the op-by-op execution path (`StreamExecutorGpuClient::RunAsync`, used under pytest-xdist with single-GPU worker isolation), input buffers produced by H2D transfers have their definition event tied to the **compute-stream** sync_point counter — not to `host_to_device_stream_`. When the compute stream advances past that sync_point and evicts it from the sliding window, `GetDefinitionEvent(nullptr_if_past=true)` returns `nullptr`, and `RunAsync` skips waiting before dispatching the kernel. The kernel then reads the input before the H2D transfer completes, getting zeros.

The invariant broken is subtle: `AllocatedRawSEDeviceMemory` always used the **compute_stream** counter to represent "buffer is ready", but H2D-produced buffers are written by `host_to_device_stream_`, an independent HIP stream. "Compute stream past sync_point" does not imply "H2D transfer complete."

### Fix

1. **`xla/pjrt/tracked_device_buffer.cc/.h`** — Add `SetProducerEvent()` / `producer_event_` to `AllocatedRawSEDeviceMemory`. `GetDefinitionEvent` returns this event (on the real producer stream) when set, falling back to the existing compute-stream sync_point mechanism for compute outputs.

2. **`xla/pjrt/se_raw_buffer.cc`** — In `CopyRawHostToDeviceAndReturnEvent`, pre-create the H2D completion event and call `SetProducerEvent` **synchronously** before scheduling the async task. Any consumer calling `GetDefinitionEvent` after this point sees the `host_to_device_stream_` event, not a compute-stream sync_point.

3. **`xla/pjrt/gpu/se_gpu_pjrt_client.cc`** — In `RunAsync`, call `WaitForAllocation` for each input flat_argument before `ExecuteThunks`. For H2D-produced inputs, this enqueues `hipStreamWaitEvent(compute_stream, h2d_event)`, preventing the kernel from starting before the transfer completes. For already-complete or compute-stream buffers, the call is a no-op.

### Design notes

- **No race on `producer_event_`**: the event handle is pre-created and stored in the buffer _before_ the async H2D task is scheduled, and before the buffer is returned to the caller. The mutex in `GetDefinitionEvent` guards concurrent reads from `RunAsync` against the (rare) case where `SetProducerEvent` is called concurrently.
- **Compute-stream buffers unaffected**: `sync_point_` fallback is unchanged; no performance regression on the common path.
- **D2D transfers** (`ScheduleCopyTo`, `IntraClientCopyToWithDependencies`) have the same cross-stream pattern but are not implicated in the known failure — left as follow-on work.
