### PR TITLE
PR #24329: [ROCm] Change logging level for unhandled operators

### DIFF
--- a/xla/backends/profiler/gpu/rocm_tracer_v1.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_v1.cc
@@ -331,11 +331,11 @@ absl::Status RocmApiCallbackImpl::operator()(uint32_t domain, uint32_t cbid,
         break;
       default:
         //
-        LOG(WARNING) << "API call "
-                     << se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API,
-                                                      cbid, 0)
-                     << ", corr. id=" << data->correlation_id
-                     << " dropped. No capturing function was found!";
+        VLOG(1) << "API call "
+                << se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid,
+                                                 0)
+                << ", corr. id=" << data->correlation_id
+                << " dropped. No capturing function was found!";
         // AddGenericEventUponApiExit(cbid, data);
         break;
     }


### PR DESCRIPTION
Imported from GitHub PR https://github.com/openxla/xla/pull/24329

Previously, when profiling, the profiler would print thousands of messages for operators that the profiler did not handle unless all warning messages were dropped.

This could cause full buffers for stdout, which slowed down computation for at least one workload by 6-7x during profiling (~2s vs ~330ms).

This PR changes the default logging for the unhandled operators, which fixes the problem. Using VLOG(1) was suggested by @pemeliya Copybara import of the project:

--
e51e4d5fb41fce10e9cfd2b850502014657b77af by Gabe Weisz <gabe.weisz@amd.com>:

Change logging level for unknown operators

--
a3c683461a37692bd1f6053424aaafa6d150bab4 by Gabe Weisz <gabe.weisz@amd.com>:

fix formatting

--
f6cb1ef20310b9df0c7bc1d14f1a503b6b04e60e by Gabe Weisz <gabe.weisz@amd.com>:

fix format again

--
80b540aecbe87fdc35eb09dad999d270335ff0b0 by Gabe Weisz <gabe.weisz@amd.com>:

use correct clang-format version

Merging this change closes #24329

COPYBARA_INTEGRATE_REVIEW=https://github.com/openxla/xla/pull/24329 from ROCm:gw_change_logging_for_unknown_operator 80b540aecbe87fdc35eb09dad999d270335ff0b0 PiperOrigin-RevId: 771944853

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
