### PR TITLE
[WIP][XLA:GPU][ROCm] Fix device memory bandwidth with per-gfx peak table

### DIFF
--- a/xla/backends/gpu/target_config/specs/mi350.txtpb
+++ b/xla/backends/gpu/target_config/specs/mi350.txtpb
@@ -1,0 +1,40 @@
+# Copyright 2026 The OpenXLA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gpu_device_info {
+  threads_per_block_limit: 1024
+  threads_per_warp: 64
+  shared_memory_per_block: 163840
+  shared_memory_per_block_optin: 163840
+  shared_memory_per_core: 163840
+  threads_per_core_limit: 2048
+  core_count: 256
+  fpus_per_core: 128
+  block_dim_limit_x: 2147483647
+  block_dim_limit_y: 65536
+  block_dim_limit_z: 65536
+  memory_bandwidth: 6810000000000
+  l2_cache_size: 4194304
+  clock_rate_ghz: 2.2
+  device_memory_size: 270566162432
+  registers_per_core_limit: 131072
+  registers_per_block_limit: 131072
+  rocm_compute_capability {
+    gcn_arch_name: "gfx950:sramecc+:xnack-"
+  }
+}
+platform_name: "ROCM"
+dnn_version_info {
+}
+device_description_str: "MI350X"

--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -733,6 +733,7 @@ lit_test_suite_for_gpus(
             "calling_convention.hlo",
             "dot_bf16.hlo",
             "kernel_reuse.hlo",
+            "memory_bandwidth_fusion.hlo",
             "offload_scan_output.hlo",
             "pad_to_static.hlo",
             "reduce_fold_zero_add.hlo",
@@ -783,7 +784,15 @@ lit_test_suite_for_gpus(
             "vectorization.hlo",
             "pdl.hlo",
         ],
+        "mi350": [
+            "dot_bf16.hlo",
+            "single_instruction.hlo",
+            "vectorization.hlo",
+            "pdl.hlo",
+        ],
         "gfx1250": [
+            # TODO: re-enable once gfx1250 memory_bandwidth is finalized.
+            "memory_bandwidth_fusion.hlo",
             "single_instruction.hlo",
             "vectorization.hlo",
             "pdl.hlo",
@@ -796,6 +805,7 @@ lit_test_suite_for_gpus(
         "gfx1250",
         "h100_sxm",
         "mi200",
+        "mi350",
         "p100",
         "v100",
     ],

--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -317,9 +317,8 @@ xla_test(
         "//xla/hlo/parser:hlo_parser",
         "//xla/stream_executor:device_description",
         "//xla/tests:hlo_pjrt_interpreter_reference_mixin",
+        "//xla/tsl/platform:test",
         "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test",
     ],
 )
 
@@ -375,10 +374,9 @@ xla_test(
         "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:verified_hlo_module",
         "//xla/tests:hlo_pjrt_interpreter_reference_mixin",
+        "//xla/tsl/platform:test",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test",
     ],
 )
 
@@ -394,7 +392,6 @@ xla_test(
         "//xla/hlo/testlib:verified_hlo_module",
         "//xla/tests:hlo_pjrt_interpreter_reference_mixin",
         "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/platform:statusor",
     ],
 )
 
@@ -517,8 +514,8 @@ xla_test(
         "//xla/hlo/builder:xla_builder",
         "//xla/hlo/testlib:test_helpers",
         "//xla/tests:client_library_test_base",
+        "//xla/tsl/platform:env",
         "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/platform:env",
     ],
 )
 
@@ -568,10 +565,10 @@ xla_test(
         "//xla:shape_util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
+        "//xla/tsl/platform:test",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/platform:test",
     ],
 )
 
@@ -597,9 +594,9 @@ xla_test(
     backends = ["gpu"],
     deps = [
         ":gpu_pjrt_codegen_test",
+        "//xla/tsl/platform:test",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/platform:test",
     ],
 )
 
@@ -1114,10 +1111,10 @@ xla_test(
     deps = [
         ":gpu_pjrt_codegen_test",
         "//xla/tests:hlo_pjrt_interpreter_reference_mixin",
+        "//xla/tsl/platform:test",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/platform:test",
     ],
 )
 
@@ -1263,11 +1260,11 @@ xla_test(
         "//xla/tests:test_utils",
         "//xla/tests:xla_internal_test_main",
         "//xla/tests/restricted:hlo_test_base_legacy",
+        "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest",
-        "@tsl//tsl/platform:statusor",
     ],
 )
 

--- a/xla/backends/gpu/tests/collective_pipeline_parallelism_test.cc
+++ b/xla/backends/gpu/tests/collective_pipeline_parallelism_test.cc
@@ -32,8 +32,8 @@ limitations under the License.
 #include "xla/tests/literal_test_util.h"
 #include "xla/tests/restricted/hlo_test_base_legacy.h"
 #include "xla/tests/test_utils.h"
+#include "xla/tsl/platform/statusor.h"
 #include "xla/xla.pb.h"
-#include "tsl/platform/statusor.h"
 
 namespace xla {
 namespace {

--- a/xla/backends/gpu/tests/gpu_alignment_test.cc
+++ b/xla/backends/gpu/tests/gpu_alignment_test.cc
@@ -16,7 +16,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "absl/status/status_matchers.h"
 #include "xla/backends/gpu/tests/gpu_pjrt_codegen_test.h"
-#include "tsl/platform/test.h"
+#include "xla/tsl/platform/test.h"
 
 namespace xla::gpu {
 namespace {

--- a/xla/backends/gpu/tests/gpu_copy_alone_test.cc
+++ b/xla/backends/gpu/tests/gpu_copy_alone_test.cc
@@ -22,7 +22,6 @@ limitations under the License.
 #include "xla/error_spec.h"
 #include "xla/hlo/testlib/verified_hlo_module.h"
 #include "xla/tests/hlo_pjrt_interpreter_reference_mixin.h"
-#include "tsl/platform/statusor.h"
 
 namespace xla::gpu {
 

--- a/xla/backends/gpu/tests/gpu_copy_test.cc
+++ b/xla/backends/gpu/tests/gpu_copy_test.cc
@@ -28,9 +28,8 @@ limitations under the License.
 #include "xla/literal.h"
 #include "xla/literal_util.h"
 #include "xla/tests/hlo_pjrt_interpreter_reference_mixin.h"
+#include "xla/tsl/platform/test.h"
 #include "xla/xla.pb.h"
-#include "tsl/platform/statusor.h"
-#include "tsl/platform/test.h"
 
 namespace xla::gpu {
 namespace {

--- a/xla/backends/gpu/tests/gpu_int4_test.cc
+++ b/xla/backends/gpu/tests/gpu_int4_test.cc
@@ -23,7 +23,7 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "xla/backends/gpu/tests/gpu_pjrt_codegen_test.h"
 #include "xla/tests/hlo_pjrt_interpreter_reference_mixin.h"
-#include "tsl/platform/test.h"
+#include "xla/tsl/platform/test.h"
 
 namespace xla::gpu {
 namespace {

--- a/xla/backends/gpu/tests/gpu_noalias_test.cc
+++ b/xla/backends/gpu/tests/gpu_noalias_test.cc
@@ -24,8 +24,8 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/shape_util.h"
+#include "xla/tsl/platform/test.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/test.h"
 
 namespace xla::gpu {
 namespace {

--- a/xla/backends/gpu/tests/infeed_test.cc
+++ b/xla/backends/gpu/tests/infeed_test.cc
@@ -29,7 +29,7 @@ limitations under the License.
 #include "xla/literal.h"
 #include "xla/literal_util.h"
 #include "xla/tests/client_library_test_base.h"
-#include "tsl/platform/env.h"
+#include "xla/tsl/platform/env.h"
 
 namespace xla {
 namespace {

--- a/xla/backends/gpu/tests/memory_bandwidth_fusion.hlo
+++ b/xla/backends/gpu/tests/memory_bandwidth_fusion.hlo
@@ -1,0 +1,67 @@
+// RUN: hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../target_config/specs/%{GPU}.txtpb --xla_gpu_autotune_level=0 | FileCheck %s --check-prefixes=CHECK-%{GPU},CHECK-%{PTX} --allow-unused-prefixes
+
+// Tests that device memory bandwidth drives the reduce-into-consumers fusion
+// decision. A reduce feeds two elementwise consumers. Duplicating the reduce
+// into a consumer means re-reading the large input from HBM, so whether it pays
+// off depends on the modeled bandwidth. This checks the final HLO, after the
+// passes that run on top of PriorityFusion -- note the final fusion count is
+// the opposite of PriorityFusion's immediate output (see
+// PriorityFusionRocmMemoryBandwidthTest.MemoryBandwidthTipsReduceFusion in
+// priority_fusion_test.cc):
+//
+//   - mi350 (gfx950, HBM3e, 6.81 TB/s): with the corrected per-gfx bandwidth
+//     (rocm_memory_bandwidth.cc) the re-read is cheap, so PriorityFusion
+//     duplicates the reduce into both consumers (two fusions); a later
+//     multi-output fusion pass then merges them, since they share the input,
+//     into a single fused_add_subtract. The legacy `2 * bus * UCLK` formula
+//     would undercount bandwidth as ~3.89 TB/s and produce the split form
+//     below; this is the regression guard for the fix.
+//   - mi200 (gfx90a, HBM2e): the re-read is too expensive to duplicate, so the
+//     reduce stays a standalone fusion and the subtract ends up in its own
+//     wrapped fusion -> two fusions.
+
+HloModule rf_8_256_1152
+
+add {
+  a = f32[] parameter(0)
+  b = f32[] parameter(1)
+  ROOT r = f32[] add(a, b)
+}
+
+ENTRY main {
+  p = f32[8,256,1152]{2,1,0} parameter(0)
+  w1 = f32[256,1152]{1,0} parameter(1)
+  w2 = f32[256,1152]{1,0} parameter(2)
+  z = f32[] constant(0)
+  red = f32[256,1152]{1,0} reduce(p, z), dimensions={0}, to_apply=add
+  c1 = f32[256,1152]{1,0} add(red, w1)
+  c2 = f32[256,1152]{1,0} subtract(red, w2)
+  ROOT out = (f32[256,1152]{1,0}, f32[256,1152]{1,0}) tuple(c1, c2)
+}
+
+// mi350: reduce + both consumers collapse into ONE multi-output fusion.
+// CHECK-mi350:      %fused_add_subtract
+// CHECK-mi350-DAG:    reduce(
+// CHECK-mi350-DAG:    add(
+// CHECK-mi350-DAG:    subtract(
+// CHECK-mi350:      ENTRY
+// CHECK-mi350:      fusion(
+// CHECK-mi350-NOT:  fusion(
+// CHECK-mi350-NOT:  wrapped_subtract
+
+// mi200: reduce fuses with only one consumer; subtract is a separate fusion.
+// CHECK-mi200:      %wrapped_subtract_computation
+// CHECK-mi200:      ENTRY
+// CHECK-mi200:      fusion({{.*}}), kind=kLoop, calls=%fused_add_reduce
+// CHECK-mi200:      fusion({{.*}}), kind=kLoop, calls=%wrapped_subtract_computation
+
+// CHECK-PTX: HloModule
+
+// CHECK-b200:      %fused_add_subtract
+// CHECK-b200-DAG:    reduce(
+// CHECK-b200-DAG:    add(
+// CHECK-b200-DAG:    subtract(
+// CHECK-b200:      ENTRY
+// CHECK-b200:      fusion(
+// CHECK-b200-NOT:  fusion(
+// CHECK-b200-NOT:  wrapped_subtract

--- a/xla/backends/gpu/tests/reduction_vectorization_test.cc
+++ b/xla/backends/gpu/tests/reduction_vectorization_test.cc
@@ -24,9 +24,8 @@ limitations under the License.
 #include "xla/hlo/parser/hlo_parser.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/tests/hlo_pjrt_interpreter_reference_mixin.h"
+#include "xla/tsl/platform/test.h"
 #include "xla/xla.pb.h"
-#include "tsl/platform/statusor.h"
-#include "tsl/platform/test.h"
 
 namespace xla::gpu {
 

--- a/xla/backends/gpu/tests/triton_tdm_elemwise.hlo
+++ b/xla/backends/gpu/tests/triton_tdm_elemwise.hlo
@@ -13,6 +13,10 @@
 // CHECK-mi200: @llvm.amdgcn.raw.ptr.buffer.load
 // CHECK-mi200-NOT: @llvm.amdgcn.{{(tensor\.|s\.wait\.tensorcnt)}}
 
+// CHECK-mi350-NOT: @llvm.amdgcn.{{(tensor\.|s\.wait\.tensorcnt)}}
+// CHECK-mi350: @llvm.amdgcn.raw.ptr.buffer.load
+// CHECK-mi350-NOT: @llvm.amdgcn.{{(tensor\.|s\.wait\.tensorcnt)}}
+
 // CHECK-PTX: define
 // CHECK-PTX-NOT: @llvm.amdgcn
 

--- a/xla/backends/gpu/transforms/priority_fusion_test.cc
+++ b/xla/backends/gpu/transforms/priority_fusion_test.cc
@@ -1596,5 +1596,81 @@ CHECK: ROOT %{{.*}} = (s8[2,256,512]{2,1,0}, bf16[2,256,4]{2,1,0}) tuple(%[[QUAN
                             /*after_pass_checks=*/nullptr, &config);
 }
 
+// Verifies that device memory bandwidth drives PriorityFusion's reduce-into-
+// consumers decision (the ROCm gfx950 case behind rocm_memory_bandwidth.cc).
+// A reduce feeds two elementwise consumers. Duplicating the reduce into a
+// consumer re-reads the large input from HBM, so whether it pays off depends on
+// bandwidth:
+//   - low (legacy formula) bandwidth  -> re-read too costly, reduce stays a
+//     standalone fusion, consumers unfused -> 1 fusion.
+//   - high (corrected) bandwidth      -> re-read cheap, reduce duplicated into
+//     both consumers -> 2 fusions.
+// Counted right after PriorityFusion; for the full-compiler behavior (a later
+// pass merges the two back into one) see memory_bandwidth_fusion.hlo.
+class PriorityFusionRocmMemoryBandwidthTest
+    : public HloHardwareIndependentTestBase {
+ public:
+  PriorityFusionRocmMemoryBandwidthTest() {
+    RegisterSymbolicExprStorage(&mlir_context_);
+  }
+
+  int RunAndCountFusions(absl::string_view hlo, int64_t memory_bandwidth) {
+    se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI350DeviceInfo();
+    device_info.set_memory_bandwidth(memory_bandwidth);
+
+    GpuHloCostAnalysis::Options options;
+    options.count_multiple_input_accesses = true;
+    PriorityFusion priority_fusion(/*thread_pool=*/nullptr, device_info,
+                                   &alias_info_, options, &mlir_context_);
+
+    auto module = ParseAndReturnVerifiedModule(hlo).value();
+    EXPECT_THAT(priority_fusion.Run(module.get()),
+                absl_testing::IsOkAndHolds(true));
+    EXPECT_THAT(module->RemoveUnusedComputations(), absl_testing::IsOk());
+
+    int fusion_count = 0;
+    for (auto computation : module->computations()) {
+      if (computation->FusionInstruction() != nullptr) {
+        ++fusion_count;
+      }
+    }
+    return fusion_count;
+  }
+
+  mlir::MLIRContext mlir_context_;
+  AliasInfo alias_info_;
+};
+
+TEST_F(PriorityFusionRocmMemoryBandwidthTest, MemoryBandwidthTipsReduceFusion) {
+  absl::string_view kHlo = R"(
+    HloModule rf_8_256_1152
+
+    add {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT r = f32[] add(a, b)
+    }
+
+    ENTRY main {
+      p = f32[8,256,1152]{2,1,0} parameter(0)
+      w1 = f32[256,1152]{1,0} parameter(1)
+      w2 = f32[256,1152]{1,0} parameter(2)
+      z = f32[] constant(0)
+      red = f32[256,1152]{1,0} reduce(p, z), dimensions={0}, to_apply=add
+      c1 = f32[256,1152]{1,0} add(red, w1)
+      c2 = f32[256,1152]{1,0} subtract(red, w2)
+      ROOT out = (f32[256,1152]{1,0}, f32[256,1152]{1,0}) tuple(c1, c2)
+    })";
+
+  // gfx950 legacy formula bandwidth: 2 * (8192/8) * 1.9e9 = 3.8912 TB/s.
+  constexpr int64_t kFormulaBandwidth = 3'891'200'000'000;
+  // gfx950 corrected per-gfx bandwidth (rocm_memory_bandwidth.cc).
+  constexpr int64_t kFixedBandwidth = 6'810'000'000'000;
+
+  // The bandwidth value changes the PriorityFusion decision for this HLO.
+  EXPECT_EQ(RunAndCountFusions(kHlo, kFormulaBandwidth), 1);
+  EXPECT_EQ(RunAndCountFusions(kHlo, kFixedBandwidth), 2);
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/lit.bzl
+++ b/xla/lit.bzl
@@ -230,7 +230,7 @@ def lit_test_suite_for_gpus(
     # If there are kwargs that need to be passed to only some of the generated
     # rules, they should be extracted into separate named arguments.
 
-    rocm_gpus = ["mi200", "gfx1250"]
+    rocm_gpus = ["mi200", "mi350", "gfx1250"]
 
     for gpu in gpus:
         is_rocm = gpu in rocm_gpus

--- a/xla/service/gpu/gpu_device_info_for_tests.cc
+++ b/xla/service/gpu/gpu_device_info_for_tests.cc
@@ -135,6 +135,33 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI210DeviceInfo() {
   return b;
 }
 
+stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI350DeviceInfo() {
+  stream_executor::DeviceDescription b;
+  b.set_gpu_compute_capability(stream_executor::GpuComputeCapability(
+      stream_executor::RocmComputeCapability("gfx950")));
+  b.set_threads_per_block_limit(1024);
+  b.set_threads_per_warp(64);
+  b.set_shared_memory_per_block(160 * 1024);
+  b.set_shared_memory_per_block_optin(160 * 1024);
+  b.set_shared_memory_per_core(160 * 1024);
+  b.set_threads_per_core_limit(2048);
+  b.set_core_count(256);
+  b.set_fpus_per_core(128);
+  b.set_block_dim_limit_x(2'147'483'647);
+  b.set_block_dim_limit_y(65536);
+  b.set_block_dim_limit_z(65536);
+  // Keep in sync with GetRocmMemoryBandwidth in rocm_memory_bandwidth.cc.
+  b.set_memory_bandwidth(6'810'000'000'000);
+  b.set_l2_cache_size(4 * 1024 * 1024);
+  b.set_clock_rate_ghz(2.2);
+  b.set_device_memory_size(270'566'162'432);
+  b.set_registers_per_core_limit(131072);
+  b.set_registers_per_block_limit(131072);
+  b.set_runtime_version(stream_executor::SemanticVersion{6, 0, 0});
+  b.set_driver_version(stream_executor::SemanticVersion{6, 0, 0});
+  return b;
+}
+
 stream_executor::DeviceDescription TestGpuDeviceInfo::AMDRX7900DeviceInfo() {
   stream_executor::DeviceDescription b;
   b.set_gpu_compute_capability(stream_executor::GpuComputeCapability(

--- a/xla/service/gpu/gpu_device_info_for_tests.h
+++ b/xla/service/gpu/gpu_device_info_for_tests.h
@@ -37,6 +37,7 @@ class TestGpuDeviceInfo {
           stream_executor::GpuComputeCapability{
               stream_executor::CudaComputeCapability(10, 0)});
   static stream_executor::DeviceDescription AMDMI210DeviceInfo();
+  static stream_executor::DeviceDescription AMDMI350DeviceInfo();
   static stream_executor::DeviceDescription AMDRX7900DeviceInfo();
   // Returns default RTXA6000 or AMDMI210 device info
   static stream_executor::DeviceDescription CudaOrRocmDeviceInfo();

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -143,6 +143,7 @@ cc_library(
         ":rocm_context",
         ":rocm_event",
         ":rocm_kernel",
+        ":rocm_memory_bandwidth",
         ":rocm_pcie_bandwidth",
         ":rocm_platform_id",
         ":rocm_status",
@@ -401,6 +402,19 @@ cc_library(
         "@com_google_absl//absl/synchronization",
         "@local_config_rocm//rocm:rocm_headers",
         "@local_config_rocm//rocm:rocm_smi",
+    ],
+)
+
+cc_library(
+    name = "rocm_memory_bandwidth",
+    srcs = ["rocm_memory_bandwidth.cc"],
+    hdrs = ["rocm_memory_bandwidth.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_compute_capability",
     ],
 )
 

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -15,8 +15,6 @@ limitations under the License.
 
 #include "xla/stream_executor/rocm/rocm_executor.h"
 
-#include <unistd.h>
-
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -79,6 +77,7 @@ limitations under the License.
 #include "xla/stream_executor/rocm/rocm_context.h"
 #include "xla/stream_executor/rocm/rocm_event.h"
 #include "xla/stream_executor/rocm/rocm_kernel.h"
+#include "xla/stream_executor/rocm/rocm_memory_bandwidth.h"
 #include "xla/stream_executor/rocm/rocm_pcie_bandwidth.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/stream_executor/rocm/rocm_status.h"
@@ -1107,11 +1106,13 @@ RocmExecutor::CreateDeviceDescription(int device_ordinal) {
     float clock_rate_ghz = static_cast<float>(prop.clockRate) / 1e6;
     desc.set_clock_rate_ghz(clock_rate_ghz);
 
-    // mem_bandwidth = 2 * mem_bus_width_in_bytes * mem_clock_rate_in_hz
-    int64_t memory_bandwidth =
-        2 * (static_cast<int64_t>(prop.memoryBusWidth) / 8) *
-        (static_cast<int64_t>(prop.memoryClockRate) * 1000);
-    desc.set_memory_bandwidth(memory_bandwidth);
+    // HIP reports the memory controller clock (UCLK), not the data-rate clock,
+    // so the legacy `2 * bus * clock` formula undercounts on HBM3+/GDDR6.
+    // GetRocmMemoryBandwidth uses a per-gfx peak for known architectures and
+    // falls back to that formula for unmodeled arches.
+    desc.set_memory_bandwidth(
+        gpu::GetRocmMemoryBandwidth(RocmComputeCapability(gcn_arch_name),
+                                    prop.memoryBusWidth, prop.memoryClockRate));
 
     desc.set_l2_cache_size(prop.l2CacheSize);
   }

--- a/xla/stream_executor/rocm/rocm_memory_bandwidth.cc
+++ b/xla/stream_executor/rocm/rocm_memory_bandwidth.cc
@@ -1,0 +1,46 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_memory_bandwidth.h"
+
+#include <cstdint>
+
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+constexpr int64_t kGbps = int64_t{1000} * 1000 * 1000;
+
+}  // namespace
+
+int64_t GetRocmMemoryBandwidth(const RocmComputeCapability& cc,
+                               int64_t mem_bus_width_bits,
+                               int64_t mem_clock_khz) {
+  // On HBM2/HBM2e (gfx908 MI100, gfx90a MI210) the formula `2 * bus_width *
+  // clock` lands at spec peak, so those arches fall through to it. On
+  // HBM3/HBM3e (gfx942 MI300X, gfx950 MI350X) and GDDR6 (gfx1201) the formula
+  // falls short of spec peak, so an explicit per-gfx value is used instead.
+  if (cc.gfx9_mi300()) return 5300 * kGbps;  // MI300X, HBM3
+  // TODO: MI355X shares gfx950 with MI350X but has a higher peak; the per-board
+  // value can be read from amd_smi gpu_metrics. Postponed because amd_smi
+  // embeds a copy of rocm_smi and exports the same symbols, which clash with
+  // the rocm_smi that RCCL pulls into the process. Revisit once the ROCm floor
+  // is >= 7.13 (where RCCL no longer depends on rocm_smi).
+  if (cc.gfx9_mi350()) return 6810 * kGbps;     // MI350X, HBM3e
+  if (cc.gfx12_discrete()) return 640 * kGbps;  // RX 9070 XT, GDDR6
+
+  // mem_bandwidth = 2 * mem_bus_width_in_bytes * mem_clock_rate_in_hz
+  return 2 * (mem_bus_width_bits / 8) * (mem_clock_khz * 1000);
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_memory_bandwidth.h
+++ b/xla/stream_executor/rocm/rocm_memory_bandwidth.h
@@ -1,0 +1,38 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_BANDWIDTH_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_BANDWIDTH_H_
+
+#include <cstdint>
+
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
+
+namespace stream_executor::gpu {
+
+// Returns the device memory (HBM/GDDR) bandwidth in bytes/second.
+//
+// The legacy `2 * bus_width * clock` formula lands at spec peak on HBM2/HBM2e
+// but falls short on HBM3/HBM3e and GDDR6. The value is resolved in two tiers,
+// first hit wins:
+//   1. a per-gfx peak for architectures the formula gets wrong;
+//   2. the legacy formula otherwise (correct on HBM2/HBM2e).
+//
+// `mem_bus_width_bits` and `mem_clock_khz` come from hipDeviceProp_t
+// (memoryBusWidth, memoryClockRate) and feed the formula.
+int64_t GetRocmMemoryBandwidth(const RocmComputeCapability& cc,
+                               int64_t mem_bus_width_bits,
+                               int64_t mem_clock_khz);
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_BANDWIDTH_H_


### PR DESCRIPTION
The legacy `2 * bus_width * mem_clock` formula undercounts memory bandwidth on HBM3/HBM3e (MI300X, MI350X) and GDDR6 (RX 9070 XT) because HIP reports the controller clock (UCLK), not the data-rate clock (~1.7x low on MI350X), skewing the GPU cost model's fusion decisions.

GetRocmMemoryBandwidth returns a per-gfx spec peak for those arches and falls back to the formula otherwise (still correct on HBM2/HBM2e).

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
