### PR TITLE
Enable collective tests

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -536,14 +536,13 @@ cc_library(
     alwayslink = True,  # registers collectives implementation
 )
 
-xla_cc_test(
+xla_test(
     name = "loopback_collectives_test",
     srcs = ["loopback_collectives_test.cc"],
-    tags = [
-        "cuda-only",
-        "gpu",
+    backends = ["gpu"],
+    tags = if_cuda_is_configured([
         "requires-gpu-nvidia",
-    ],
+    ]),
     deps = [
         ":gpu_clique_key",
         ":gpu_collectives",
@@ -559,13 +558,16 @@ xla_cc_test(
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
-        "//xla/stream_executor/cuda:cuda_platform",
         "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
-    ],
+    ] + if_cuda_is_configured([
+        "//xla/stream_executor/cuda:cuda_platform",
+    ]) + if_rocm_is_configured([
+        "//xla/stream_executor/rocm:rocm_platform",
+    ]),
 )
 
 cc_library(

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -346,14 +346,18 @@ cc_library(
     ],
 )
 
-xla_cc_test(
+xla_test(
     name = "gpu_collectives_test",
     srcs = ["gpu_collectives_test.cc"],
-    tags = [
-        "cuda-only",
-        "gpu",
+    backend_tags = {
+        "gpu": [
+            "multi_gpu",
+        ],
+    },
+    backends = ["gpu"],
+    tags = if_cuda_is_configured([
         "requires-gpu-nvidia:2",
-    ],
+    ]),
     deps = [
         ":allocator_memory_registration",
         ":cancellation_token",
@@ -376,8 +380,6 @@ xla_cc_test(
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
-        "//xla/stream_executor/cuda:cuda_compute_capability",
-        "//xla/stream_executor/cuda:cuda_platform",
         "//xla/tsl/concurrency:executor",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:status_macros",
@@ -389,7 +391,13 @@ xla_cc_test(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",  # buildcleaner: keep
-    ],
+    ] + if_cuda_is_configured([
+        "//xla/stream_executor/cuda:cuda_platform",
+        "//xla/stream_executor/cuda:cuda_compute_capability",
+    ]) + if_rocm_is_configured([
+        "//xla/stream_executor/rocm:rocm_platform",
+        "//xla/stream_executor/rocm:rocm_compute_capability",
+    ]),
 )
 
 xla_test(

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -5,6 +5,7 @@ load("//xla/stream_executor:build_defs.bzl", "if_cuda_or_rocm_is_configured")
 load("//xla/tests:build_defs.bzl", "xla_test")
 load("//xla/tsl:tsl.bzl", "if_google", "if_nccl", "internal_visibility")
 load("//xla/tsl/platform:rules_cc.bzl", "cc_library")
+load("//xla/tsl/platform/default:cuda_build_defs.bzl", "if_cuda_is_configured")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -250,7 +251,6 @@ xla_test(
         ":gpu_cliques",
         ":gpu_collectives",
         ":loopback_collectives",
-        ":nccl_or_rccl_collectives",  # fixdeps: keep
         "//xla:executable_run_options",
         "//xla:future",
         "//xla/core/collectives",
@@ -270,10 +270,13 @@ xla_test(
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",  # fixdeps: keep
         "@tsl//tsl/platform:casts",
-    ] + if_cuda_is_configured([
+    ] + if_cuda_or_rocm_is_configured([
+        ":nccl_or_rccl_collectives",
+    ]) + if_cuda_is_configured([
         "//xla/stream_executor/cuda:cuda_platform",
     ]) + if_rocm_is_configured([
         "//xla/stream_executor/rocm:rocm_platform",
@@ -366,7 +369,6 @@ xla_test(
         ":gpu_clique_key",
         ":gpu_collectives",
         ":gpu_communicator",
-        ":nccl_or_rccl_collectives",  # buildcleaner: keep
         "//xla:future",
         "//xla:xla_data_proto_cc",
         "//xla/core/collectives:communicator",
@@ -374,12 +376,14 @@ xla_test(
         "//xla/core/collectives:reduction_kind",
         "//xla/core/collectives:registered_memory",
         "//xla/runtime:device_id",
+        "//xla/service:platform_util",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:memory_allocation",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/cuda:cuda_compute_capability",
         "//xla/tsl/concurrency:executor",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:status_macros",
@@ -391,12 +395,12 @@ xla_test(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",  # buildcleaner: keep
-    ] + if_cuda_is_configured([
+    ] + if_cuda_or_rocm_is_configured([
+        ":nccl_or_rccl_collectives",
+    ]) + if_cuda_is_configured([
         "//xla/stream_executor/cuda:cuda_platform",
-        "//xla/stream_executor/cuda:cuda_compute_capability",
     ]) + if_rocm_is_configured([
         "//xla/stream_executor/rocm:rocm_platform",
-        "//xla/stream_executor/rocm:rocm_compute_capability",
     ]),
 )
 
@@ -553,6 +557,7 @@ xla_test(
         "//xla/core/collectives:communicator",
         "//xla/core/collectives:rank_id",
         "//xla/runtime:device_id",
+        "//xla/service:platform_util",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_manager",
@@ -561,6 +566,7 @@ xla_test(
         "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
     ] + if_cuda_is_configured([
@@ -650,7 +656,7 @@ xla_cc_test(
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@local_config_rocm//rocm:rccl", 
+        "@local_config_rocm//rocm:rccl",
     ],
 )
 

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -615,6 +615,46 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "rccl_types",
+    srcs = ["rccl_types.cc"],
+    hdrs = ["rccl_types.h"],
+    tags = [
+        "rocm-only",
+        "gpu",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//xla:shape_util",
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/core/collectives:reduction_kind",
+        "//xla/stream_executor/rocm:rocm_compute_capability",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
+xla_cc_test(
+    name = "rccl_types_test",
+    srcs = ["rccl_types_test.cc"],
+    tags = [
+        "rocm-only",
+        "gpu",
+    ],
+    deps = [
+        ":rccl_types",
+        "//xla:xla_data_proto_cc",
+        "//xla/core/collectives:reduction_kind",
+        "//xla/stream_executor/rocm:rocm_compute_capability",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:rccl", 
+    ],
+)
+
+cc_library(
     name = "nccl_errors",
     srcs = ["nccl_errors.cc"],
     hdrs = ["nccl_errors.h"],
@@ -1019,6 +1059,7 @@ cc_library(
         ":rccl_errors",
         ":rccl_group",
         ":rccl_symmetric_memory",
+        ":rccl_types",
         ":single_threaded_executor",
         "//xla:future",
         "//xla:shape_util",

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -232,14 +232,18 @@ cc_library(
     ],
 )
 
-xla_cc_test(
+xla_test(
     name = "gpu_cliques_test",
     srcs = ["gpu_cliques_test.cc"],
-    tags = [
-        "cuda-only",
-        "gpu",
+    backend_tags = {
+        "gpu": [
+            "multi_gpu",
+        ],
+    },
+    backends = ["gpu"],
+    tags = if_cuda_is_configured([
         "requires-gpu-nvidia:2",
-    ],
+    ]),
     deps = [
         ":gpu_clique",
         ":gpu_clique_key",
@@ -258,7 +262,7 @@ xla_cc_test(
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:stream_executor_h",
-        "//xla/stream_executor/cuda:cuda_platform",
+        "//xla/service:platform_util",
         "//xla/tsl/concurrency:executor",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:status_macros",
@@ -269,7 +273,11 @@ xla_cc_test(
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",  # fixdeps: keep
         "@tsl//tsl/platform:casts",
-    ],
+    ] + if_cuda_is_configured([
+        "//xla/stream_executor/cuda:cuda_platform",
+    ]) + if_rocm_is_configured([
+        "//xla/stream_executor/rocm:rocm_platform",
+    ]),
 )
 
 cc_library(

--- a/xla/backends/gpu/collectives/gpu_cliques_test.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques_test.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "absl/cleanup/cleanup.h"
 #include "absl/log/check.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/ascii.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/collectives/gpu_clique.h"
@@ -39,10 +40,10 @@ limitations under the License.
 #include "xla/executable_run_options.h"
 #include "xla/future.h"
 #include "xla/runtime/device_id.h"
+#include "xla/service/platform_util.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
 #include "xla/stream_executor/stream_executor.h"
-#include "xla/service/platform_util.h"
 #include "xla/tsl/concurrency/executor.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/threadpool.h"
@@ -158,7 +159,7 @@ TEST(GpuCliquesTest, AcquireCliques) {
 TEST(GpuCliquesTest, OnGpuCliqueCreatedCallback) {
   auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
   auto name = absl::AsciiStrToUpper(
-    xla::PlatformUtil::CanonicalPlatformName("gpu").value());
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
 
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
                        se::PlatformManager::PlatformWithName(name));
@@ -203,7 +204,7 @@ TEST(GpuCliquesTest, OnGpuCliqueCreatedCallback) {
 TEST(GpuCliquesTest, SplitCliques) {
   auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
   auto name = absl::AsciiStrToUpper(
-    xla::PlatformUtil::CanonicalPlatformName("gpu").value());
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
 
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
                        se::PlatformManager::PlatformWithName(name));

--- a/xla/backends/gpu/collectives/gpu_cliques_test.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques_test.cc
@@ -42,6 +42,7 @@ limitations under the License.
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/service/platform_util.h"
 #include "xla/tsl/concurrency/executor.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/threadpool.h"
@@ -125,9 +126,10 @@ WaitCliques(std::vector<Future<std::shared_ptr<LockableGpuClique::Lock>>> fs) {
 
 TEST(GpuCliquesTest, AcquireCliques) {
   auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
-
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
@@ -155,9 +157,11 @@ TEST(GpuCliquesTest, AcquireCliques) {
 
 TEST(GpuCliquesTest, OnGpuCliqueCreatedCallback) {
   auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
+  auto name = absl::AsciiStrToUpper(
+    xla::PlatformUtil::CanonicalPlatformName("gpu").value());
 
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
@@ -198,9 +202,11 @@ TEST(GpuCliquesTest, OnGpuCliqueCreatedCallback) {
 
 TEST(GpuCliquesTest, SplitCliques) {
   auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
+  auto name = absl::AsciiStrToUpper(
+    xla::PlatformUtil::CanonicalPlatformName("gpu").value());
 
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 4) {
     GTEST_SKIP() << "Test requires at least 4 GPUs";
@@ -249,9 +255,11 @@ TEST(GpuCliquesTest, SplitCliques) {
 
 TEST(GpuCliquesTest, SplitCliquesNoDeadlock0) {
   auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
 
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 4) {
     GTEST_SKIP() << "Test requires at least 4 GPUs";
@@ -306,9 +314,11 @@ TEST(GpuCliquesTest, SplitCliquesNoDeadlock0) {
 
 TEST(GpuCliquesTest, SplitCliquesNoDeadlock1) {
   auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
 
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 4) {
     GTEST_SKIP() << "Test requires at least 4 GPUs";
@@ -369,9 +379,11 @@ TEST(GpuCliquesTest, SplitCliquesNoDeadlock1) {
 // abandon.
 TEST(GpuCliquesTest, ParentSupersetSkipsAbandon) {
   auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
 
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 8) {
     GTEST_SKIP() << "Test requires at least 8 GPUs";
@@ -479,9 +491,11 @@ TEST(GpuCliquesTest, ParentSupersetSkipsAbandon) {
 // communicators for the same clique key.
 TEST(GpuCliquesTest, DifferentCollectivesProduceDifferentCliques) {
   auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
 
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -44,11 +44,13 @@ limitations under the License.
 #include "xla/core/collectives/registered_memory.h"
 #include "xla/future.h"
 #include "xla/runtime/device_id.h"
+#include "xla/service/platform_util.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/concurrency/executor.h"
@@ -65,8 +67,10 @@ static constexpr GlobalDeviceId kD2(2);
 static constexpr GlobalDeviceId kD3(3);
 
 TEST(GpuCollectivesTest, CreateWithMultipleIds) {
+  auto name = absl::AsciiStrToUpper(
+    xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
@@ -84,8 +88,10 @@ TEST(GpuCollectivesTest, CreateWithMultipleIds) {
 }
 
 TEST(GpuCollectivesTest, SplitCommunicators) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
@@ -108,8 +114,10 @@ TEST(GpuCollectivesTest, SplitCommunicators) {
 }
 
 TEST(GpuCollectivesTest, GroupLaunchMultipleCommunicators) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 4) {
     GTEST_SKIP() << "Test requires at least 4 GPUs";
@@ -200,8 +208,10 @@ TEST(GpuCollectivesTest, GroupLaunchMultipleCommunicators) {
 }
 
 TEST(GpuCollectivesTest, CreateSymmetricMemory) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
@@ -237,8 +247,10 @@ TEST(GpuCollectivesTest, CreateSymmetricMemory) {
 }
 
 TEST(GpuCollectivesTest, CreateRegisteredMemory) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
@@ -268,8 +280,10 @@ TEST(GpuCollectivesTest, CreateRegisteredMemory) {
 }
 
 TEST(GpuCollectivesTest, CreateSymmetricMemoryOnDifferentComms) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 4) {
     GTEST_SKIP() << "Test requires at least 4 GPUs";
@@ -313,8 +327,10 @@ TEST(GpuCollectivesTest, CreateSymmetricMemoryOnDifferentComms) {
 }
 
 TEST(GpuCollectivesTest, CreateDeviceComm) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
@@ -369,8 +385,10 @@ static void AssertEventAborted(Future<> future) {
 TEST_P(GpuAbortCollectivesTest, Abort) {
   bool blocking = GetParam();
 
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
@@ -416,8 +434,10 @@ INSTANTIATE_TEST_SUITE_P(GpuAbortCollectives, GpuAbortCollectivesTest,
                          testing::Values(true, false));
 
 TEST(GpuCollectivesTest, PutAndWaitSignal) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
@@ -428,10 +448,8 @@ TEST(GpuCollectivesTest, PutAndWaitSignal) {
   if (!executors[0]->CanEnablePeerAccessTo(executors[1])) {
     GTEST_SKIP() << "Test requires peer access between devices";
   }
-  if (!executors[0]
-           ->GetDeviceDescription()
-           .cuda_compute_capability()
-           .IsAtLeastHopper()) {
+  if (auto cc = executors[0]->GetDeviceDescription().gpu_compute_capability(); 
+      cc.IsCuda() && !cc.cuda_compute_capability()->IsAtLeastHopper()) {
     GTEST_SKIP() << "Test requires at least Hopper architecture";
   }
 

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/ascii.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/collectives/allocator_memory_registration.h"
@@ -50,7 +51,6 @@ limitations under the License.
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
-#include "xla/stream_executor/rocm/rocm_compute_capability.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/concurrency/executor.h"
@@ -68,7 +68,7 @@ static constexpr GlobalDeviceId kD3(3);
 
 TEST(GpuCollectivesTest, CreateWithMultipleIds) {
   auto name = absl::AsciiStrToUpper(
-    xla::PlatformUtil::CanonicalPlatformName("gpu").value());
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
                        se::PlatformManager::PlatformWithName(name));
 
@@ -448,7 +448,7 @@ TEST(GpuCollectivesTest, PutAndWaitSignal) {
   if (!executors[0]->CanEnablePeerAccessTo(executors[1])) {
     GTEST_SKIP() << "Test requires peer access between devices";
   }
-  if (auto cc = executors[0]->GetDeviceDescription().gpu_compute_capability(); 
+  if (auto cc = executors[0]->GetDeviceDescription().gpu_compute_capability();
       cc.IsCuda() && !cc.cuda_compute_capability()->IsAtLeastHopper()) {
     GTEST_SKIP() << "Test requires at least Hopper architecture";
   }

--- a/xla/backends/gpu/collectives/loopback_collectives_test.cc
+++ b/xla/backends/gpu/collectives/loopback_collectives_test.cc
@@ -32,6 +32,7 @@ limitations under the License.
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/runtime/device_id.h"
+#include "xla/service/platform_util.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
@@ -135,8 +136,10 @@ SplitCommunicators(
 // Verifies that LoopbackCollectives fits into the clique acquisition API by
 // creating communicators through CreateCommunicators.
 TEST(LoopbackCollectivesTest, CreateCommunicators) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 1) {
     GTEST_SKIP() << "Test requires at least 1 GPU";
@@ -155,8 +158,10 @@ TEST(LoopbackCollectivesTest, CreateCommunicators) {
 
 // Verifies that LoopbackCollectives can create multi-rank communicators.
 TEST(LoopbackCollectivesTest, CreateMultiRankCommunicators) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
@@ -177,8 +182,10 @@ TEST(LoopbackCollectivesTest, CreateMultiRankCommunicators) {
 
 // Verifies that LoopbackCollectives supports SplitCommunicators.
 TEST(LoopbackCollectivesTest, SplitCommunicators) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
@@ -200,8 +207,10 @@ TEST(LoopbackCollectivesTest, SplitCommunicators) {
 
 // Verifies that AllReduce copies send to recv on a single device.
 TEST(LoopbackCollectivesTest, AllReduce) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 1) {
     GTEST_SKIP() << "Test requires at least 1 GPU";
@@ -244,8 +253,10 @@ TEST(LoopbackCollectivesTest, AllReduce) {
 
 // Verifies that AllGather replicates input into every rank's slot.
 TEST(LoopbackCollectivesTest, AllGather) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 1) {
     GTEST_SKIP() << "Test requires at least 1 GPU";
@@ -291,8 +302,10 @@ TEST(LoopbackCollectivesTest, AllGather) {
 
 // Verifies that CollectivePermute copies send to recv (loopback).
 TEST(LoopbackCollectivesTest, CollectivePermute) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(name));
 
   if (platform->VisibleDeviceCount() < 1) {
     GTEST_SKIP() << "Test requires at least 1 GPU";

--- a/xla/backends/gpu/collectives/loopback_collectives_test.cc
+++ b/xla/backends/gpu/collectives/loopback_collectives_test.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/ascii.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"

--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -44,6 +44,7 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/rccl_errors.h"
 #include "xla/backends/gpu/collectives/rccl_group.h"
 #include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
+#include "xla/backends/gpu/collectives/rccl_types.h"
 #include "xla/backends/gpu/collectives/single_threaded_executor.h"
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
@@ -70,79 +71,6 @@ hipStream_t AsHipStream(se::Stream* stream) {
 
 se::Stream* ToStream(const Communicator::Executor& executor) {
   return absl::down_cast<const GpuCollectives::Executor&>(executor).stream();
-}
-
-//==-----------------------------------------------------------------------===//
-// Conversions between XLA and RCCL data types
-//==-----------------------------------------------------------------------===//
-
-static size_t ToNcclCount(PrimitiveType dtype, size_t count) {
-  return primitive_util::IsComplexType(dtype) ? count * 2 : count;
-}
-
-static absl::StatusOr<ncclDataType_t> ToNcclDataType(
-    PrimitiveType dtype, bool is_reduction_op,
-    se::RocmComputeCapability rocm_cc) {
-  switch (dtype) {
-    case F8E5M2:
-      return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e5m2 : ncclInt8;
-    case F8E4M3FN:
-      return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e4m3 : ncclInt8;
-    case S8:
-    case F8E5M2FNUZ:
-    case F8E4M3FNUZ:
-    case F8E8M0FNU:
-      return ncclInt8;
-    case PRED:
-    case U8:
-      return ncclUint8;
-    case S32:
-      return ncclInt32;
-    case U32:
-      return ncclUint32;
-    case S64:
-      return ncclInt64;
-    case U64:
-      return ncclUint64;
-    case F16:
-      return ncclFloat16;
-    case F32:
-    case C64:
-      return ncclFloat32;
-    case F64:
-    case C128:
-      return ncclFloat64;
-    case S16:
-    case U16:
-      // For reductions we expect 16 bit integer types to be promoted to 32-bit.
-      if (is_reduction_op) {
-        return absl::InvalidArgumentError(
-            absl::StrFormat("Unsupported data type for reduction operation: %s",
-                            primitive_util::LowercasePrimitiveTypeName(dtype)));
-      }
-      // For collectives that just move data around, we can use ncclFloat16 for
-      // 16-bit integer data types.
-      return ncclFloat16;
-    case BF16:
-      return ncclBfloat16;
-    default:
-      return absl::InvalidArgumentError(
-          absl::StrFormat("Unsupported data type: %s",
-                          primitive_util::LowercasePrimitiveTypeName(dtype)));
-  }
-}
-
-static ncclRedOp_t ToNcclReduction(ReductionKind kind) {
-  switch (kind) {
-    case ReductionKind::SUM:
-      return ncclSum;
-    case ReductionKind::PRODUCT:
-      return ncclProd;
-    case ReductionKind::MIN:
-      return ncclMin;
-    case ReductionKind::MAX:
-      return ncclMax;
-  }
 }
 
 }  // namespace

--- a/xla/backends/gpu/collectives/rccl_types.cc
+++ b/xla/backends/gpu/collectives/rccl_types.cc
@@ -1,0 +1,99 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_types.h"
+
+#include <cstddef>
+
+#include "absl/status/statusor.h"
+#include "rocm/include/rccl/rccl.h"
+#include "xla/core/collectives/reduction_kind.h"
+#include "xla/primitive_util.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
+#include "xla/util.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+size_t ToNcclCount(PrimitiveType dtype, size_t count) {
+  return primitive_util::IsComplexType(dtype) ? count * 2 : count;
+}
+
+absl::StatusOr<ncclDataType_t> ToNcclDataType(
+    PrimitiveType dtype, bool is_reduction_op,
+    se::RocmComputeCapability rocm_cc) {
+  switch (dtype) {
+    case F8E5M2:
+      return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e5m2 : ncclInt8;
+    case F8E4M3FN:
+      return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e4m3 : ncclInt8;
+    case S8:
+    case F8E5M2FNUZ:
+    case F8E4M3FNUZ:
+    case F8E8M0FNU:
+      return ncclInt8;
+    case PRED:
+    case U8:
+      return ncclUint8;
+    case S32:
+      return ncclInt32;
+    case U32:
+      return ncclUint32;
+    case S64:
+      return ncclInt64;
+    case U64:
+      return ncclUint64;
+    case F16:
+      return ncclFloat16;
+    case F32:
+    case C64:
+      return ncclFloat32;
+    case F64:
+    case C128:
+      return ncclFloat64;
+    case S16:
+    case U16:
+      // For reductions we expect 16 bit integer types to be promoted to 32-bit.
+      if (is_reduction_op) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Unsupported data type for reduction operation: %s",
+                            primitive_util::LowercasePrimitiveTypeName(dtype)));
+      }
+      // For collectives that just move data around, we can use ncclFloat16 for
+      // 16-bit integer data types.
+      return ncclFloat16;
+    case BF16:
+      return ncclBfloat16;
+    default:
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Unsupported data type: %s",
+                          primitive_util::LowercasePrimitiveTypeName(dtype)));
+  }
+}
+
+ncclRedOp_t ToNcclReduction(ReductionKind kind) {
+  switch (kind) {
+    case ReductionKind::SUM:
+      return ncclSum;
+    case ReductionKind::PRODUCT:
+      return ncclProd;
+    case ReductionKind::MIN:
+      return ncclMin;
+    case ReductionKind::MAX:
+      return ncclMax;
+  }
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/rccl_types.cc
+++ b/xla/backends/gpu/collectives/rccl_types.cc
@@ -33,7 +33,7 @@ size_t ToNcclCount(PrimitiveType dtype, size_t count) {
 
 absl::StatusOr<ncclDataType_t> ToNcclDataType(
     PrimitiveType dtype, bool is_reduction_op,
-    se::RocmComputeCapability rocm_cc) {
+    stream_executor::RocmComputeCapability rocm_cc) {
   switch (dtype) {
     case F8E5M2:
       return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e5m2 : ncclInt8;
@@ -67,9 +67,9 @@ absl::StatusOr<ncclDataType_t> ToNcclDataType(
     case U16:
       // For reductions we expect 16 bit integer types to be promoted to 32-bit.
       if (is_reduction_op) {
-        return absl::InvalidArgumentError(
-            absl::StrFormat("Unsupported data type for reduction operation: %s",
-                            primitive_util::LowercasePrimitiveTypeName(dtype)));
+        return InvalidArgument(
+            "Unsupported data type for reduction operation: %s",
+            primitive_util::LowercasePrimitiveTypeName(dtype));
       }
       // For collectives that just move data around, we can use ncclFloat16 for
       // 16-bit integer data types.
@@ -77,9 +77,8 @@ absl::StatusOr<ncclDataType_t> ToNcclDataType(
     case BF16:
       return ncclBfloat16;
     default:
-      return absl::InvalidArgumentError(
-          absl::StrFormat("Unsupported data type: %s",
-                          primitive_util::LowercasePrimitiveTypeName(dtype)));
+      return InvalidArgument("Unsupported data type: %s",
+                             primitive_util::LowercasePrimitiveTypeName(dtype));
   }
 }
 

--- a/xla/backends/gpu/collectives/rccl_types.h
+++ b/xla/backends/gpu/collectives/rccl_types.h
@@ -1,0 +1,43 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_RCCL_TYPES_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_RCCL_TYPES_H_
+
+#include <cstddef>
+
+#include "absl/status/statusor.h"
+#include "rocm/include/rccl/rccl.h"
+#include "xla/core/collectives/reduction_kind.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+//===----------------------------------------------------------------------===//
+// Conversions between XLA and RCCL data types
+//===----------------------------------------------------------------------===//
+
+size_t ToNcclCount(PrimitiveType dtype, size_t count);
+
+absl::StatusOr<ncclDataType_t> ToNcclDataType(
+    PrimitiveType dtype, bool is_reduction_op,
+    stream_executor::RocmComputeCapability cc);
+
+ncclRedOp_t ToNcclReduction(ReductionKind kind);
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_RCCL_TYPES_H_

--- a/xla/backends/gpu/collectives/rccl_types_test.cc
+++ b/xla/backends/gpu/collectives/rccl_types_test.cc
@@ -1,0 +1,106 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_types.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "rocm/include/rccl/rccl.h"
+#include "xla/core/collectives/reduction_kind.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+namespace se = stream_executor;
+using ::absl_testing::IsOkAndHolds;
+using ::absl_testing::StatusIs;
+
+TEST(NcclTypesTest, ToNcclCountScalar) {
+  EXPECT_EQ(ToNcclCount(F32, 10), 10);
+  EXPECT_EQ(ToNcclCount(S32, 5), 5);
+}
+
+TEST(NcclTypesTest, ToNcclCountComplex) {
+  EXPECT_EQ(ToNcclCount(C64, 10), 20);
+  EXPECT_EQ(ToNcclCount(C128, 5), 10);
+}
+
+TEST(NcclTypesTest, ToNcclDataTypeBasicTypes) {
+  se::RocmComputeCapability cc("gfx950");
+  EXPECT_THAT(ToNcclDataType(F32, false, cc), IsOkAndHolds(ncclFloat32));
+  EXPECT_THAT(ToNcclDataType(F64, false, cc), IsOkAndHolds(ncclFloat64));
+  EXPECT_THAT(ToNcclDataType(F16, false, cc), IsOkAndHolds(ncclFloat16));
+  EXPECT_THAT(ToNcclDataType(BF16, false, cc), IsOkAndHolds(ncclBfloat16));
+  EXPECT_THAT(ToNcclDataType(S32, false, cc), IsOkAndHolds(ncclInt32));
+  EXPECT_THAT(ToNcclDataType(U32, false, cc), IsOkAndHolds(ncclUint32));
+  EXPECT_THAT(ToNcclDataType(S64, false, cc), IsOkAndHolds(ncclInt64));
+  EXPECT_THAT(ToNcclDataType(U64, false, cc), IsOkAndHolds(ncclUint64));
+  EXPECT_THAT(ToNcclDataType(S8, false, cc), IsOkAndHolds(ncclInt8));
+  EXPECT_THAT(ToNcclDataType(U8, false, cc), IsOkAndHolds(ncclUint8));
+  EXPECT_THAT(ToNcclDataType(PRED, false, cc), IsOkAndHolds(ncclUint8));
+}
+
+TEST(NcclTypesTest, ToNcclDataTypeComplexUsesReal) {
+  se::RocmComputeCapability cc("gfx950");
+  EXPECT_THAT(ToNcclDataType(C64, false, cc), IsOkAndHolds(ncclFloat32));
+  EXPECT_THAT(ToNcclDataType(C128, false, cc), IsOkAndHolds(ncclFloat64));
+}
+
+TEST(NcclTypesTest, ToNcclDataType16BitIntNonReduction) {
+  se::RocmComputeCapability cc("gfx950");
+  EXPECT_THAT(ToNcclDataType(S16, false, cc), IsOkAndHolds(ncclFloat16));
+  EXPECT_THAT(ToNcclDataType(U16, false, cc), IsOkAndHolds(ncclFloat16));
+}
+
+TEST(NcclTypesTest, ToNcclDataType16BitIntReductionFails) {
+  se::RocmComputeCapability cc("gfx950");
+  EXPECT_THAT(ToNcclDataType(S16, true, cc),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(ToNcclDataType(U16, true, cc),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(NcclTypesTest, ToNcclDataTypeNoOcpFp8Support) {
+  se::RocmComputeCapability cc("gfx942");
+  EXPECT_THAT(ToNcclDataType(F8E5M2, false, cc), IsOkAndHolds(ncclInt8));
+  EXPECT_THAT(ToNcclDataType(F8E4M3FN, false, cc), IsOkAndHolds(ncclInt8));
+}
+
+TEST(NcclTypesTest, ToNcclDataTypeOcpFp8Support) {
+  se::RocmComputeCapability cc("gfx950");
+  EXPECT_THAT(ToNcclDataType(F8E5M2, false, cc), IsOkAndHolds(ncclFloat8e5m2));
+  EXPECT_THAT(ToNcclDataType(F8E4M3FN, false, cc),
+              IsOkAndHolds(ncclFloat8e4m3));
+}
+
+TEST(NcclTypesTest, ToNcclDataTypeUnsupported) {
+  se::RocmComputeCapability cc("gfx950");
+  EXPECT_THAT(ToNcclDataType(TOKEN, false, cc),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(NcclTypesTest, ToNcclReduction) {
+  EXPECT_EQ(ToNcclReduction(ReductionKind::SUM), ncclSum);
+  EXPECT_EQ(ToNcclReduction(ReductionKind::PRODUCT), ncclProd);
+  EXPECT_EQ(ToNcclReduction(ReductionKind::MIN), ncclMin);
+  EXPECT_EQ(ToNcclReduction(ReductionKind::MAX), ncclMax);
+}
+
+}  // namespace
+}  // namespace xla::gpu


### PR DESCRIPTION
## Motivation

This PR enables:
- `//xla/backends/gpu/collectives:gpu_cliques_test`,
- `//xla/backends/gpu/collectives:gpu_collectives_test`,  and 
- `//xla/backends/gpu/collectives:loopback_collectives_test`. 

It also extracts `ToNcclCount`, `ToNcclDataType` and `ToNcclReduction` from `xla/backends/gpu/collectives/rccl_communicator.cc` to the newly added `xla/backends/gpu/collectives/rccl_types.cc` and adds `xla/backends/gpu/collectives/rccl_types_test.cc`. This mirrors `nccl_types.cc` and `nccl_types_test.cc`.

## Technical Details

1. Switched all enabled tests from `xla_cc_test` to `xla_test` target
2. Generalized enabled tests to use the provided platform instead of hardcoded CUDA
3. As mentioned above, separated `rccl_types` in a separate file and added the appropriate test, mirroring CUDA implementation.

## Test Plan

/

## Test Result

There are five failing subtests in `gpu_collectives_test` which will be addressed later. Other tests are passing.
```
[  FAILED  ] GpuCollectivesTest.CreateRegisteredMemory
[  FAILED  ] GpuCollectivesTest.CreateWithMultipleIds
[  FAILED  ] GpuCollectivesTest.SplitCommunicators
[  FAILED  ] GpuCollectivesTest.CreateSymmetricMemory
[  FAILED  ] GpuCollectivesTest.PutAndWaitSignal
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
