### PR TITLE
CI: enable iota_test

### DIFF
--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -58,7 +58,6 @@ done
     -- \
     //xla/... \
     -//xla/backends/gpu/autotuner:triton_test_amdgpu_any \
-    -//xla/tests:iota_test_amdgpu_any \
     -//xla/backends/gpu/tests:sorting_test_amdgpu_any \
     -//xla/hlo/builder/lib:self_adjoint_eig_test_amdgpu_any
     # TODO: skippped tests from https://wardite.cluster.engflow.com/invocations/default/f6e1d975-7f66-4b51-8430-d79e0ab0493a


### PR DESCRIPTION
## Motivation

It can be enabled after the long running time was fixed by https://github.com/openxla/xla/pull/44130

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
