### PR TITLE
CI: enable triton_test

### DIFF
--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -57,7 +57,6 @@ done
     --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_do_gfx950 \
     -- \
     //xla/... \
-    -//xla/backends/gpu/autotuner:triton_test_amdgpu_any \
     -//xla/backends/gpu/tests:sorting_test_amdgpu_any \
     -//xla/hlo/builder/lib:self_adjoint_eig_test_amdgpu_any
     # TODO: skippped tests from https://wardite.cluster.engflow.com/invocations/default/f6e1d975-7f66-4b51-8430-d79e0ab0493a


### PR DESCRIPTION
## Motivation

The test is passing after openxla#42248 has been merged as openxla@6d6a84b

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
