### PR TITLE
Cherry-pick PR #983 ROCm fixes to rocm-jaxlib-v0.10.2

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -148,6 +148,7 @@ rocm_lib_import(
     data = glob(
         [
             "%{rocm_root}/lib/libamdhip64.so*",
+            "%{rocm_root}/lib/librocm_kpack.so*",
         ],
     ),
     interface_library = "%{rocm_root}/lib/libamdhip64.so",
@@ -195,6 +196,7 @@ cc_library(
             "%{rocm_root}/lib/libamd_comgr_loader.so*",
             "%{rocm_root}/lib/libamd_comgr.so*",
             "%{rocm_root}/lib/llvm/lib/libLLVM.so*",
+            "%{rocm_root}/lib/llvm/lib/libclang-cpp.so*",
         ],
     ),
     deps = [

--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -1,6 +1,5 @@
 load("@rules_cc//cc:cc_import.bzl", "cc_import")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-load("@rules_cc//cc:cc_import.bzl", "cc_import")
 
 # Macros for building ROCm code.
 def if_rocm(if_true, if_false = []):
@@ -84,7 +83,7 @@ def rocm_library(copts = [], deps = [], **kwargs):
 def get_rbe_amdgpu_pool(is_single_gpu = False):
     return "%{single_gpu_rbe_pool}" if is_single_gpu else "%{multi_gpu_rbe_pool}"
 
-def rocm_lib_import(name, interface_library, data, deps=[]):
+def rocm_lib_import(name, interface_library, data, deps):
     cc_import(
         name = name + "_interface",
         shared_library = interface_library,

--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:cc_import.bzl", "cc_import")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
 
 # Macros for building ROCm code.
 def if_rocm(if_true, if_false = []):
@@ -83,7 +84,7 @@ def rocm_library(copts = [], deps = [], **kwargs):
 def get_rbe_amdgpu_pool(is_single_gpu = False):
     return "%{single_gpu_rbe_pool}" if is_single_gpu else "%{multi_gpu_rbe_pool}"
 
-def rocm_lib_import(name, interface_library, data, deps):
+def rocm_lib_import(name, interface_library, data, deps=[]):
     cc_import(
         name = name + "_interface",
         shared_library = interface_library,

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -69,7 +69,7 @@ namespace {
 
 #define ROCBLAS_API_WRAPPER(__name)               \
   struct WrapperShim__##__name {                  \
-    constexpr static const char* kName = #__name; \
+    constexpr static const char *kName = #__name; \
     template <typename... Args>                   \
     rocblas_status operator()(Args... args) {     \
       return (::__name)(args...);                 \

--- a/xla/tsl/platform/default/dso_loader.cc
+++ b/xla/tsl/platform/default/dso_loader.cc
@@ -50,7 +50,6 @@ absl::string_view GetCusparseVersion() { return TF_CUSPARSE_VERSION; }
 absl::string_view GetNcclVersion() { return TF_NCCL_VERSION; }
 absl::string_view GetTensorRTVersion() { return TF_TENSORRT_VERSION; }
 absl::string_view GetNvshmemVersion() { return XLA_NVSHMEM_VERSION; }
-
 absl::StatusOr<void*> GetDsoHandle(const std::string& name,
                                    absl::string_view version) {
   auto filename =


### PR DESCRIPTION
## Motivation

Brings the ROCm release deltas from #983 (`Cherrypick pr932 to v0.10.1`) onto the new `rocm-jaxlib-v0.10.2` branch, which was cut from the JAX 0.10.2 pinned XLA commit `5a9e73cbd92530cac2ac36f4736a774b2412afe2`.

## Commits (cherry-picked with `-x`)

| Commit | Origin | Notes |
|--------|--------|-------|
| `PR #40385: [ROCm] Streamline bazel targets for rocm libraries` | openxla/xla#40385 | partial delta (bulk already in pinned XLA) |
| `PR #41591: [ROCm] Unblock CI after PR #40385` | openxla/xla#41591 | partial delta |
| `[ROCm] Add librocm_kpack and libclang-cpp to runfiles globs` | ROCm 7.13 DT_NEEDED runfiles fix | |
| `Fix formatting error in rocm_blas.cc` | formatting | |

All four applied cleanly onto the pinned base (no empty/dropped commits).

## Files changed

- `third_party/gpus/rocm/build_defs.bzl.tpl`
- `third_party/gpus/rocm/BUILD.tpl`
- `xla/stream_executor/rocm/rocm_blas.cc`
- `xla/tsl/platform/default/dso_loader.cc`

## Test Plan

- Used as the pinned XLA for the JAX `release/0.10.2` release-validation workflow.