### PR TITLE
Cherry-pick ROCm/xla 13dc711: Fix failing tests (#939)

### DIFF
--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -13,7 +13,7 @@ build:rocm_rbe --platforms="@local_config_rocm//rocm:linux_x64"
 build:rocm_rbe --bes_timeout=600s
 build:rocm_rbe --tls_client_certificate="/data/ci-cert.crt"
 build:rocm_rbe --tls_client_key="/data/ci-cert.key"
-build:rocm_rbe --spawn_strategy=remote,local
+build:rocm_rbe --spawn_strategy=local
 build:rocm_rbe --grpc_keepalive_time=30s
 build:rocm_rbe --remote_cache_compression
 

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -23,9 +23,14 @@ TAG_FILTERS=$($SCRIPT_DIR/rocm_tag_filters.sh)
 
 mkdir -p /tf/pkg
 
+EXCLUDED_TESTS=(
+    "F8E4M3FNTests/DotAlgorithmSupportTest.AlgorithmIsSupportedFromCudaCapability/dot_any_f8_any_f8_f32_fast_accum_with_lhs_f8e4m3fn_rhs_f8e4m3fn_output_f8e5m2_from_cc_8_9_rocm_63_no_restriction_c_32_nc_32"
+    "F8E4M3FNTests/DotAlgorithmSupportTest.AlgorithmIsSupportedFromCudaCapability/dot_any_f8_any_f8_f32_fast_accum_with_lhs_f8e4m3fn_rhs_f8e4m3fn_output_f8e5m2_from_cc_8_9_rocm_63_no_restriction_c_16_nc_2"
+)
+
 for arg in "$@"; do
     if [[ "$arg" == "--config=ci_multi_gpu" ]]; then
-        TAG_FILTERS="${TAG_FILTERS},multi_gpu"
+        TAG_FILTERS="${TAG_FILTERS},requires-gpu-rocm,requires-gpu-amd,multi_gpu"
     fi
     if [[ "$arg" == "--config=ci_single_gpu" ]]; then
         TAG_FILTERS="${TAG_FILTERS},requires-gpu-rocm,requires-gpu-amd,-multi_gpu"
@@ -35,7 +40,6 @@ for arg in "$@"; do
     fi
 done
 
-SCRIPT_DIR=$(dirname $0)
 bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \
     --build_tag_filters=$TAG_FILTERS \
     --test_tag_filters=$TAG_FILTERS \
@@ -45,4 +49,16 @@ bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \
     --action_env=XLA_FLAGS="--xla_gpu_enable_llvm_module_compilation_parallelism=true --xla_gpu_force_compilation_parallelism=16" \
     --test_output=errors \
     --run_under=//build_tools/rocm:parallel_gpu_execute \
-    "$@"
+    --test_filter=-$(
+        IFS=:
+        echo "${EXCLUDED_TESTS[*]}"
+    ) \
+    --color=yes \
+    "$@" \
+    -- \
+    //xla/... \
+    -//xla/pjrt/gpu:se_gpu_pjrt_client_test_amdgpu_any \
+    -//xla/tests:iota_test_amdgpu_any \
+    -//xla/backends/gpu/codegen:dynamic_slice_fusion_test_amdgpu_any \
+    -//xla/backends/gpu/tests:ragged_all_to_all_e2e_test_amdgpu_any \
+    -//xla/tests:local_client_execute_test_amdgpu_any


### PR DESCRIPTION
## Motivation

Requested in ROCm/xla#985 review (@i-chaochen): "0.10.2 CI needs this commit 13dc711". Cherry-pick onto `rocm-jaxlib-v0.10.2` (missing from base `5a9e73cb`).

## Commit (cherry-picked with `-x`)

- `13dc711ab5557f9b38c3ef892782421725ccf727` — Fix failing tests (#939)

## Files changed

- `build_tools/rocm/rocm_xla.bazelrc`
- `build_tools/rocm/run_xla_ci_build.sh`

(3-way merge; the squash's workflow-deletion step was a no-op on this base.)

## Test Plan

- ROCm/xla CI on `rocm-jaxlib-v0.10.2`.