### PR TITLE
[WIP] [XLA:GPU] Fix data race in FissionBackend's rewriter pipeline

### DIFF
--- a/xla/backends/gpu/autotuner/factory_cuda.cc
+++ b/xla/backends/gpu/autotuner/factory_cuda.cc
@@ -92,7 +92,9 @@ std::vector<std::unique_ptr<CodegenBackend>> GetCodegenBackendsForCuda(
       debug_options, compiler, target_config,
       std::make_unique<CublasLtBackend>(stream_executor, debug_options,
                                         compiler, target_config),
-      GetCublasLtRewriterPipeline(target_config->device_description),
+      [device_description = target_config->device_description] {
+        return GetCublasLtRewriterPipeline(device_description);
+      },
       alias_info, mlir_context));
   backends.push_back(std::make_unique<NativeEmitterBackend>(
       debug_options, compiler, target_config));

--- a/xla/backends/gpu/autotuner/factory_rocm.cc
+++ b/xla/backends/gpu/autotuner/factory_rocm.cc
@@ -95,8 +95,10 @@ std::vector<std::unique_ptr<CodegenBackend>> GetCodegenBackendsForROCm(
       debug_options, compiler, target_config,
       std::make_unique<HipblasLtBackend>(stream_executor, debug_options,
                                          compiler, target_config),
-      GetGemmRewriterPipeline(target_config->device_description,
-                              absl::Span<const DType>(kAllDTypes)),
+      [device_description = target_config->device_description] {
+        return GetGemmRewriterPipeline(device_description,
+                                       absl::Span<const DType>(kAllDTypes));
+      },
       alias_info, mlir_context));
   backends.push_back(std::make_unique<NativeEmitterBackend>(
       debug_options, compiler, target_config));

--- a/xla/backends/gpu/autotuner/fission_backend.cc
+++ b/xla/backends/gpu/autotuner/fission_backend.cc
@@ -198,7 +198,9 @@ FissionBackend::GetFissionedAndRewrittenModule(
   // pipeline (e.g. GemmRewriter reads xla_gpu_gemm_rewrite_size_threshold) and
   // any subsequent PriorityFusion run observe the correct flag values.
   hlo_module->mutable_config().set_debug_options(debug_options());
-  RETURN_IF_ERROR(rewriter_pipeline_->Run(hlo_module.get()).status());
+  std::unique_ptr<HloPassPipeline> rewriter_pipeline =
+      rewriter_pipeline_factory_();
+  RETURN_IF_ERROR(rewriter_pipeline->Run(hlo_module.get()).status());
   return hlo_module;
 }
 

--- a/xla/backends/gpu/autotuner/fission_backend.h
+++ b/xla/backends/gpu/autotuner/fission_backend.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_BACKENDS_GPU_AUTOTUNER_FISSION_BACKEND_H_
 #define XLA_BACKENDS_GPU_AUTOTUNER_FISSION_BACKEND_H_
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -49,24 +50,30 @@ inline autotuner::Backend GetFissionBackend(autotuner::Backend backend) {
   LOG(FATAL) << "Could not parse fission backend name: " << fission_name;
 }
 
-// A proxy backend that wraps an actual codegen backend. The `rewriter_pipeline`
-// is used to transform unfused instructions to retarget them for the underlying
-// codegen backend.
+// A proxy backend that wraps an actual codegen backend. The pipeline built
+// by `rewriter_pipeline_factory` is used to transform unfused instructions
+// to retarget them for the underlying codegen backend.
 // If multiple supported instructions are found, the first one is profiled, then
 // we use its config for the rest of the supported instructions, provided they
 // are identical. E.g. three 'dots' resulting from "_X3" or "_X6" algorithms are
 // identical.
 class FissionBackend : public GpuCodegenBackend {
  public:
+  using RewriterPipelineFactory =
+      std::function<std::unique_ptr<HloPassPipeline>()>;
+
+  // Builds a fresh HloPassPipeline per call: FissionBackend runs on a
+  // thread pool, and HloPassPipeline::Run() isn't safe to share across
+  // concurrent calls.
   FissionBackend(const DebugOptions* debug_options, Compiler* compiler,
                  const Compiler::GpuTargetConfig* target_config,
                  std::unique_ptr<GpuCodegenBackend> backend,
-                 std::unique_ptr<HloPassPipeline> rewriter_pipeline,
+                 RewriterPipelineFactory rewriter_pipeline_factory,
                  const AliasInfo* alias_info, mlir::MLIRContext* mlir_context,
                  stream_executor::StreamExecutor* stream_executor = nullptr)
       : GpuCodegenBackend(GetFissionBackend(backend->backend()), debug_options,
                           compiler, target_config, stream_executor),
-        rewriter_pipeline_(std::move(rewriter_pipeline)),
+        rewriter_pipeline_factory_(std::move(rewriter_pipeline_factory)),
         codegen_backend_(std::move(backend)),
         alias_info_(alias_info),
         mlir_context_(mlir_context) {}
@@ -97,7 +104,7 @@ class FissionBackend : public GpuCodegenBackend {
   // module has been generated.
   absl::Status RunPriorityFusion(HloModule* module);
 
-  std::unique_ptr<HloPassPipeline> rewriter_pipeline_;
+  RewriterPipelineFactory rewriter_pipeline_factory_;
   std::unique_ptr<GpuCodegenBackend> codegen_backend_;
   const AliasInfo* alias_info_;
   mlir::MLIRContext* mlir_context_;

--- a/xla/backends/gpu/autotuner/fission_backend_test.cc
+++ b/xla/backends/gpu/autotuner/fission_backend_test.cc
@@ -199,7 +199,6 @@ class FissionTest : public HloHardwareIndependentTestBase,
   std::unique_ptr<Compiler> compiler_;
   Compiler::GpuTargetConfig target_config_;
   se::DeviceDescription device_description_;
-  std::unique_ptr<HloPassPipeline> rewriter_pipeline_;
   std::unique_ptr<GpuCodegenBackend> base_codegen_backend_;
   GpuAliasInfo alias_info_;
   std::unique_ptr<FissionBackend> fission_backend_;
@@ -211,14 +210,17 @@ class FissionTest : public HloHardwareIndependentTestBase,
         compiler_(Compiler::GetForPlatform(platform_->id()).value()),
         target_config_(stream_executor_),
         device_description_(stream_executor_->GetDeviceDescription()),
-        rewriter_pipeline_(GetParam().pipeline_factory(device_description_)),
         base_codegen_backend_(
             GetParam().backend_factory(stream_executor_, &debug_options_,
                                        compiler_.get(), &target_config_)),
         alias_info_(device_description_),
         fission_backend_(std::make_unique<FissionBackend>(
             &debug_options_, compiler_.get(), &target_config_,
-            std::move(base_codegen_backend_), std::move(rewriter_pipeline_),
+            std::move(base_codegen_backend_),
+            [pipeline_factory = GetParam().pipeline_factory,
+             device_description = device_description_] {
+              return pipeline_factory(device_description);
+            },
             &alias_info_, &mlir_context_, stream_executor_)) {}
 };
 
@@ -383,8 +385,10 @@ class CublasFissionBackendTest : public HloHardwareIndependentTestBase {
             &debug_options_, compiler_.get(), &target_config_,
             CreateCublasLtBackend(stream_executor_, &debug_options_,
                                   compiler_.get(), &target_config_),
-            GetCublasRewriterPipeline(device_description_), &alias_info_,
-            &mlir_context_, stream_executor_)) {}
+            [device_description = device_description_] {
+              return GetCublasRewriterPipeline(device_description);
+            },
+            &alias_info_, &mlir_context_, stream_executor_)) {}
 };
 
 TEST_F(CublasFissionBackendTest, ApplyConfigReplacesFusionWithControlDeps) {


### PR DESCRIPTION
CodegenOrchestrator dispatches ApplyConfig/Compile for a single FissionBackend instance onto a thread pool, but HloPassPipeline::Run() mutates non-atomic internal state (e.g. run_called_, per-pass stats), so sharing one HloPassPipeline instance across threads is a data race.

Replace the shared rewriter_pipeline_ member with a RewriterPipelineFactory that builds a fresh HloPassPipeline on every call, matching the existing pattern used for PriorityFusion in RunPriorityFusion. Update the CUDA/ROCm backend factories and the fission_backend_test fixture accordingly.

Principal TSAN stack trace, from //xla/tests:cholesky_test_amdgpu_any (two threads write the same byte in HloPassPipeline::RunImpl via the shared pipeline):

  WARNING: ThreadSanitizer: data race
    Write of size 1 by thread T283:
      #0 xla::HloPassPipeline::RunImpl() hlo_pass_pipeline.cc:301
      #1 xla::HloPassInterface::Run() hlo_pass_interface.cc:66
      #2 xla::gpu::FissionBackend::GetFissionedAndRewrittenModule()
         fission_backend.cc:201
      #3 xla::gpu::FissionBackend::ApplyConfig() fission_backend.cc:150
      #4 xla::gpu::GpuCodegenBackend::Compile() gpu_codegen_backend.h:102
      #5 xla::CodegenOrchestrator::Compile() codegen_orchestrator.cc:103
      #6 xla::CodegenOrchestrator::CompileAll()::$_0::operator()()
         codegen_orchestrator.cc:124
      ... (dispatched onto tsl::thread::ThreadPool)

    Previous write of size 1 by thread T291:
      #0 xla::HloPassPipeline::RunImpl() hlo_pass_pipeline.cc:301
      #1 xla::HloPassInterface::Run() hlo_pass_interface.cc:66
      #2 xla::gpu::FissionBackend::GetFissionedAndRewrittenModule()
         fission_backend.cc:201
      #3 xla::gpu::FissionBackend::ApplyConfig() fission_backend.cc:150
      #4 xla::gpu::GpuCodegenBackend::Compile() gpu_codegen_backend.h:102
      #5 xla::CodegenOrchestrator::Compile() codegen_orchestrator.cc:103
      #6 xla::CodegenOrchestrator::CompileAll()::$_0::operator()()
         codegen_orchestrator.cc:124
      ... (dispatched onto tsl::thread::ThreadPool)

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
