### PR TITLE
Update expected ROCm fingerprint

### DIFF
--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -644,7 +644,7 @@ absl::StatusOr<std::string> GetExpectedBackendFingerprint() {
   ASSIGN_OR_RETURN(std::string platform_name,
                    PlatformUtil::CanonicalPlatformName("gpu"));
   if (platform_name == "rocm") {
-    return "2971291867";
+    return "3128633344";
   }
   return "286644258";
 }


### PR DESCRIPTION
## Motivation

This fixes `FunctionalHloRunnerTest.ShardedAutotuningWorks` issue described in https://github.com/ROCm/xla-internal/issues/40#issuecomment-4892084258

## Technical Details

PR updates stale backend fingerprint for ROCm platform.

## Test Result

`//xla/tools/multihost_hlo_runner:functional_hlo_runner_test_amdgpu_any` is now passing

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
