### PR TITLE
Cj/rocm profiler roctx markers

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -557,6 +557,7 @@ xla_cc_test(
     name = "rocm_tracer_test",
     size = "small",
     srcs = ["rocm_tracer_test.cc"],
+    linkopts = ["-ldl"],  # for dlopen/dlsym in RealRoctxCallsProduceNvtxRangeInXSpace
     tags = [
         "gpu",
         "rocm-only",
@@ -570,6 +571,7 @@ xla_cc_test(
         ":rocm_tracer_utils",
         "//xla/tsl/lib/core:status_test_util",
         "@com_google_absl//absl/log",
+        "@com_google_absl//absl/strings:str_join",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -571,7 +571,7 @@ xla_cc_test(
         ":rocm_tracer_utils",
         "//xla/tsl/lib/core:status_test_util",
         "@com_google_absl//absl/log",
-        "@com_google_absl//absl/strings:str_join",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -570,6 +570,7 @@ xla_cc_test(
         ":rocm_tracer",
         ":rocm_tracer_utils",
         "//xla/tsl/lib/core:status_test_util",
+        "//xla/tsl/platform:env_time",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -206,7 +207,8 @@ void PerDeviceCollector::CreateXEvent(const RocmTracerEvent& event,
   VLOG(7) << "Adding event to line=" << line->Id();
   xevent.SetTimestampNs(event.start_time_ns);
   xevent.SetEndTimestampNs(event.end_time_ns);
-  if (event.source == RocmTracerEventSource::ApiCallback) {
+  if (event.source == RocmTracerEventSource::ApiCallback &&
+      event.device_id != RocmTracerEvent::kInvalidDeviceId) {
     xevent.AddStatValue(
         *plane->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kDeviceId)),
         event.device_id);
@@ -572,17 +574,23 @@ void RocmTraceCollectorImpl::Flush() {
           << " activity events, and aggregated them into "
           << aggregated_events.size() << " events.";
 
-  // device ids for GPUs filled in by roctracer are not zero indexed.
-  // They are offset by number of CPUs on the machine
-  uint32_t min_device_id = INT32_MAX;
+  // Device IDs from rocprofiler are not zero-indexed; find the minimum
+  // valid ID so we can normalise to [0, num_gpus_).
+  uint32_t min_device_id = std::numeric_limits<uint32_t>::max();
 
   for (const auto& event : aggregated_events) {
-    if (event.device_id < min_device_id) {
+    if (event.device_id != RocmTracerEvent::kInvalidDeviceId &&
+        event.device_id < min_device_id) {
       min_device_id = event.device_id;
     }
   }
 
   for (auto& event : aggregated_events) {
+    if (event.device_id == RocmTracerEvent::kInvalidDeviceId ||
+        min_device_id == std::numeric_limits<uint32_t>::max()) {
+      PrintRocmTracerEvent(event, ". Dropped due to invalid device ID!");
+      continue;
+    }
     auto id = event.device_id - min_device_id;
     if (id < num_gpus_) {
       per_device_collector_[id].AddEvent(std::move(event));

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -391,8 +391,17 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
             << plane->Name();
 
     XLineBuilder line = plane->GetOrCreateLine(line_id);
-    line.SetTimestampNs(start_gputime_ns);
-    CreateXEvent(event, plane, start_gputime_ns, end_gputime_ns, &line);
+    if (is_host_event) {
+      // Host-side events use wall-clock timestamps, not GPU timestamps.
+      // Pass 0/UINT64_MAX as bounds so the timestamp check in CreateXEvent
+      // never rejects them regardless of clock skew between domains.
+      line.SetTimestampNs(start_walltime_ns);
+      CreateXEvent(event, plane, 0, std::numeric_limits<uint64_t>::max(),
+                   &line);
+    } else {
+      line.SetTimestampNs(start_gputime_ns);
+      CreateXEvent(event, plane, start_gputime_ns, end_gputime_ns, &line);
+    }
   }
 
   device_plane->ForEachLine([&](XLineBuilder line) {

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -394,17 +394,8 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
             << plane->Name();
 
     XLineBuilder line = plane->GetOrCreateLine(line_id);
-    if (is_host_event) {
-      // Host-side events use wall-clock timestamps, not GPU timestamps.
-      // Pass 0/UINT64_MAX as bounds so the timestamp check in CreateXEvent
-      // never rejects them regardless of clock skew between domains.
-      line.SetTimestampNs(start_walltime_ns);
-      CreateXEvent(event, plane, 0, std::numeric_limits<uint64_t>::max(),
-                   &line);
-    } else {
-      line.SetTimestampNs(start_gputime_ns);
-      CreateXEvent(event, plane, start_gputime_ns, end_gputime_ns, &line);
-    }
+    line.SetTimestampNs(start_gputime_ns);
+    CreateXEvent(event, plane, start_gputime_ns, end_gputime_ns, &line);
   }
 
   device_plane->ForEachLine([&](XLineBuilder line) {

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -387,7 +387,8 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
       continue;
     }
     auto* plane = is_host_event ? host_plane : device_plane;
-    VLOG(9) << "Event" << " type=" << static_cast<int>(event.type)
+    VLOG(9) << "Event"
+            << " type=" << static_cast<int>(event.type)
             << " line_id=" << line_id
             << (is_host_event ? " host plane=" : " device plane=")
             << plane->Name();
@@ -702,7 +703,7 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
                         "Type="
                      << GetRocmTracerEventTypeName(api_event.type);
     }  // switch
-  }  // for
+  }    // for
 
   // Make sure for all activity events we have API callback events.
   //
@@ -775,8 +776,8 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
                           "Type="
                        << GetRocmTracerEventTypeName(activity_event.type);
       }  // switch
-    }  // for activity_event
-  }  // for activity_iter
+    }    // for activity_event
+  }      // for activity_iter
 
   return aggregated_events;
 }

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -498,6 +498,15 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
                                       bool is_auxiliary) {
   absl::MutexLock lock(event_maps_mutex_);
 
+  // Generic events (e.g. ROCTX/NVTX markers) have no GPU-side activity
+  // counterpart. Route them directly to standalone_events_ so they bypass
+  // ApiActivityInfoExchange and are flushed straight to per_device_collector_.
+  // Check this BEFORE the source-based branching below.
+  if (event.type == RocmTracerEventType::Generic) {
+    standalone_events_.push_back(std::move(event));
+    return;
+  }
+
   if (event.source == RocmTracerEventSource::ApiCallback) {
     if (!is_auxiliary) {
       if (num_callback_events_ >= options_.max_callback_api_events) {
@@ -572,6 +581,13 @@ void RocmTraceCollectorImpl::Flush() {
       PrintRocmTracerEvent(event, ". Dropped due to invalid device ID!");
     }
   }
+
+  // Flush standalone events (e.g. ROCTX markers) directly — they have no
+  // GPU-side activity counterpart and bypass ApiActivityInfoExchange.
+  for (auto& event : standalone_events_) {
+    per_device_collector_[0].AddEvent(std::move(event));
+  }
+  standalone_events_.clear();
 
   activity_ops_events_map_.clear();
   api_events_map_.clear();

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -228,6 +228,12 @@ class RocmTraceCollectorImpl : public RocmTraceCollector {
   absl::flat_hash_map<uint32_t, RocmTracerEvent> auxiliary_api_events_map_
       ABSL_GUARDED_BY(event_maps_mutex_);
 
+  // Host-side events that need no API↔Activity join (e.g. ROCTX markers).
+  // Flushed directly to per_device_collector_ without going through
+  // ApiActivityInfoExchange.
+  std::vector<RocmTracerEvent> standalone_events_
+      ABSL_GUARDED_BY(event_maps_mutex_);
+
   std::vector<RocmTracerEvent> ApiActivityInfoExchange()
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(event_maps_mutex_);
 

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -24,7 +24,6 @@ limitations under the License.
 #include <tuple>
 #include <vector>
 
-#include "rocprofiler-sdk/agent.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_map.h"
@@ -32,6 +31,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
 #include "rocm/include/hip/hip_runtime.h"
+#include "rocprofiler-sdk/agent.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/utils/xplane_builder.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -351,18 +351,22 @@ void RocmTracer::MarkerCallback(
       static_cast<const rocprofiler_callback_tracing_marker_api_data_t*>(
           record.payload);
   const uint64_t tid = record.thread_id;
-  const uint64_t ts = GetTimestamp();
 
   if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA &&
       record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+    const uint64_t ts = GetTimestamp();
+    if (ts == 0) return;
     const char* msg = data ? data->args.roctxRangePushA.message : nullptr;
     absl::MutexLock lock(&roctx_stack_mutex_);
     roctx_stack_[tid].push_back(
         RoctxFrame{msg ? std::string(msg) : std::string(), ts,
-                   static_cast<uint32_t>(record.correlation_id.internal)});
+                   record.correlation_id.internal});
 
   } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop &&
              record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) {
+    const uint64_t ts = GetTimestamp();
+    if (ts == 0) return;
+
     RoctxFrame frame;
     {
       absl::MutexLock lock(&roctx_stack_mutex_);
@@ -372,15 +376,12 @@ void RocmTracer::MarkerCallback(
       it->second.pop_back();
     }
 
-    // Intern the message string so the string_view in the event stays valid
-    // until PerDeviceCollector::Export() consumes events_.
     absl::string_view stable_msg;
     {
       absl::MutexLock lock(&roctx_strings_mutex_);
       stable_msg = *roctx_strings_.insert(std::move(frame.message)).first;
     }
 
-    absl::MutexLock coll_lock(collector_mutex_);
     if (collector() == nullptr) return;
     RocmTracerEvent event;
     event.type = RocmTracerEventType::Generic;
@@ -399,6 +400,9 @@ void RocmTracer::MarkerCallback(
 
   } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA &&
              record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+    const uint64_t ts = GetTimestamp();
+    if (ts == 0) return;
+
     const char* msg = data ? data->args.roctxMarkA.message : nullptr;
     if (!msg || msg[0] == '\0') return;
 
@@ -408,7 +412,6 @@ void RocmTracer::MarkerCallback(
       stable_msg = *roctx_strings_.insert(std::string(msg)).first;
     }
 
-    absl::MutexLock coll_lock(collector_mutex_);
     if (collector() == nullptr) return;
     RocmTracerEvent event;
     event.type = RocmTracerEventType::Generic;

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -359,7 +359,7 @@ void RocmTracer::MarkerCallback(
     absl::MutexLock lock(&roctx_stack_mutex_);
     roctx_stack_[tid].push_back(
         RoctxFrame{msg ? std::string(msg) : std::string(), ts,
-                   record.correlation_id.internal});
+                   static_cast<uint32_t>(record.correlation_id.internal)});
 
   } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop &&
              record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) {

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -143,7 +143,13 @@ bool RocmTracer::IsAvailable() const {
 
 absl::Status RocmTracer::Enable(const RocmTracerOptions& options,
                                 RocmTraceCollector* collector) {
-  // Clear per-session ROCTX state before starting a new context.
+  absl::MutexLock lock(collector_mutex_);
+  if (collector_ != nullptr) {
+    return absl::AlreadyExistsError("ROCM tracer is already running");
+  }
+
+  // Clear per-session state while holding collector_mutex_ so no in-flight
+  // callback can race between the clear and the new session start.
   annotation_map_.Clear();
   {
     absl::MutexLock roctx_lock(&roctx_stack_mutex_);
@@ -154,10 +160,6 @@ absl::Status RocmTracer::Enable(const RocmTracerOptions& options,
     roctx_strings_.clear();
   }
 
-  absl::MutexLock lock(collector_mutex_);
-  if (collector_ != nullptr) {
-    return absl::AlreadyExistsError("ROCM tracer is already running");
-  }
   options_ = options;
   collector_ = collector;
 
@@ -169,7 +171,6 @@ absl::Status RocmTracer::Enable(const RocmTracerOptions& options,
     return absl::InternalError(
         absl::StrCat("rocprofiler_start_context failed: ", errstr));
   }
-  annotation_map_.Clear();
   api_tracing_enabled_ = true;
   activity_tracing_enabled_ = true;
   VLOG(1) << "GpuTracer started with number of GPUs = " << NumGpus();
@@ -382,7 +383,6 @@ void RocmTracer::MarkerCallback(
       stable_msg = *roctx_strings_.insert(std::move(frame.message)).first;
     }
 
-    if (collector() == nullptr) return;
     RocmTracerEvent event;
     event.type = RocmTracerEventType::Generic;
     event.source = RocmTracerEventSource::ApiCallback;
@@ -396,7 +396,12 @@ void RocmTracer::MarkerCallback(
     event.correlation_id = frame.correlation_id;
     event.stream_id = RocmTracerEvent::kInvalidStreamId;
     event.scope_range_id = 0;
-    collector()->AddEvent(std::move(event), false);
+    {
+      absl::MutexLock lock(&collector_mutex_);
+      if (collector()) {
+        collector()->AddEvent(std::move(event), false);
+      }
+    }
 
   } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA &&
              record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
@@ -412,7 +417,6 @@ void RocmTracer::MarkerCallback(
       stable_msg = *roctx_strings_.insert(std::string(msg)).first;
     }
 
-    if (collector() == nullptr) return;
     RocmTracerEvent event;
     event.type = RocmTracerEventType::Generic;
     event.source = RocmTracerEventSource::ApiCallback;
@@ -426,7 +430,12 @@ void RocmTracer::MarkerCallback(
     event.correlation_id = record.correlation_id.internal;
     event.stream_id = RocmTracerEvent::kInvalidStreamId;
     event.scope_range_id = 0;
-    collector()->AddEvent(std::move(event), false);
+    {
+      absl::MutexLock lock(&collector_mutex_);
+      if (collector()) {
+        collector()->AddEvent(std::move(event), false);
+      }
+    }
   }
 }
 

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -44,6 +44,7 @@ limitations under the License.
 #include "rocm/include/rocprofiler-sdk/fwd.h"
 #include "rocm/include/rocprofiler-sdk/hip/runtime_api_id.h"
 #include "rocm/include/rocprofiler-sdk/internal_threading.h"
+#include "rocm/include/rocprofiler-sdk/marker.h"
 #include "rocm/include/rocprofiler-sdk/registration.h"
 #include "rocm/include/rocprofiler-sdk/rocprofiler.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
@@ -142,6 +143,17 @@ bool RocmTracer::IsAvailable() const {
 
 absl::Status RocmTracer::Enable(const RocmTracerOptions& options,
                                 RocmTraceCollector* collector) {
+  // Clear per-session ROCTX state before starting a new context.
+  annotation_map_.Clear();
+  {
+    absl::MutexLock roctx_lock(&roctx_stack_mutex_);
+    roctx_stack_.clear();
+  }
+  {
+    absl::MutexLock roctx_str_lock(&roctx_strings_mutex_);
+    roctx_strings_.clear();
+  }
+
   absl::MutexLock lock(collector_mutex_);
   if (collector_ != nullptr) {
     return absl::AlreadyExistsError("ROCM tracer is already running");
@@ -331,6 +343,90 @@ void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
   if (it != kernel_info_.end()) trace_event->name = it->second.name;
 }
 
+void RocmTracer::MarkerCallback(
+    const rocprofiler_callback_tracing_record_t& record) {
+  if (record.kind != ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API) return;
+
+  const auto* data =
+      static_cast<const rocprofiler_callback_tracing_marker_api_data_t*>(
+          record.payload);
+  const uint64_t tid = record.thread_id;
+  const uint64_t ts = GetTimestamp();
+
+  if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA &&
+      record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+    const char* msg = data ? data->args.roctxRangePushA.message : nullptr;
+    absl::MutexLock lock(&roctx_stack_mutex_);
+    roctx_stack_[tid].push_back(
+        RoctxFrame{msg ? std::string(msg) : std::string(), ts,
+                   record.correlation_id.internal});
+
+  } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop &&
+             record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) {
+    RoctxFrame frame;
+    {
+      absl::MutexLock lock(&roctx_stack_mutex_);
+      auto it = roctx_stack_.find(tid);
+      if (it == roctx_stack_.end() || it->second.empty()) return;
+      frame = std::move(it->second.back());
+      it->second.pop_back();
+    }
+
+    // Intern the message string so the string_view in the event stays valid
+    // until PerDeviceCollector::Export() consumes events_.
+    absl::string_view stable_msg;
+    {
+      absl::MutexLock lock(&roctx_strings_mutex_);
+      stable_msg = *roctx_strings_.insert(std::move(frame.message)).first;
+    }
+
+    absl::MutexLock coll_lock(collector_mutex_);
+    if (collector() == nullptr) return;
+    RocmTracerEvent event;
+    event.type = RocmTracerEventType::Generic;
+    event.source = RocmTracerEventSource::ApiCallback;
+    event.domain = RocmTracerEventDomain::HIP_API;
+    event.name = std::string(stable_msg);
+    event.roctx_range = stable_msg;
+    event.start_time_ns = frame.start_ns;
+    event.end_time_ns = ts;
+    event.thread_id = tid;
+    event.device_id = RocmTracerEvent::kInvalidDeviceId;
+    event.correlation_id = frame.correlation_id;
+    event.stream_id = RocmTracerEvent::kInvalidStreamId;
+    event.scope_range_id = 0;
+    collector()->AddEvent(std::move(event), false);
+
+  } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA &&
+             record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+    const char* msg = data ? data->args.roctxMarkA.message : nullptr;
+    if (!msg || msg[0] == '\0') return;
+
+    absl::string_view stable_msg;
+    {
+      absl::MutexLock lock(&roctx_strings_mutex_);
+      stable_msg = *roctx_strings_.insert(std::string(msg)).first;
+    }
+
+    absl::MutexLock coll_lock(collector_mutex_);
+    if (collector() == nullptr) return;
+    RocmTracerEvent event;
+    event.type = RocmTracerEventType::Generic;
+    event.source = RocmTracerEventSource::ApiCallback;
+    event.domain = RocmTracerEventDomain::HIP_API;
+    event.name = std::string(stable_msg);
+    event.roctx_range = stable_msg;
+    event.start_time_ns = ts;
+    event.end_time_ns = ts;
+    event.thread_id = tid;
+    event.device_id = RocmTracerEvent::kInvalidDeviceId;
+    event.correlation_id = record.correlation_id.internal;
+    event.stream_id = RocmTracerEvent::kInvalidStreamId;
+    event.scope_range_id = 0;
+    collector()->AddEvent(std::move(event), false);
+  }
+}
+
 void RocmTracer::TracingCallback(rocprofiler_context_id_t context,
                                  rocprofiler_buffer_id_t buffer_id,
                                  rocprofiler_record_header_t** headers,
@@ -505,6 +601,18 @@ absl::Status RocmTracer::InitProfiling(void* tool_data) {
             },
             nullptr)));
   }
+
+  // ROCTX / NVTX marker tracing: capture roctxRangePushA, roctxRangePop, and
+  // roctxMarkA so that JAX TraceAnnotation ranges appear as named bands in the
+  // XPlane host thread timeline (kNVTXRange stat on Generic events).
+  RETURN_IF_ERROR(RocprofilerStatusToAbslStatus(
+      rocprofiler_configure_callback_tracing_service(
+          context_, ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API, nullptr, 0,
+          [](rocprofiler_callback_tracing_record_t record,
+             rocprofiler_user_data_t*, void*) {
+            RocmTracer::GetRocmTracerSingleton().MarkerCallback(record);
+          },
+          nullptr)));
 
   auto client_thread = rocprofiler_callback_thread_t{};
   RETURN_IF_ERROR(RocprofilerStatusToAbslStatus(

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -110,6 +110,7 @@ class RocmTracer {
   absl::Mutex roctx_strings_mutex_;
   absl::node_hash_set<std::string> roctx_strings_
       ABSL_GUARDED_BY(roctx_strings_mutex_);
+
  public:
   using kernel_symbol_data_t =
       rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -72,6 +72,11 @@ class RocmTracer {
   void CodeObjectCallback(rocprofiler_callback_tracing_record_t record,
                           void* callback_data);
 
+  // Called from the MARKER_CORE_API callback. Handles roctxRangePushA,
+  // roctxRangePop, and roctxMarkA, emitting RocmTracerEvent(Generic) for each
+  // completed range or instantaneous mark.
+  void MarkerCallback(const rocprofiler_callback_tracing_record_t& record);
+
   AnnotationMap* annotation_map() { return &annotation_map_; }
 
  protected:
@@ -95,6 +100,19 @@ class RocmTracer {
 
   AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
 
+  // Per-thread stack of pending ROCTX ranges (roctxRangePushA not yet matched
+  // by roctxRangePop). Key is the OS thread_id from the callback record.
+  absl::Mutex roctx_stack_mutex_;
+  absl::flat_hash_map<uint64_t, std::vector<RoctxFrame>> roctx_stack_
+      ABSL_GUARDED_BY(roctx_stack_mutex_);
+
+  // Stable storage for ROCTX range label strings. RocmTracerEvent::roctx_range
+  // is a string_view; it must outlive the event. Strings are interned here and
+  // never erased during a session, so the string_view remains valid until
+  // Export() completes and events_ is cleared.
+  absl::Mutex roctx_strings_mutex_;
+  absl::node_hash_set<std::string> roctx_strings_
+      ABSL_GUARDED_BY(roctx_strings_mutex_);
  public:
   using kernel_symbol_data_t =
       rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -100,8 +100,10 @@ class RocmTracer {
 
   AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
 
-  // Lock ordering: roctx_stack_mutex_ → roctx_strings_mutex_.
-  // MarkerCallback acquires them in this order; never reverse it.
+  // Lock ordering: roctx_stack_mutex_ and roctx_strings_mutex_ are each
+  // acquired and released independently in MarkerCallback (never nested).
+  // collector_mutex_ may be acquired after both are released.
+  // Enable() holds collector_mutex_ while acquiring the roctx locks.
 
   absl::Mutex roctx_stack_mutex_;
   absl::flat_hash_map<uint64_t, std::vector<RoctxFrame>> roctx_stack_

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -100,16 +100,13 @@ class RocmTracer {
 
   AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
 
-  // Per-thread stack of pending ROCTX ranges (roctxRangePushA not yet matched
-  // by roctxRangePop). Key is the OS thread_id from the callback record.
+  // Lock ordering: roctx_stack_mutex_ → roctx_strings_mutex_.
+  // MarkerCallback acquires them in this order; never reverse it.
+
   absl::Mutex roctx_stack_mutex_;
   absl::flat_hash_map<uint64_t, std::vector<RoctxFrame>> roctx_stack_
       ABSL_GUARDED_BY(roctx_stack_mutex_);
 
-  // Stable storage for ROCTX range label strings. RocmTracerEvent::roctx_range
-  // is a string_view; it must outlive the event. Strings are interned here and
-  // never erased during a session, so the string_view remains valid until
-  // Export() completes and events_ is cleared.
   absl::Mutex roctx_strings_mutex_;
   absl::node_hash_set<std::string> roctx_strings_
       ABSL_GUARDED_BY(roctx_strings_mutex_);

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -27,8 +28,10 @@ limitations under the License.
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "rocm/include/hip/hip_runtime.h"
+#include "rocm/include/rocprofiler-sdk/callback_tracing.h"
 #include "rocm/include/rocprofiler-sdk/context.h"
 #include "rocm/include/rocprofiler-sdk/fwd.h"
+#include "rocm/include/rocprofiler-sdk/marker.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/lib/core/status_test_util.h"
@@ -335,6 +338,257 @@ TEST(RocmTracerTest, DisableIsolatesNextSession) {
       << " events despite no HIP activity between its Enable() and Disable();"
       << " these must have leaked from the preceding no-profiler window of "
       << kLeakedPairs << " hipMemcpy pairs";
+}
+
+// MarkerCallback unit tests — exercise MarkerCallback() directly without
+// requiring real ROCTX API calls, using a capturing collector.
+// ============================================================================
+
+// Collector variant that captures the full RocmTracerEvent for inspection.
+class MarkerCapturingCollector : public RocmTraceCollector {
+ public:
+  MarkerCapturingCollector() : RocmTraceCollector(MakeCollectorOptions()) {}
+
+  void AddEvent(RocmTracerEvent&& event, bool) override {
+    absl::MutexLock lock(&mu_);
+    events_.push_back(std::move(event));
+  }
+  void OnEventsDropped(const std::string&, uint32_t) override {}
+  void Flush() override {}
+  void Export(tsl::profiler::XSpace*) override {}
+
+  std::vector<RocmTracerEvent> TakeEvents() {
+    absl::MutexLock lock(&mu_);
+    return std::exchange(events_, {});
+  }
+
+ private:
+  static RocmTraceCollectorOptions MakeCollectorOptions() {
+    RocmTraceCollectorOptions o;
+    o.max_callback_api_events = 1024;
+    o.max_activity_api_events = 1024;
+    o.max_annotation_strings = 1024;
+    o.num_gpus = 1;
+    return o;
+  }
+  absl::Mutex mu_;
+  std::vector<RocmTracerEvent> events_ ABSL_GUARDED_BY(mu_);
+};
+
+// Build a minimal rocprofiler_callback_tracing_record_t for MARKER_CORE_API.
+// `payload` must point to a live rocprofiler_callback_tracing_marker_api_data_t
+// for the duration of the MarkerCallback call.
+static rocprofiler_callback_tracing_record_t MakeMarkerRecord(
+    rocprofiler_marker_core_api_id_t op,
+    rocprofiler_callback_phase_t phase,
+    uint64_t thread_id,
+    void* payload) {
+  rocprofiler_callback_tracing_record_t rec{};
+  rec.kind = ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API;
+  rec.operation = static_cast<rocprofiler_tracing_operation_t>(op);
+  rec.phase = phase;
+  rec.thread_id = thread_id;
+  rec.correlation_id.internal = 99;
+  rec.payload = payload;
+  return rec;
+}
+
+TEST(RocmTracerTest, MarkerCallbackPushPopEmitsRoctxRange) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  const uint64_t tid = 12345;
+  const char* label = "my_roctx_range";
+
+  // Simulate roctxRangePushA ENTER
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = label;
+  auto push_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                                   ROCPROFILER_CALLBACK_PHASE_ENTER, tid,
+                                   &push_data);
+  tracer.MarkerCallback(push_rec);
+
+  // No event yet — PUSH doesn't emit
+  EXPECT_TRUE(cptr->TakeEvents().empty())
+      << "roctxRangePushA must not emit an event until the matching Pop";
+
+  // Simulate roctxRangePop EXIT
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                                  ROCPROFILER_CALLBACK_PHASE_EXIT, tid,
+                                  &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  auto events = cptr->TakeEvents();
+  ASSERT_EQ(events.size(), 1u) << "Expected exactly one range event from Push+Pop";
+
+  const RocmTracerEvent& e = events[0];
+  EXPECT_EQ(e.type, RocmTracerEventType::Generic);
+  EXPECT_EQ(e.source, RocmTracerEventSource::ApiCallback);
+  EXPECT_EQ(e.roctx_range, label);
+  EXPECT_EQ(e.thread_id, tid);
+  EXPECT_GT(e.end_time_ns, e.start_time_ns)
+      << "end_time must be after start_time";
+}
+
+TEST(RocmTracerTest, MarkerCallbackMarkEmitsInstantaneousEvent) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  const uint64_t tid = 77777;
+  const char* label = "checkpoint";
+
+  rocprofiler_callback_tracing_marker_api_data_t mark_data{};
+  mark_data.args.roctxMarkA.message = label;
+  auto mark_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA,
+                                   ROCPROFILER_CALLBACK_PHASE_ENTER, tid,
+                                   &mark_data);
+  tracer.MarkerCallback(mark_rec);
+
+  tracer.Disable();
+
+  auto events = cptr->TakeEvents();
+  ASSERT_EQ(events.size(), 1u) << "roctxMarkA must emit exactly one event";
+
+  const RocmTracerEvent& e = events[0];
+  EXPECT_EQ(e.type, RocmTracerEventType::Generic);
+  EXPECT_EQ(e.roctx_range, label);
+  EXPECT_EQ(e.thread_id, tid);
+  EXPECT_EQ(e.start_time_ns, e.end_time_ns)
+      << "roctxMarkA produces an instantaneous event (start == end)";
+}
+
+TEST(RocmTracerTest, MarkerCallbackUnmatchedPopIsIgnored) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  // Pop without any preceding Push — must not crash, must not emit any event.
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                                  ROCPROFILER_CALLBACK_PHASE_EXIT, 1111,
+                                  &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  EXPECT_TRUE(cptr->TakeEvents().empty())
+      << "An unmatched roctxRangePop must not emit an event";
+}
+
+TEST(RocmTracerTest, MarkerCallbackNullMessageSafelyIgnored) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  const uint64_t tid = 2222;
+
+  // Push with null message — must not crash
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = nullptr;
+  auto push_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                                   ROCPROFILER_CALLBACK_PHASE_ENTER, tid,
+                                   &push_data);
+  tracer.MarkerCallback(push_rec);
+
+  // Pop should still emit (with empty label) without crashing
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                                  ROCPROFILER_CALLBACK_PHASE_EXIT, tid,
+                                  &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  // Event is emitted but with empty roctx_range (null message → empty string)
+  auto events = cptr->TakeEvents();
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_TRUE(events[0].roctx_range.empty())
+      << "Null message should produce an empty roctx_range";
+}
+
+// Integration test: verifies the full pipeline — MarkerCallback → AddEvent →
+// PerDeviceCollector::Export — produces a Generic event in the XSpace host
+// plane. Uses the unit-test collector path (real rocprofiler context is live
+// because Enable() starts it; we inject the event via MarkerCallback directly
+// rather than going through the real ROCTX library).
+TEST(RocmTracerTest, MarkerEventAppearsInExportedXSpace) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  RocmTraceCollectorOptions col_opts;
+  col_opts.max_callback_api_events = 1024;
+  col_opts.max_activity_api_events = 1024;
+  col_opts.max_annotation_strings = 1024;
+  col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
+
+  uint64_t start_wall = RocmTracer::GetTimestamp();
+  uint64_t start_gpu = RocmTracer::GetTimestamp();
+  auto collector = std::make_unique<RocmTraceCollectorImpl>(
+      col_opts, start_wall, start_gpu);
+  collector->SetGpuAgents(tracer.GpuAgents());
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  const uint64_t tid = 4242;
+  const char* label = "integration_label";
+
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = label;
+  auto push_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data);
+  tracer.MarkerCallback(push_rec);
+
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  tsl::profiler::XSpace space;
+  collector->Export(&space);
+
+  // The host plane should have a Generic event with kNVTXRange stat.
+  bool found_nvtx_stat = false;
+  for (const auto& plane : space.planes()) {
+    for (const auto& [id, stat_md] : plane.stat_metadata()) {
+      if (stat_md.name() == "nvtx_range") {
+        found_nvtx_stat = true;
+        break;
+      }
+    }
+    if (found_nvtx_stat) break;
+  }
+  EXPECT_TRUE(found_nvtx_stat)
+      << "XSpace should contain nvtx_range stat metadata after a ROCTX range";
 }
 
 }  // namespace

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -15,8 +15,6 @@ limitations under the License.
 
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 
-#include <dlfcn.h>
-
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -36,6 +34,7 @@ limitations under the License.
 #include "rocm/include/rocprofiler-sdk/context.h"
 #include "rocm/include/rocprofiler-sdk/fwd.h"
 #include "rocm/include/rocprofiler-sdk/marker.h"
+#include <dlfcn.h>
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/lib/core/status_test_util.h"
@@ -383,10 +382,8 @@ class MarkerCapturingCollector : public RocmTraceCollector {
 // `payload` must point to a live rocprofiler_callback_tracing_marker_api_data_t
 // for the duration of the MarkerCallback call.
 static rocprofiler_callback_tracing_record_t MakeMarkerRecord(
-    rocprofiler_marker_core_api_id_t op,
-    rocprofiler_callback_phase_t phase,
-    uint64_t thread_id,
-    void* payload) {
+    rocprofiler_marker_core_api_id_t op, rocprofiler_callback_phase_t phase,
+    uint64_t thread_id, void* payload) {
   rocprofiler_callback_tracing_record_t rec{};
   rec.kind = ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API;
   rec.operation = static_cast<rocprofiler_tracing_operation_t>(op);
@@ -413,9 +410,9 @@ TEST(RocmTracerTest, MarkerCallbackPushPopEmitsRoctxRange) {
   // Simulate roctxRangePushA ENTER
   rocprofiler_callback_tracing_marker_api_data_t push_data{};
   push_data.args.roctxRangePushA.message = label;
-  auto push_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
-                                   ROCPROFILER_CALLBACK_PHASE_ENTER, tid,
-                                   &push_data);
+  auto push_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data);
   tracer.MarkerCallback(push_rec);
 
   // No event yet — PUSH doesn't emit
@@ -424,15 +421,16 @@ TEST(RocmTracerTest, MarkerCallbackPushPopEmitsRoctxRange) {
 
   // Simulate roctxRangePop EXIT
   rocprofiler_callback_tracing_marker_api_data_t pop_data{};
-  auto pop_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
-                                  ROCPROFILER_CALLBACK_PHASE_EXIT, tid,
-                                  &pop_data);
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data);
   tracer.MarkerCallback(pop_rec);
 
   tracer.Disable();
 
   auto events = cptr->TakeEvents();
-  ASSERT_EQ(events.size(), 1u) << "Expected exactly one range event from Push+Pop";
+  ASSERT_EQ(events.size(), 1u)
+      << "Expected exactly one range event from Push+Pop";
 
   const RocmTracerEvent& e = events[0];
   EXPECT_EQ(e.type, RocmTracerEventType::Generic);
@@ -458,9 +456,9 @@ TEST(RocmTracerTest, MarkerCallbackMarkEmitsInstantaneousEvent) {
 
   rocprofiler_callback_tracing_marker_api_data_t mark_data{};
   mark_data.args.roctxMarkA.message = label;
-  auto mark_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA,
-                                   ROCPROFILER_CALLBACK_PHASE_ENTER, tid,
-                                   &mark_data);
+  auto mark_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &mark_data);
   tracer.MarkerCallback(mark_rec);
 
   tracer.Disable();
@@ -488,9 +486,9 @@ TEST(RocmTracerTest, MarkerCallbackUnmatchedPopIsIgnored) {
 
   // Pop without any preceding Push — must not crash, must not emit any event.
   rocprofiler_callback_tracing_marker_api_data_t pop_data{};
-  auto pop_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
-                                  ROCPROFILER_CALLBACK_PHASE_EXIT, 1111,
-                                  &pop_data);
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, 1111, &pop_data);
   tracer.MarkerCallback(pop_rec);
 
   tracer.Disable();
@@ -514,16 +512,16 @@ TEST(RocmTracerTest, MarkerCallbackNullMessageSafelyIgnored) {
   // Push with null message — must not crash
   rocprofiler_callback_tracing_marker_api_data_t push_data{};
   push_data.args.roctxRangePushA.message = nullptr;
-  auto push_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
-                                   ROCPROFILER_CALLBACK_PHASE_ENTER, tid,
-                                   &push_data);
+  auto push_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data);
   tracer.MarkerCallback(push_rec);
 
   // Pop should still emit (with empty label) without crashing
   rocprofiler_callback_tracing_marker_api_data_t pop_data{};
-  auto pop_rec = MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
-                                  ROCPROFILER_CALLBACK_PHASE_EXIT, tid,
-                                  &pop_data);
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data);
   tracer.MarkerCallback(pop_rec);
 
   tracer.Disable();
@@ -552,8 +550,8 @@ TEST(RocmTracerTest, MarkerEventAppearsInExportedXSpace) {
 
   uint64_t start_wall = RocmTracer::GetTimestamp();
   uint64_t start_gpu = RocmTracer::GetTimestamp();
-  auto collector = std::make_unique<RocmTraceCollectorImpl>(
-      col_opts, start_wall, start_gpu);
+  auto collector =
+      std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
   collector->SetGpuAgents(tracer.GpuAgents());
 
   RocmTracerOptions opts{/*max_annotation_strings=*/1024};
@@ -670,8 +668,8 @@ TEST(RocmTracerTest, RealRoctxCallsProduceNvtxRangeInXSpace) {
 
   uint64_t start_wall = RocmTracer::GetTimestamp();
   uint64_t start_gpu = RocmTracer::GetTimestamp();
-  auto collector = std::make_unique<RocmTraceCollectorImpl>(
-      col_opts, start_wall, start_gpu);
+  auto collector =
+      std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
   collector->SetGpuAgents(tracer.GpuAgents());
 
   RocmTracerOptions opts{/*max_annotation_strings=*/1024};
@@ -711,8 +709,7 @@ TEST(RocmTracerTest, RealRoctxCallsProduceNvtxRangeInXSpace) {
       for (const auto& event : line.events()) {
         for (const auto& stat : event.stats()) {
           if (stat.metadata_id() != nvtx_stat_id) continue;
-          if (stat.value_case() ==
-              tensorflow::profiler::XStat::kRefValue) {
+          if (stat.value_case() == tensorflow::profiler::XStat::kRefValue) {
             int64_t ref = stat.ref_value();
             auto it = plane.stat_metadata().find(ref);
             if (it != plane.stat_metadata().end()) {

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -17,13 +17,16 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <dlfcn.h>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
 #include "absl/log/log.h"
+#include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
@@ -589,6 +592,157 @@ TEST(RocmTracerTest, MarkerEventAppearsInExportedXSpace) {
   }
   EXPECT_TRUE(found_nvtx_stat)
       << "XSpace should contain nvtx_range stat metadata after a ROCTX range";
+}
+
+// ============================================================================
+// Integration test: real librocprofiler-sdk-roctx.so → MarkerCallback →
+// kNVTXRange stat in exported XSpace.
+//
+// NOTE: libroctx64.so (old roctracer-era roctx) is NOT intercepted by
+// rocprofiler-sdk. We must use librocprofiler-sdk-roctx.so, which links
+// against librocprofiler-register.so and goes through rocprofiler's
+// intercept table. We load it via dlopen at runtime to avoid a hard
+// link-time dependency.
+// ============================================================================
+
+// Thin RAII wrapper around dlopen for roctx functions.
+struct RoctxLib {
+  void* handle = nullptr;
+  int (*roctxRangePushA)(const char*) = nullptr;
+  int (*roctxRangePop)() = nullptr;
+  void (*roctxMarkA)(const char*) = nullptr;
+
+  static RoctxLib Load() {
+    RoctxLib lib;
+    // Must use the rocprofiler-sdk-integrated roctx — NOT libroctx64.so.
+    // librocprofiler-sdk-roctx.so registers with librocprofiler-register.so
+    // so rocprofiler-sdk intercepts its calls.
+    const char* candidates[] = {
+        "librocprofiler-sdk-roctx.so",
+        "/opt/rocm/lib/librocprofiler-sdk-roctx.so",
+    };
+    for (const char* path : candidates) {
+      lib.handle = dlopen(path, RTLD_LAZY | RTLD_GLOBAL);
+      if (lib.handle) break;
+    }
+    if (!lib.handle) return lib;
+
+    lib.roctxRangePushA = reinterpret_cast<int (*)(const char*)>(
+        dlsym(lib.handle, "roctxRangePushA"));
+    lib.roctxRangePop =
+        reinterpret_cast<int (*)()>(dlsym(lib.handle, "roctxRangePop"));
+    lib.roctxMarkA = reinterpret_cast<void (*)(const char*)>(
+        dlsym(lib.handle, "roctxMarkA"));
+
+    if (!lib.roctxRangePushA || !lib.roctxRangePop || !lib.roctxMarkA) {
+      dlclose(lib.handle);
+      lib.handle = nullptr;
+    }
+    return lib;
+  }
+
+  bool ok() const { return handle != nullptr; }
+
+  ~RoctxLib() {
+    if (handle) dlclose(handle);
+  }
+};
+
+// Test: real roctxRangePushA/roctxRangePop → kNVTXRange stat in XSpace.
+//
+// The test uses librocprofiler-sdk-roctx.so (intercepted by rocprofiler-sdk).
+// If the library is not found (non-ROCm CI), the test is skipped gracefully.
+TEST(RocmTracerTest, RealRoctxCallsProduceNvtxRangeInXSpace) {
+  RoctxLib roctx = RoctxLib::Load();
+  if (!roctx.ok()) {
+    GTEST_SKIP() << "librocprofiler-sdk-roctx.so not available — skipping";
+  }
+
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  RocmTraceCollectorOptions col_opts;
+  col_opts.max_callback_api_events = 1024;
+  col_opts.max_activity_api_events = 1024;
+  col_opts.max_annotation_strings = 1024;
+  col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
+
+  uint64_t start_wall = RocmTracer::GetTimestamp();
+  uint64_t start_gpu = RocmTracer::GetTimestamp();
+  auto collector = std::make_unique<RocmTraceCollectorImpl>(
+      col_opts, start_wall, start_gpu);
+  collector->SetGpuAgents(tracer.GpuAgents());
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  // Emit real ROCTX ranges — rocprofiler-sdk intercepts these and fires
+  // MarkerCallback, which emits Generic RocmTracerEvents.
+  EXPECT_GE(roctx.roctxRangePushA("unit_test_outer"), 0);
+  EXPECT_GE(roctx.roctxRangePushA("unit_test_inner"), 0);
+  roctx.roctxMarkA("unit_test_mark");
+  roctx.roctxRangePop();  // end unit_test_inner
+  roctx.roctxRangePop();  // end unit_test_outer
+
+  tracer.Disable();
+
+  // Export and verify kNVTXRange stat appears in XSpace.
+  tsl::profiler::XSpace space;
+  collector->Export(&space);
+
+  bool found_nvtx_stat = false;
+  std::vector<std::string> found_labels;
+
+  for (const auto& plane : space.planes()) {
+    // Find the nvtx_range stat metadata id in this plane.
+    int64_t nvtx_stat_id = -1;
+    for (const auto& [sid, smd] : plane.stat_metadata()) {
+      if (smd.name() == "nvtx_range") {
+        nvtx_stat_id = sid;
+        found_nvtx_stat = true;
+        break;
+      }
+    }
+    if (nvtx_stat_id < 0) continue;
+
+    // Collect the label strings from event stats.
+    for (const auto& line : plane.lines()) {
+      for (const auto& event : line.events()) {
+        for (const auto& stat : event.stats()) {
+          if (stat.metadata_id() != nvtx_stat_id) continue;
+          if (stat.value_case() ==
+              tensorflow::profiler::XStat::kRefValue) {
+            int64_t ref = stat.ref_value();
+            auto it = plane.stat_metadata().find(ref);
+            if (it != plane.stat_metadata().end()) {
+              found_labels.push_back(it->second.name());
+            }
+          } else if (stat.value_case() ==
+                     tensorflow::profiler::XStat::kStrValue) {
+            found_labels.push_back(stat.str_value());
+          }
+        }
+      }
+    }
+  }
+
+  EXPECT_TRUE(found_nvtx_stat)
+      << "XSpace should contain 'nvtx_range' stat metadata after real ROCTX "
+         "calls via librocprofiler-sdk-roctx.so";
+
+  if (found_nvtx_stat) {
+    std::set<std::string> label_set(found_labels.begin(), found_labels.end());
+    EXPECT_TRUE(label_set.count("unit_test_outer"))
+        << "Expected 'unit_test_outer' in nvtx_range labels. Found: "
+        << absl::StrJoin(found_labels, ", ");
+    EXPECT_TRUE(label_set.count("unit_test_inner"))
+        << "Expected 'unit_test_inner' in nvtx_range labels. Found: "
+        << absl::StrJoin(found_labels, ", ");
+    // roctxMarkA emits an instantaneous event — label is present
+    EXPECT_TRUE(label_set.count("unit_test_mark"))
+        << "Expected 'unit_test_mark' in nvtx_range labels. Found: "
+        << absl::StrJoin(found_labels, ", ");
+  }
 }
 
 }  // namespace

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -15,9 +15,10 @@ limitations under the License.
 
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 
+#include <dlfcn.h>
+
 #include <cstddef>
 #include <cstdint>
-#include <dlfcn.h>
 #include <memory>
 #include <set>
 #include <string>

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -38,6 +38,7 @@ limitations under the License.
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/lib/core/status_test_util.h"
+#include "xla/tsl/platform/env_time.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
 
 namespace xla {
@@ -548,8 +549,8 @@ TEST(RocmTracerTest, MarkerEventAppearsInExportedXSpace) {
   col_opts.max_annotation_strings = 1024;
   col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
 
-  uint64_t start_wall = RocmTracer::GetTimestamp();
   uint64_t start_gpu = RocmTracer::GetTimestamp();
+  uint64_t start_wall = tsl::EnvTime::NowNanos();
   auto collector =
       std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
   collector->SetGpuAgents(tracer.GpuAgents());
@@ -666,8 +667,8 @@ TEST(RocmTracerTest, RealRoctxCallsProduceNvtxRangeInXSpace) {
   col_opts.max_annotation_strings = 1024;
   col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
 
-  uint64_t start_wall = RocmTracer::GetTimestamp();
   uint64_t start_gpu = RocmTracer::GetTimestamp();
+  uint64_t start_wall = tsl::EnvTime::NowNanos();
   auto collector =
       std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
   collector->SetGpuAgents(tracer.GpuAgents());

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -94,7 +94,8 @@ void AnnotationMap::Add(uint32_t correlation_id, const std::string& annotation,
   if (annotation.empty()) {
     return;
   }
-  VLOG(3) << "Add annotation: " << " correlation_id=" << correlation_id
+  VLOG(3) << "Add annotation: "
+          << " correlation_id=" << correlation_id
           << ", annotation: " << annotation;
   absl::MutexLock lock(map_.mutex);
   if (map_.annotations.size() < max_size_) {

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -154,6 +154,14 @@ struct RocmTracerEvent {
   };
 };
 
+// Represents one pending ROCTX range pushed via roctxRangePushA. Stored on
+// a per-thread stack in RocmTracer and consumed when roctxRangePop fires.
+struct RoctxFrame {
+  std::string message;     // the range label (owned here for lifetime safety)
+  uint64_t start_ns;       // timestamp captured at push time
+  uint32_t correlation_id; // rocprofiler correlation_id at push time
+};
+
 struct RocmTraceCollectorOptions {
   // Maximum number of events to collect from callback API; if -1, no limit.
   // if 0, the callback API is enabled to build a correlation map, but no

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -157,9 +157,9 @@ struct RocmTracerEvent {
 // Represents one pending ROCTX range pushed via roctxRangePushA. Stored on
 // a per-thread stack in RocmTracer and consumed when roctxRangePop fires.
 struct RoctxFrame {
-  std::string message;     // the range label (owned here for lifetime safety)
-  uint64_t start_ns;       // timestamp captured at push time
-  uint32_t correlation_id; // rocprofiler correlation_id at push time
+  std::string message;      // the range label (owned here for lifetime safety)
+  uint64_t start_ns;        // timestamp captured at push time
+  uint64_t correlation_id;  // rocprofiler correlation_id at push time
 };
 
 struct RocmTraceCollectorOptions {


### PR DESCRIPTION
## Motivation

close the gap between cupti nvtx and rocprofiler-sdk roctx.  internal PR first. 