### PR TITLE
regression check on recent ROCM-27094

### DIFF
--- a/perf_tools/rocm_latency_check_tool/README.md
+++ b/perf_tools/rocm_latency_check_tool/README.md
@@ -71,15 +71,6 @@ Requirements:
 
 - An AMD GPU (or several) and a ROCm installation providing `hipcc`. No hipBLASLt.
 
-To build against a **specific ROCm version** (this is the core of the regression
-flow), invoke that version's `hipcc`. The binary embeds the HIP version it was
-built with, which is exactly the version under test:
-
-```bash
-/opt/rocm-7.2.1/bin/hipcc -O3 -std=c++17 rocm_latency_check_tool.cpp -pthread \
-  -o rocm_latency_check_tool_7.2.1
-```
-
 ## Usage
 
 Run with defaults:
@@ -138,6 +129,7 @@ Flags accept both `--flag value` and `--flag=value`.
 | `--skip-d2d` | off | Skip the D2D copy for copy-stage isolation. |
 | `--skip-d2h` | off | Skip the D2H copy for copy-stage isolation. |
 | `--warmup-iters N` | `20` | Warmup iterations per slot before the measured phase. |
+| `--busy-kernel-ns N` | `80000` | Per-busy-kernel GPU duration (ns). `0` = near-nop launch, which puts the tool in a dispatch-bound regime that exposes HIP-runtime / dispatch overhead (used by the [regression validation](#regression-validation-validatesh) case). |
 | `--csv PATH` | disabled | Append one row per report to this CSV file (see below). |
 | `--label STR` | auto | ROCm release tag stamped into the CSV `rocm_version` column (e.g. `7.2.1`). If omitted, the compiled HIP version is used. |
 | `-h`, `--help` | | Print help and exit. |
@@ -150,16 +142,21 @@ buffer on the **neighbor GPU** `(g+1) % num_gpus`; the tool enables peer access
 at startup and the copy becomes a cross-GPU transfer. `--d2d-peer` therefore
 requires `--num-gpus >= 2`.
 
-## The compute kernel is fixed by design
+## The compute kernel shape is fixed by design
 
-The busy kernel's parameters are **compile-time constants** (no flags, no
-environment variables), so the compute baseline is fixed and fully reproducible
-across ROCm versions:
+The busy kernel's **shape** is a compile-time constant, so the compute baseline
+stays reproducible across ROCm versions:
 
-- duration ≈ 80us (`wall_clock64` spin)
 - 256 threads per block
 - blocks = auto (GPU CU count)
 - yields with `s_sleep` while spinning
+- duration ≈ 80us (`wall_clock64` spin) by default
+
+Only the per-kernel **duration** is tunable, via `--busy-kernel-ns` (default
+`80000`). Leave it at the default for normal cross-version latency comparisons.
+Set it to `0` (a near-nop launch) to push the tool into a *dispatch-bound*
+regime where HIP-runtime and stream→hardware-queue overhead dominate — this is
+what makes the dynamic hardware-queue regression measurable (see below).
 
 ## Reading the output
 
@@ -223,7 +220,7 @@ Columns:
 | `skip_h2d`, `skip_d2d`, `skip_d2h` | Copy-stage isolation switches (`1` = skipped). |
 | `warmup_iters` | Warmup iterations per slot before the measured phase. |
 | `compute_op` | Always `timedBusyKernel`. |
-| `busy_kernel_ns`, `busy_kernel_threads`, `busy_kernel_blocks`, `busy_kernel_use_sleep` | Fixed busy-kernel config (documents the compute baseline; `blocks=0` = auto). |
+| `busy_kernel_ns`, `busy_kernel_threads`, `busy_kernel_blocks`, `busy_kernel_use_sleep` | Busy-kernel config (documents the compute baseline). `busy_kernel_ns` reflects `--busy-kernel-ns` (`0` = near-nop dispatch); `threads`/`use_sleep` are fixed and `blocks=0` = auto. |
 | `work_m`, `work_n`, `work_k` | Workload shape that determines the copy sizes. |
 | `count`, `qps` | Requests measured so far and throughput. |
 | `min_us`, `max_us`, `mean_us`, `stddev_us` | Latency summary (microseconds). |
@@ -231,15 +228,107 @@ Columns:
 
 ## Regression workflow: comparing ROCm versions
 
-1. Build one binary per ROCm version using that version's `hipcc` (see
-   [Building](#building)).
+1. Build one binary per ROCm version (see [Building](#building)).
 2. Run each binary with identical flags, writing into the **same** CSV and
    tagging each with a distinct `--label`:
 
 ```bash
-./rocm_latency_check_tool_7.1.0 --duration-sec 30 --csv latency.csv --label 7.1.0
-./rocm_latency_check_tool_7.2.1 --duration-sec 30 --csv latency.csv --label 7.2.1
+./rocm_latency_check_tool_7.2.2 --duration-sec 30 --csv latency.csv --label 7.2.2
+./rocm_latency_check_tool_7.15  --duration-sec 30 --csv latency.csv --label 7.15
 ```
 
 3. Compare the `final` rows (or the percentile columns) across `label`s to spot
    latency/throughput regressions between ROCm versions.
+
+## Regression validation (`validate.sh`)
+
+`validate.sh` is a small harness that runs the **same** binary under several
+environments/configs and prints a compact QPS + tail-latency table, so a
+regression shows up as a gap between rows. HIP **runtime** flags (like
+`DEBUG_HIP_DYNAMIC_QUEUES`) are set as an env prefix in front of the binary, not
+as tool flags — the tool stays a simple, generic benchmark and you choose the
+runtime behavior on the command line.
+
+Run it against a built binary:
+
+```bash
+bash validate.sh ./rocm_latency_check_tool           # the built binary
+DURATION=20 bash validate.sh ./rocm_latency_check_tool
+```
+
+It ships with one worked usage case — the HIP dynamic hardware-queue regression
+below — and is structured so you can add more comparisons by copying that block.
+
+### Usage case: the HIP dynamic hardware-queue regression
+
+Recent HIP runtimes map HIP streams onto a small per-device pool of **hardware
+queues** (`GPU_MAX_HW_QUEUES`, default **4**). With *dynamic queue management*
+enabled (`DEBUG_HIP_DYNAMIC_QUEUES`, default **1**), a stream **releases** its
+hardware queue as soon as it goes idle and **re-acquires / re-selects** one on
+its next submit:
+
+- When the streams in flight per GPU stay **within** the queue pool, this is
+  cheap — a stream simply gets its previous queue back.
+- When streams **oversubscribe** the pool (streams/GPU > `GPU_MAX_HW_QUEUES`),
+  idle/reused streams keep being re-selected onto *different* physical queues.
+  This is the "moving around" that serializes dispatch and inflates latency.
+
+Setting `DEBUG_HIP_DYNAMIC_QUEUES=0` restores a **static** stream→queue mapping
+and removes the churn, so the `1`-vs-`0` gap is a direct measure of the
+regression.
+
+**Why the default pipeline hides it.** Each default request spends ~160us in the
+two busy kernels plus H2D/D2D/D2H copy time, so the per-dispatch queue
+acquire/release/re-select overhead (µs-scale) is completely buried; the tool
+shows essentially identical numbers with dynamic queues on or off. To expose it,
+push the tool into a **dispatch-bound, queue-oversubscribed** regime: many
+streams on one GPU with a near-nop op and copies skipped, so per-dispatch queue
+management dominates. That is exactly what `validate.sh` does — 1 GPU × 64
+streams, 64 threads (16× oversubscription of the 4 queues), `--busy-kernel-ns 0`,
+copies skipped — for `DEBUG_HIP_DYNAMIC_QUEUES=1` vs `=0`.
+
+To run it by hand and record CSV rows (the `--label` values below use the
+convention `<rocm-version>-dq<0|1>`, where `dq1`/`dq0` just mean
+`DEBUG_HIP_DYNAMIC_QUEUES=1`/`=0`; the label is free-form text stamped into the
+CSV so you can tell the rows apart):
+
+```bash
+# dynamic queues ON (runtime default) — the regressed path
+DEBUG_HIP_DYNAMIC_QUEUES=1 ./rocm_latency_check_tool \
+  --num-gpus 1 --streams-per-gpu 64 --consumer-threads 64 \
+  --skip-h2d --skip-d2d --skip-d2h --busy-kernel-ns 0 \
+  --duration-sec 10 --csv qstress.csv --label 7.15-dq1
+
+# dynamic queues OFF (static mapping) — the reference
+DEBUG_HIP_DYNAMIC_QUEUES=0 ./rocm_latency_check_tool \
+  --num-gpus 1 --streams-per-gpu 64 --consumer-threads 64 \
+  --skip-h2d --skip-d2d --skip-d2h --busy-kernel-ns 0 \
+  --duration-sec 10 --csv qstress.csv --label 7.15-dq0
+```
+
+With dynamic queues on you should see a multi-x drop in QPS and a large blow-up
+in the p99/p99.9 tail. Measured on 4× MI355X (gfx950), 1 GPU, 64 streams, 64
+threads, near-nop dispatch:
+
+| runtime | `DEBUG_HIP_DYNAMIC_QUEUES` | QPS | mean (µs) | p99 (µs) | p99.9 (µs) |
+| --- | --- | ---: | ---: | ---: | ---: |
+| ROCm 7.2.2 | `1` (default) | 35,600 | 1,794 | 6,401 | 10,636 |
+| ROCm 7.2.2 | `0` | 313,800 | 202 | 231 | 241 |
+| the-rock 7.15 | `1` (default) | 97,300 | 656 | 3,748 | 5,837 |
+| the-rock 7.15 | `0` | 312,000 | 203 | 231 | 239 |
+
+For contrast, the **default** pipeline (16 streams, no oversubscription) shows
+essentially no difference between `1` and `0` on either runtime — which is why
+the regression is invisible there.
+
+**Notes**
+
+- `GPU_MAX_HW_QUEUES` (HIP runtime env, default 4) is the per-device queue
+  budget; any `--streams-per-gpu` above it triggers the churn, and higher ratios
+  amplify it.
+- Sweep `--busy-kernel-ns` (0 = near-nop) to see how much per-op compute it takes
+  to mask the churn.
+- On runtime builds that emit queue logs you can confirm the churn directly with
+  `AMD_LOG_LEVEL=3 AMD_LOG_MASK=0x10` and counting the `releaseQueue` /
+  `Selected queue` / `acquireQueue` lines (they scale ~linearly with requests
+  when dynamic queues are on, and stay near-constant when off).

--- a/perf_tools/rocm_latency_check_tool/rocm_latency_check_tool.cpp
+++ b/perf_tools/rocm_latency_check_tool/rocm_latency_check_tool.cpp
@@ -25,6 +25,16 @@
 #include <vector>
 #include <cstring>
 
+// The synthetic compute op is a fixed on-GPU busy kernel. The thread/block/sleep
+// shape is a compile-time constant so the compute baseline stays reproducible
+// across ROCm versions. Only the per-kernel duration is tunable (--busy-kernel-ns)
+// so the tool can also be pushed into a dispatch-bound regime (duration 0 = a
+// near-nop launch) that exposes HIP-runtime + dispatch overhead.
+constexpr long long kBusyKernelDurationNsDefault = 80000;  // ~80us synthetic compute
+constexpr int kBusyKernelThreads = 256;
+constexpr int kBusyKernelBlocks = 0;                // 0 = auto (use CU count)
+constexpr bool kBusyKernelUseSleep = true;
+
 // Runtime configuration. Every field is overridable via a command-line flag
 // (see parse_args / --help); the initializers below are the defaults and match
 // the values this tool historically hard-coded.
@@ -47,6 +57,7 @@ struct Config {
   bool skip_d2d = false;             // --skip-d2d
   bool skip_d2h = false;             // --skip-d2h
   int warmup_iters = 20;             // --warmup-iters
+  long long busy_kernel_ns = kBusyKernelDurationNsDefault;  // --busy-kernel-ns (0 = near-nop dispatch)
   std::string csv_path;             // --csv (empty = CSV disabled)
   std::string label;                // --label (ROCm release tag, e.g. 7.2.1)
 
@@ -56,14 +67,6 @@ struct Config {
 
 // Parsed once at the very start of main() before any GPU resources exist.
 Config g_cfg;
-
-// The synthetic compute op is a fixed on-GPU busy kernel. These are compile-time
-// constants by design (no flags, no env) so the compute baseline is fixed and
-// fully reproducible across ROCm versions; only HIP runtime + copy overhead varies.
-constexpr long long kBusyKernelDurationNs = 80000;  // ~80us synthetic compute
-constexpr int kBusyKernelThreads = 256;
-constexpr int kBusyKernelBlocks = 0;                // 0 = auto (use CU count)
-constexpr bool kBusyKernelUseSleep = true;
 
 #define HIP_CHECK(cmd)                                                         \
   do {                                                                         \
@@ -338,7 +341,7 @@ static inline void launch_compute_op(GpuResources& gpu,
   const int blocks = (kBusyKernelBlocks > 0) ? kBusyKernelBlocks
                                              : std::max(1, gpu.multiprocessor_count);
   timedBusyKernel<<<blocks, kBusyKernelThreads, 0, stream>>>(
-      kBusyKernelDurationNs,
+      g_cfg.busy_kernel_ns,
       static_cast<long long>(gpu.wall_clock_rate_khz),
       kBusyKernelUseSleep,
       nullptr);
@@ -797,7 +800,7 @@ class CsvWriter {
          << (g_cfg.skip_d2h ? 1 : 0) << ','
          << g_cfg.warmup_iters << ','
          << compute_op_ << ','
-         << kBusyKernelDurationNs << ','
+         << g_cfg.busy_kernel_ns << ','
          << kBusyKernelThreads << ','
          << kBusyKernelBlocks << ','
          << (kBusyKernelUseSleep ? 1 : 0) << ','
@@ -870,6 +873,8 @@ static void print_usage(const char* prog) {
       "  --skip-d2d                skip D2D copy for copy-stage isolation [%s]\n"
       "  --skip-d2h                skip D2H copy for copy-stage isolation [%s]\n"
       "  --warmup-iters N          warmup iterations per slot before measuring [%d]\n"
+      "  --busy-kernel-ns N        per-busy-kernel GPU duration in ns; 0 = near-nop\n"
+      "                            dispatch (dispatch-bound regime) [%lld]\n"
       "  --csv PATH                append per-report rows to this CSV file [disabled]\n"
       "  --label STR               ROCm release tag stamped into CSV (e.g. 7.2.1) [auto]\n"
       "  -h, --help                show this help and exit\n\n"
@@ -881,7 +886,7 @@ static void print_usage(const char* prog) {
       g_cfg.preload_weights ? "on" : "off", g_cfg.extra_h2d_bytes,
       g_cfg.extra_h2d_count, g_cfg.skip_h2d ? "on" : "off",
       g_cfg.skip_d2d ? "on" : "off", g_cfg.skip_d2h ? "on" : "off",
-      g_cfg.warmup_iters);
+      g_cfg.warmup_iters, g_cfg.busy_kernel_ns);
 }
 
 static ParseResult parse_args(int argc, char** argv) {
@@ -993,6 +998,10 @@ static ParseResult parse_args(int argc, char** argv) {
       g_cfg.skip_d2h = true;
     } else if (matches(arg, "--warmup-iters")) {
       if (!parse_int_arg(i, "--warmup-iters", g_cfg.warmup_iters)) return ParseResult::kError;
+    } else if (matches(arg, "--busy-kernel-ns")) {
+      size_t tmp = 0;
+      if (!parse_size_arg(i, "--busy-kernel-ns", tmp)) return ParseResult::kError;
+      g_cfg.busy_kernel_ns = static_cast<long long>(tmp);
     } else if (matches(arg, "--csv")) {
       if (!need_value(i, "--csv", val)) return ParseResult::kError;
       g_cfg.csv_path = val;
@@ -1144,8 +1153,9 @@ int main(int argc, char** argv) {
               g_cfg.num_gpus, g_cfg.streams_per_gpu, GpuResources::kStreamsPerSlot,
               g_cfg.num_gpus * g_cfg.streams_per_gpu * GpuResources::kStreamsPerSlot);
   std::printf("Compute op: timedBusyKernel x2 per request (HIP runtime latency probe)\n");
-  std::printf("timedBusyKernel config: duration_ns=%lld blocks=%d threads=%d use_sleep=%s\n",
-              static_cast<long long>(kBusyKernelDurationNs),
+  std::printf("timedBusyKernel config: duration_ns=%lld%s blocks=%d threads=%d use_sleep=%s\n",
+              g_cfg.busy_kernel_ns,
+              (g_cfg.busy_kernel_ns == 0 ? " (near-nop dispatch)" : ""),
               (kBusyKernelBlocks > 0 ? kBusyKernelBlocks : std::max(1, resources[0]->multiprocessor_count)),
               kBusyKernelThreads,
               kBusyKernelUseSleep ? "true" : "false");

--- a/perf_tools/rocm_latency_check_tool/validate.sh
+++ b/perf_tools/rocm_latency_check_tool/validate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# validate.sh - regression-validation harness for rocm_latency_check_tool.
+#
+# Runs the SAME tool binary under several environments/configs and prints a
+# compact QPS + tail-latency table, so a regression shows up as a gap between
+# rows. HIP *runtime* flags (e.g. DEBUG_HIP_DYNAMIC_QUEUES) are set in front of
+# the binary as an env prefix, never as tool flags -- the tool stays a simple,
+# generic benchmark and you pick the runtime behavior on the command line.
+#
+# Usage:
+#   ./validate.sh [path-to-binary]      # default: ./rocm_latency_check_tool
+#   DURATION=20 ./validate.sh ./tool    # override per-run duration (seconds)
+#
+# To compare across ROCm versions, build one binary per version (see README's
+# "Building" section) and run this script once per binary.
+#
+set -uo pipefail
+
+BIN="${1:-./rocm_latency_check_tool}"
+DURATION="${DURATION:-10}"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "error: '$BIN' not found or not executable" >&2
+  echo "usage: $0 [path-to-rocm_latency_check_tool]" >&2
+  exit 1
+fi
+
+# Pull QPS / mean / p99 / p99.9 / count out of a tool run (last report wins).
+summarize() {
+  awk '
+    /count =/  {c=$3}
+    /mean =/   {m=$3}
+    / 99% <=/  {p99=$3}
+    /99.9% <=/ {p999=$3}
+    /QPS =/    {q=$3}
+    END { printf "QPS=%-11s mean_us=%-9s p99_us=%-9s p999_us=%-9s (n=%s)\n", q, m, p99, p999, c }
+  '
+}
+
+# run <row-label> <env-prefix> <tool-args...>
+run() {
+  local label="$1"; shift
+  local envp="$1"; shift
+  printf "  %-30s : " "$label"
+  env $envp "$BIN" "$@" \
+      --duration-sec "$DURATION" --report-interval-sec "$DURATION" 2>/dev/null \
+    | summarize
+}
+
+echo "binary : $BIN"
+echo "config : duration=${DURATION}s/run"
+echo
+
+# ---------------------------------------------------------------------------
+# Usage case: HIP dynamic hardware-queue regression.
+#
+# The HIP runtime maps streams onto a small per-device pool of hardware queues
+# (GPU_MAX_HW_QUEUES, default 4). With dynamic queue management on
+# (DEBUG_HIP_DYNAMIC_QUEUES=1, the runtime default) an idle stream releases its
+# HW queue and re-selects one on its next submit; when many streams
+# oversubscribe the 4-queue pool this "moving around" serializes dispatch.
+#
+# Put the tool in a dispatch-bound regime (near-nop op, copies skipped) with 64
+# streams on 1 GPU (16x oversubscription) so per-dispatch queue management
+# dominates, then compare the runtime flag ON vs OFF.
+# ---------------------------------------------------------------------------
+echo "== HIP dynamic hardware-queue regression (1 GPU, 64 streams, near-nop dispatch) =="
+QCFG=(--num-gpus 1 --streams-per-gpu 64 --consumer-threads 64
+      --skip-h2d --skip-d2d --skip-d2h --busy-kernel-ns 0 --warmup-iters 10)
+run "DEBUG_HIP_DYNAMIC_QUEUES=1 (default)" "DEBUG_HIP_DYNAMIC_QUEUES=1" "${QCFG[@]}"
+run "DEBUG_HIP_DYNAMIC_QUEUES=0 (static)"  "DEBUG_HIP_DYNAMIC_QUEUES=0" "${QCFG[@]}"
+echo
+echo "A large QPS drop / p99.9 blow-up on the =1 row vs the =0 row is the dynamic"
+echo "hardware-queue regression. The default pipeline (run without the flags above)"
+echo "hides it, because compute + copy time dominates each request."
+
+# ---------------------------------------------------------------------------
+# Add more usage cases below by copying the block above, e.g. a different env
+# prefix ("" for none), a different tool config, and two or more run rows to
+# compare. Keep runtime flags as the env prefix, not as tool flags.
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Make `rocm_latency_check_tool` able to detect the HIP **dynamic hardware-queue**
regression (ROCM-27094), which its default configuration completely hides. 


The tool's default pipeline can't see this: ~160 µs of busy-kernel compute plus
H2D/D2D/D2H copies dominate each request, burying the µs-scale per-dispatch queue
overhead. So `DEBUG_HIP_DYNAMIC_QUEUES=1` vs `=0` (and 7.2.x vs newer) look
identical, even though the regression is real.


Adds a single generic knob (`--busy-kernel-ns`) plus a small `validate.sh` harness
that reproduces the regression as a clear QPS / tail-latency gap.


## Technical Details

- **`rocm_latency_check_tool.cpp`**: add `--busy-kernel-ns N` (default `80000`;
  `0` = near-nop launch). The busy-kernel duration used to be a compile-time
  constant; making it tunable lets the tool run in a dispatch-bound regime where
  HIP-runtime/dispatch overhead is measurable. No behavior change at defaults.
  The HIP runtime flag itself is **not** a tool flag — set it as an env prefix.
- **`validate.sh`** (new): regression-validation harness that runs the same
  binary under multiple env/config rows and prints a compact QPS + p99/p99.9
  table. Ships with the ROCM-27094 case as the worked example (1 GPU × 64
  streams, 64 threads = 16× oversubscription, near-nop op, copies skipped),
  comparing `DEBUG_HIP_DYNAMIC_QUEUES=1` vs `=0`.
- **`README.md`**: document `--busy-kernel-ns`, add a "Regression validation
  (`validate.sh`)" section explaining the mechanism, the detection recipe, and
  the results, plus the `dq0`/`dq1` label convention.


## Test Plan


Build one binary per ROCm version and run the harness:
```bash
bash validate.sh ./rocm_latency_check_tool
