### PR TITLE
[WIP][ROCm] Handle singleton tile dims in TDM lowering

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -102,6 +102,7 @@ cc_library(
     hdrs = ["lowering_util.h"],
     deps = [
         ":tma_utils",
+        "//xla:permutation_util",
         "//xla:util",
         "//xla/backends/gpu/codegen/triton/ir:triton_xla",
         "//xla/codegen/emitters/ir:xla",

--- a/xla/backends/gpu/codegen/triton/lowering_util.cc
+++ b/xla/backends/gpu/codegen/triton/lowering_util.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "xla/backends/gpu/codegen/triton/lowering_util.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -46,6 +47,7 @@ limitations under the License.
 #include "xla/hlo/analysis/indexing_map.h"
 #include "xla/hlo/analysis/interval.h"
 #include "xla/hlo/analysis/symbolic_map.h"
+#include "xla/permutation_util.h"
 #include "xla/stream_executor/gpu/tma_metadata.h"
 #include "xla/stream_executor/launch_dim.h"
 #include "xla/tsl/platform/statusor.h"
@@ -170,6 +172,30 @@ llvm::SmallVector<int64_t> ComputeStrides(llvm::ArrayRef<int64_t> shape,
     stride *= shape[dim];
   }
   return result;
+}
+
+bool IsMajorToMinorLayout(llvm::ArrayRef<int64_t> layout) {
+  for (auto [i, value] : llvm::enumerate(layout)) {
+    if (value != layout.size() - 1 - i) {
+      return false;
+    }
+  }
+  return true;
+}
+
+llvm::SmallVector<mlir::Value> GetMajorToMinorOrder(
+    mlir::ValueRange values, llvm::ArrayRef<int64_t> layout) {
+  return GetMajorToMinorOrder(
+      llvm::ArrayRef<mlir::Value>(llvm::to_vector(values)), layout);
+}
+
+llvm::SmallVector<int32_t> GetInverseLayoutPermutation(
+    llvm::ArrayRef<int64_t> layout) {
+  auto reversed_layout = llvm::to_vector(layout);
+  std::reverse(reversed_layout.begin(), reversed_layout.end());
+  auto permutation =
+      llvm::to_vector_of<int32_t>(::xla::InversePermutation(reversed_layout));
+  return llvm::SmallVector<int32_t>(permutation.begin(), permutation.end());
 }
 
 llvm::SmallVector<unsigned> GetRetainedDims(

--- a/xla/backends/gpu/codegen/triton/lowering_util.h
+++ b/xla/backends/gpu/codegen/triton/lowering_util.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_BACKENDS_GPU_CODEGEN_TRITON_LOWERING_UTIL_H_
 #define XLA_BACKENDS_GPU_CODEGEN_TRITON_LOWERING_UTIL_H_
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <utility>
@@ -31,10 +32,37 @@ limitations under the License.
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
+#include "xla/permutation_util.h"
 #include "xla/stream_executor/gpu/tma_metadata.h"
 #include "xla/stream_executor/launch_dim.h"
 
 namespace xla::gpu::triton {
+
+// Checks whether 'layout' is the default HLO layout in major-to-minor order,
+// i.e. iff it's [N-1, N-2, ... 1, 0].
+bool IsMajorToMinorLayout(llvm::ArrayRef<int64_t> layout);
+
+// Returns 'values' in major-to-minor order given minor-to-major 'layout'.
+template <typename T>
+llvm::SmallVector<T> GetMajorToMinorOrder(llvm::ArrayRef<T> values,
+                                          llvm::ArrayRef<int64_t> layout) {
+  if (IsMajorToMinorLayout(layout)) {
+    return llvm::to_vector(values);
+  }
+  auto reversed_layout = llvm::to_vector(layout);
+  std::reverse(reversed_layout.begin(), reversed_layout.end());
+  std::vector<T> vector = ::xla::Permute(values, reversed_layout);
+  return llvm::SmallVector<T>(vector.begin(), vector.end());
+}
+
+// Returns 'values' in major-to-minor order given minor-to-major 'layout'.
+llvm::SmallVector<mlir::Value> GetMajorToMinorOrder(
+    mlir::ValueRange values, llvm::ArrayRef<int64_t> layout);
+
+// Given the layout of a tensor, return the inverse permutation required to
+// transpose an already major-to-minor tensor to the original tensor.
+llvm::SmallVector<int32_t> GetInverseLayoutPermutation(
+    llvm::ArrayRef<int64_t> layout);
 
 // Extracts thread dimensions from Triton module attributes.
 absl::StatusOr<stream_executor::ThreadDim> ExtractThreadDims(

--- a/xla/backends/gpu/codegen/triton/transforms/BUILD
+++ b/xla/backends/gpu/codegen/triton/transforms/BUILD
@@ -29,6 +29,23 @@ gentbl_cc_library(
 )
 
 cc_library(
+    name = "tdm_lowering_util",
+    srcs = ["tdm_lowering_util.cc"],
+    hdrs = ["tdm_lowering_util.h"],
+    deps = [
+        "//xla/backends/gpu/codegen/triton:lowering_util",
+        "//xla/service:decision",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+        "@triton//:TritonDialects",
+    ],
+)
+
+cc_library(
     name = "passes",
     srcs = [
         "arith_fp8_conversion_to_triton.cc",
@@ -60,6 +77,7 @@ cc_library(
     ],
     deps = [
         ":passes_inc_gen",
+        ":tdm_lowering_util",
         "//xla:permutation_util",
         "//xla:util",
         "//xla:xla_data_proto_cc",

--- a/xla/backends/gpu/codegen/triton/transforms/tdm_lowering_util.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/tdm_lowering_util.cc
@@ -1,0 +1,208 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/codegen/triton/transforms/tdm_lowering_util.h"
+
+#include <cstdint>
+#include <optional>
+
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Support/LLVM.h"
+#include "xla/backends/gpu/codegen/triton/lowering_util.h"
+#include "xla/service/decision.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+
+namespace mlir::triton::xla {
+
+namespace xtriton = ::xla::gpu::triton;
+namespace arith = ::mlir::arith;
+
+SmallVector<int64_t> GetSingletonTileDims(
+    ArrayRef<int64_t> tile_sizes, ArrayRef<int64_t> minor_to_major_layout) {
+  SmallVector<int64_t> singletons;
+  for (int64_t dim : minor_to_major_layout) {
+    if (tile_sizes[dim] == 1) {
+      singletons.push_back(dim);
+    }
+  }
+  return singletons;
+}
+
+::xla::Decision CanUseTdm(bool allow_tdm, ArrayRef<int64_t> original_shape,
+                          ArrayRef<int64_t> tile_sizes,
+                          ArrayRef<int64_t> tile_strides,
+                          ArrayRef<int64_t> minor_to_major_layout,
+                          int64_t element_bit_width) {
+  if (!allow_tdm) {
+    return ::xla::Decision::Forbid("TDM is disabled.");
+  }
+  // Dynamic sizes or strides would feed sentinel values into the i32/i64
+  // descriptor constants and silently produce a malformed descriptor.
+  if (mlir::ShapedType::isDynamicShape(tile_sizes) ||
+      mlir::ShapedType::isDynamicShape(tile_strides)) {
+    return ::xla::Decision::Forbid("dynamic tile sizes or strides.");
+  }
+  // TDM descriptors describe contiguous boxes; non-unit (or zero) tile strides
+  // cannot be expressed and would silently produce a contiguous load.
+  for (int64_t s : tile_strides) {
+    if (s != 1) {
+      return ::xla::Decision::Forbid("non-unit tile stride.");
+    }
+  }
+  // The minor-most surviving (non-singleton) tile dim, after folding all
+  // singleton dims into the base pointer, must have global stride 1.
+  std::optional<int64_t> minor_survivor;
+  for (int64_t dim : minor_to_major_layout) {
+    if (tile_sizes[dim] != 1) {
+      minor_survivor = dim;
+      break;
+    }
+  }
+  if (!minor_survivor.has_value()) {
+    return ::xla::Decision::Forbid("all tile dims are singletons.");
+  }
+  SmallVector<int64_t> original_strides =
+      xtriton::ComputeStrides(original_shape, minor_to_major_layout);
+  if (original_strides[*minor_survivor] != 1) {
+    return ::xla::Decision::Forbid(
+        "surviving minor-most dim has global stride != 1.");
+  }
+  constexpr int64_t kDwordBitWidth = 32;
+  constexpr int64_t kMinPadIntervalBits = 2 * kDwordBitWidth;
+  if (tile_sizes[*minor_survivor] * element_bit_width < kMinPadIntervalBits) {
+    return ::xla::Decision::Forbid(
+        "surviving minor-most dim spans fewer than 2 dwords.");
+  }
+  return ::xla::Decision::Allow();
+}
+
+bool TdmAllowed(const ::xla::Decision& decision) {
+  if (!decision) {
+    VLOG(1) << "Can't use TDM: " << decision.Explain();
+  }
+  return decision.IsAllowed();
+}
+
+TdmDescriptorOperands::TdmDescriptorOperands(Value pointer,
+                                             ArrayRef<int64_t> shape,
+                                             ArrayRef<int64_t> layout,
+                                             ArrayRef<int64_t> sizes,
+                                             ValueRange offsets)
+    : pointer(pointer),
+      shape(shape),
+      layout(layout),
+      strides(xtriton::ComputeStrides(shape, layout)),
+      sizes(sizes),
+      offsets(offsets) {}
+
+TdmDescriptorOperands TdmDescriptorOperands::DropSingletonTileDims(
+    ImplicitLocOpBuilder& builder, ArrayRef<int64_t> dims_to_drop) const {
+  if (dims_to_drop.empty()) {
+    return *this;
+  }
+  int64_t rank = shape.size();
+
+  // Fold each dropped dim's fixed offset into the base pointer, and map each
+  // surviving dim to its index in the reduced rank (dropped dims map to -1):
+  //   new_ptr = ptr + sum(offset[d] * stride[d]) for d in dims_to_drop.
+  SmallVector<int64_t> old_to_new(rank, -1);
+  Value element_offset;
+  for (int64_t dim = 0, new_index = 0; dim < rank; ++dim) {
+    if (!llvm::is_contained(dims_to_drop, dim)) {
+      old_to_new[dim] = new_index++;
+      continue;
+    }
+    Value offset_i64 =
+        xtriton::IndexCast(builder, builder.getI64Type(), offsets[dim])[0];
+    Value stride_i64 = arith::ConstantOp::create(
+        builder, builder.getI64IntegerAttr(strides[dim]));
+    Value contribution = arith::MulIOp::create(builder, offset_i64, stride_i64);
+    element_offset = element_offset ? arith::AddIOp::create(
+                                          builder, element_offset, contribution)
+                                    : contribution;
+  }
+
+  TdmDescriptorOperands result;
+  result.pointer =
+      AddPtrOp::create(builder, pointer.getType(), pointer, element_offset);
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    if (old_to_new[dim] < 0) {
+      continue;
+    }
+    result.shape.push_back(shape[dim]);
+    result.strides.push_back(strides[dim]);
+    result.sizes.push_back(sizes[dim]);
+    result.offsets.push_back(offsets[dim]);
+  }
+  for (int64_t dim : layout) {
+    if (old_to_new[dim] >= 0) {
+      result.layout.push_back(old_to_new[dim]);
+    }
+  }
+  return result;
+}
+
+MakeTensorDescOp BuildTensorDescriptor(ImplicitLocOpBuilder& builder,
+                                       const TdmDescriptorOperands& operands) {
+  // Global shape as i32 SSA values, in major-to-minor order.
+  auto ordered_shape = xtriton::GetMajorToMinorOrder(
+      ArrayRef<int64_t>(operands.shape), operands.layout);
+  SmallVector<Value> shape_values;
+  for (int64_t dim : ordered_shape) {
+    shape_values.push_back(
+        arith::ConstantOp::create(builder, builder.getI32IntegerAttr(dim)));
+  }
+
+  // Global strides as i64 SSA values, in major-to-minor order.
+  auto ordered_strides = xtriton::GetMajorToMinorOrder(
+      ArrayRef<int64_t>(operands.strides), operands.layout);
+  SmallVector<Value> stride_values;
+  for (int64_t s : ordered_strides) {
+    stride_values.push_back(
+        arith::ConstantOp::create(builder, builder.getI64IntegerAttr(s)));
+  }
+
+  // Block shape in major-to-minor order as i32.
+  auto ordered_sizes = xtriton::GetMajorToMinorOrder(
+      ArrayRef<int64_t>(operands.sizes), operands.layout);
+  SmallVector<int32_t> block_shape;
+  for (int64_t s : ordered_sizes) {
+    CHECK_LE(s, INT32_MAX) << "tile dim " << s << " exceeds i32 range";
+    block_shape.push_back(static_cast<int32_t>(s));
+  }
+
+  auto element_type =
+      cast<PointerType>(operands.pointer.getType()).getPointeeType();
+  bool is_signed_integer =
+      mlir::isa<IntegerType>(element_type) && !element_type.isUnsignedInteger();
+
+  return MakeTensorDescOp::create(builder, operands.pointer, shape_values,
+                                  stride_values, block_shape, is_signed_integer,
+                                  PaddingOption::PAD_ZERO);
+}
+
+}  // namespace mlir::triton::xla

--- a/xla/backends/gpu/codegen/triton/transforms/tdm_lowering_util.h
+++ b/xla/backends/gpu/codegen/triton/transforms/tdm_lowering_util.h
@@ -1,0 +1,104 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_CODEGEN_TRITON_TRANSFORMS_TDM_LOWERING_UTIL_H_
+#define XLA_BACKENDS_GPU_CODEGEN_TRITON_TRANSFORMS_TDM_LOWERING_UTIL_H_
+
+#include <cstdint>
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "xla/service/decision.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir::triton::xla {
+
+// Returns the original dim indices of all size-1 tile dims.
+llvm::SmallVector<int64_t> GetSingletonTileDims(
+    llvm::ArrayRef<int64_t> tile_sizes,
+    llvm::ArrayRef<int64_t> minor_to_major_layout);
+
+// Whether the tile shape is compatible with AMD TDM lowering. Rejects:
+//   - dynamic tile sizes or strides
+//   - non-unit tile strides
+//   - tiles the singleton fold cannot turn into a valid TDM box
+//   - tiles whose surviving minor-most dim spans fewer than 2 dwords
+//
+// Singleton (size-1) tile dims are folded into the base pointer (at any
+// position, not just trailing) and dropped from the descriptor.
+// TDM requires the descriptor's minor-most dim to have global stride 1. After
+// folding, that dim is the minor-most survivor, which keeps stride 1 only if no
+// folded singleton was more-minor than it. A batch-major operand [1, M, K]
+// keeps K's stride 1 (accept); a batch-minor operand [M, K, 1] makes K inherit
+// the batch's non-unit stride (reject).
+//
+// TDM encodes LDS padding as a power-of-two dword interval from the minor-most
+// extent (Triton's TDMUtility.cpp); a single-dword extent underflows that field
+// to garbage, so require >= 2 dwords (e.g. f8[.,.,4] = 1 dword is rejected).
+//
+// Not checked here, deferred to upstream Triton / hardware legalization:
+//   - Hardware rank cap (TDM supports ranks 1 to 5).
+//   - Per-dim box size limits.
+//   - Padding mode compatibility (this pass hardcodes PAD_ZERO).
+::xla::Decision CanUseTdm(bool allow_tdm,
+                          llvm::ArrayRef<int64_t> original_shape,
+                          llvm::ArrayRef<int64_t> tile_sizes,
+                          llvm::ArrayRef<int64_t> tile_strides,
+                          llvm::ArrayRef<int64_t> minor_to_major_layout,
+                          int64_t element_bit_width);
+
+// Wraps CanUseTdm, logging the reason when TDM is declined.
+bool TdmAllowed(const ::xla::Decision& decision);
+
+// Operands for a TDM tensor descriptor. Constructed from the full tile, then
+// optionally reduced via DropSingletonTileDims.
+struct TdmDescriptorOperands {
+  TdmDescriptorOperands(Value pointer, llvm::ArrayRef<int64_t> shape,
+                        llvm::ArrayRef<int64_t> layout,
+                        llvm::ArrayRef<int64_t> sizes, ValueRange offsets);
+
+  // Returns a copy with dims_to_drop (the size-1 tile dims, at any position)
+  // folded out: their fixed offset is baked into the base pointer via tt.addptr
+  // and they are dropped from every field, with layout renumbered to the
+  // reduced rank. Returns *this unchanged if empty. Survivors keep the pre-fold
+  // strides (recomputing from the reduced shape would lose the dropped dims'
+  // extents).
+  TdmDescriptorOperands DropSingletonTileDims(
+      ImplicitLocOpBuilder& builder,
+      llvm::ArrayRef<int64_t> dims_to_drop) const;
+
+  Value pointer;
+  llvm::SmallVector<int64_t> shape;
+  llvm::SmallVector<int64_t> layout;
+  llvm::SmallVector<int64_t> strides;
+  llvm::SmallVector<int64_t> sizes;
+  llvm::SmallVector<Value> offsets;
+
+ private:
+  TdmDescriptorOperands() = default;
+};
+
+// Builds a tt.make_tensor_descriptor for a contiguous box load/store from the
+// given operands, reordered major-to-minor for Triton's TDM legalizer. Padding
+// is hardcoded to PAD_ZERO.
+MakeTensorDescOp BuildTensorDescriptor(ImplicitLocOpBuilder& builder,
+                                       const TdmDescriptorOperands& operands);
+
+}  // namespace mlir::triton::xla
+
+#endif  // XLA_BACKENDS_GPU_CODEGEN_TRITON_TRANSFORMS_TDM_LOWERING_UTIL_H_

--- a/xla/backends/gpu/codegen/triton/transforms/tests/triton_pipeline_tdm.mlir
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/triton_pipeline_tdm.mlir
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ==============================================================================
-// RUN: xla-opt %s --triton-xla-pipeline='target=gfx1250' \
+// RUN: xla-opt %s -split-input-file --triton-xla-pipeline='target=gfx1250' \
 // RUN:   | FileCheck %s --check-prefix=CHECK-TDM
 //
-// RUN: xla-opt %s --triton-xla-pipeline='target=gfx950' \
+// RUN: xla-opt %s -split-input-file --triton-xla-pipeline='target=gfx950' \
 // RUN:   | FileCheck %s --check-prefix=CHECK-NOTDM
 
 // Verifies that the full Triton XLA + AMD lowering pipeline emits TDM
@@ -37,6 +37,63 @@ func.func @lower_extract_insert(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>) {
 // CHECK-TDM:       tensor.store.from.lds
 
 // CHECK-NOTDM-LABEL: llvm.func @lower_extract_insert
+// CHECK-NOTDM-NOT:   tensor.load.to.lds
+// CHECK-NOTDM-NOT:   tensor.store.from.lds
+// CHECK-NOTDM:       raw.ptr.buffer.load
+
+// -----
+
+func.func @batched_dot(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>,
+                       %arg2: !tt.ptr<bf16>) {
+  %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32>
+
+  %lhs_tile = triton_xla.extract from %arg0
+      as memref<4x32x256xbf16, #xtile.layout<[2, 1, 0]>>
+      [2, 0, 0] [1, 32, 256] [1, 1, 1] : tensor<32x256xbf16>
+
+  %rhs_tile = triton_xla.extract from %arg1
+      as memref<4x256x32xbf16, #xtile.layout<[2, 1, 0]>>
+      [2, 0, 0] [1, 256, 32] [1, 1, 1] : tensor<256x32xbf16>
+
+  %dot = tt.dot %lhs_tile, %rhs_tile, %cst, inputPrecision = tf32
+      : tensor<32x256xbf16> * tensor<256x32xbf16> -> tensor<32x32xf32>
+  %dot_bf16 = arith.truncf %dot : tensor<32x32xf32> to tensor<32x32xbf16>
+
+  triton_xla.insert %dot_bf16 into %arg2
+      as memref<32x32xbf16, #xtile.layout<[1, 0]>>
+      [0, 0] [32, 32] [1, 1] : tensor<32x32xbf16>
+  func.return
+}
+
+// CHECK-TDM-LABEL: llvm.func @batched_dot
+// CHECK-TDM:       tensor.load.to.lds
+// CHECK-TDM:       tensor.load.to.lds
+// CHECK-TDM:       s.wait.tensorcnt
+// CHECK-TDM:       tensor.store.from.lds
+
+// CHECK-NOTDM-LABEL: llvm.func @batched_dot
+// CHECK-NOTDM-NOT:   tensor.load.to.lds
+// CHECK-NOTDM-NOT:   tensor.store.from.lds
+// CHECK-NOTDM:       raw.ptr.buffer.load
+
+// -----
+
+func.func @lower_extract_insert_3d(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>) {
+  %extracted_tensor = triton_xla.extract from %arg0
+      as memref<32x256x4xbf16, #xtile.layout<[2, 1, 0]>>
+      [0, 0, 0] [32, 256, 4] [1, 1, 1] : tensor<32x256x4xbf16>
+  triton_xla.insert %extracted_tensor into %arg1
+      as memref<32x256x4xbf16, #xtile.layout<[2, 1, 0]>>
+      [0, 0, 0] [32, 256, 4] [1, 1, 1] : tensor<32x256x4xbf16>
+  func.return
+}
+
+// CHECK-TDM-LABEL: llvm.func @lower_extract_insert_3d
+// CHECK-TDM:       tensor.load.to.lds
+// CHECK-TDM:       s.wait.tensorcnt
+// CHECK-TDM:       tensor.store.from.lds
+
+// CHECK-NOTDM-LABEL: llvm.func @lower_extract_insert_3d
 // CHECK-NOTDM-NOT:   tensor.load.to.lds
 // CHECK-NOTDM-NOT:   tensor.store.from.lds
 // CHECK-NOTDM:       raw.ptr.buffer.load

--- a/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_extract_insert_to_triton.mlir
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_extract_insert_to_triton.mlir
@@ -48,15 +48,110 @@ func.func @lower_extract_insert(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>) {
 // CHECK-TMA:         tt.descriptor_store %arg1[{{.*}}],
 // CHECK-TMA:         tt.return
 
-// Middle singleton dim is TDM-incompatible, so fall back to pointer loads.
 // CHECK-TDM-LABEL: tt.func @lower_extract_insert(
 // CHECK-TDM-SAME:      %arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
 // CHECK-TDM-SAME:      %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32}) {
+// CHECK-TDM:         %[[PTR0:.*]] = tt.addptr %arg0, %{{.*}} : !tt.ptr<bf16>, i64
+// CHECK-TDM:         %[[DESC0:.*]] = tt.make_tensor_descriptor %[[PTR0]]
+// CHECK-TDM-SAME:       <bf16>, <16x64xbf16>
+// CHECK-TDM:         %[[LOAD:.*]] = tt.descriptor_load %[[DESC0]]
+// CHECK-TDM:         %[[PTR1:.*]] = tt.addptr %arg1, %{{.*}} : !tt.ptr<bf16>, i64
+// CHECK-TDM:         %[[DESC1:.*]] = tt.make_tensor_descriptor %[[PTR1]]
+// CHECK-TDM-SAME:       <bf16>, <16x64xbf16>
+// CHECK-TDM:         tt.descriptor_store %[[DESC1]]{{.*}}, %[[LOAD]]
+// CHECK-TDM:         tt.return
+
+// -----
+
+func.func @lower_extract_insert_batch_major_dim(
+    %arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>) {
+  %extracted_tensor = triton_xla.extract from %arg0
+      as memref<4x32x256xbf16, #xtile.layout<[2, 1, 0]>>
+      [2, 0, 0] [1, 32, 256] [1, 1, 1] : tensor<32x256xbf16>
+  triton_xla.insert %extracted_tensor into %arg1
+      as memref<4x32x256xbf16, #xtile.layout<[2, 1, 0]>>
+      [1, 0, 0] [1, 32, 256] [1, 1, 1] : tensor<32x256xbf16>
+  func.return
+}
+
+// CHECK-TDM-LABEL: tt.func @lower_extract_insert_batch_major_dim(
+// CHECK-TDM:         %[[PTR0:.*]] = tt.addptr %arg0, %{{.*}} : !tt.ptr<bf16>, i64
+// CHECK-TDM:         %[[DESC0:.*]] = tt.make_tensor_descriptor %[[PTR0]]
+// CHECK-TDM-SAME:       <bf16>, <32x256xbf16>
+// CHECK-TDM:         %[[LOAD:.*]] = tt.descriptor_load %[[DESC0]]
+// CHECK-TDM:         %[[PTR1:.*]] = tt.addptr %arg1, %{{.*}} : !tt.ptr<bf16>, i64
+// CHECK-TDM:         %[[DESC1:.*]] = tt.make_tensor_descriptor %[[PTR1]]
+// CHECK-TDM-SAME:       <bf16>, <32x256xbf16>
+// CHECK-TDM:         tt.descriptor_store %[[DESC1]]{{.*}}, %[[LOAD]]
+// CHECK-TDM:         tt.return
+
+// -----
+
+func.func @lower_extract_insert_small_minor_dim(
+    %arg0: !tt.ptr<f8E4M3FN>, %arg1: !tt.ptr<f8E4M3FN>) {
+  %extracted_tensor = triton_xla.extract from %arg0
+      as memref<4x128x4xf8E4M3FN, #xtile.layout<[2, 1, 0]>>
+      [2, 0, 0] [1, 128, 4] [1, 1, 1] : tensor<128x4xf8E4M3FN>
+  triton_xla.insert %extracted_tensor into %arg1
+      as memref<4x128x4xf8E4M3FN, #xtile.layout<[2, 1, 0]>>
+      [1, 0, 0] [1, 128, 4] [1, 1, 1] : tensor<128x4xf8E4M3FN>
+  func.return
+}
+
+// CHECK-TDM-LABEL: tt.func @lower_extract_insert_small_minor_dim(
 // CHECK-TDM-NOT:     tt.make_tensor_descriptor
 // CHECK-TDM-NOT:     tt.descriptor_load
 // CHECK-TDM-NOT:     tt.descriptor_store
 // CHECK-TDM:         %[[LOAD:.*]] = tt.load
 // CHECK-TDM:         tt.store {{.*}}, %[[LOAD]]
+// CHECK-TDM:         tt.return
+
+// -----
+
+func.func @lower_extract_insert_trivial_batch_dim(
+    %arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>) {
+  %extracted_tensor = triton_xla.extract from %arg0
+      as memref<32x256x4xbf16, #xtile.layout<[2, 1, 0]>>
+      [0, 0, 2] [32, 256, 1] [1, 1, 1] : tensor<32x256xbf16>
+  triton_xla.insert %extracted_tensor into %arg1
+      as memref<32x256x4xbf16, #xtile.layout<[2, 1, 0]>>
+      [0, 0, 1] [32, 256, 1] [1, 1, 1] : tensor<32x256xbf16>
+  func.return
+}
+
+// CHECK-TDM-LABEL: tt.func @lower_extract_insert_trivial_batch_dim(
+// CHECK-TDM-NOT:     tt.make_tensor_descriptor
+// CHECK-TDM-NOT:     tt.descriptor_load
+// CHECK-TDM-NOT:     tt.descriptor_store
+// CHECK-TDM:         %[[LOAD:.*]] = tt.load
+// CHECK-TDM:         tt.store {{.*}}, %[[LOAD]]
+// CHECK-TDM:         tt.return
+
+// -----
+
+func.func @lower_extract_insert_nontrivial_batch_dim(
+    %arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>) {
+  %extracted_tensor = triton_xla.extract from %arg0
+      as memref<32x256x8xbf16, #xtile.layout<[2, 1, 0]>>
+      [0, 0, 0] [32, 256, 8] [1, 1, 1] : tensor<32x256x8xbf16>
+  triton_xla.insert %extracted_tensor into %arg1
+      as memref<32x256x8xbf16, #xtile.layout<[2, 1, 0]>>
+      [0, 0, 0] [32, 256, 8] [1, 1, 1] : tensor<32x256x8xbf16>
+  func.return
+}
+
+// CHECK-LABEL: tt.func @lower_extract_insert_nontrivial_batch_dim
+// CHECK:         %[[LOAD:.*]] = tt.load
+// CHECK:         tt.store {{.*}}, %[[LOAD]]
+
+// CHECK-TDM-LABEL: tt.func @lower_extract_insert_nontrivial_batch_dim(
+// CHECK-TDM-NOT:     tt.addptr
+// CHECK-TDM:         %[[DESC0:.*]] = tt.make_tensor_descriptor %arg0
+// CHECK-TDM-SAME:       <bf16>, <32x256x8xbf16>
+// CHECK-TDM:         %[[LOAD:.*]] = tt.descriptor_load %[[DESC0]]
+// CHECK-TDM:         %[[DESC1:.*]] = tt.make_tensor_descriptor %arg1
+// CHECK-TDM-SAME:       <bf16>, <32x256x8xbf16>
+// CHECK-TDM:         tt.descriptor_store %[[DESC1]]{{.*}}, %[[LOAD]]
 // CHECK-TDM:         tt.return
 
 // -----
@@ -300,8 +395,10 @@ func.func @incompatible_tma_const_offset_not_divisible_by_16_bytes(
 // CHECK-TMA:         tt.descriptor_store
 
 // CHECK-TDM-LABEL: tt.func @incompatible_tma_const_offset_not_divisible_by_16_bytes
-// CHECK-TDM-NOT:     tt.make_tensor_descriptor
-// CHECK-TDM:         tt.load
+// CHECK-TDM:         %[[DESC0:.*]] = tt.make_tensor_descriptor %arg0
+// CHECK-TDM-SAME:       <bf16>, <64xbf16>
+// CHECK-TDM:         %[[LOAD:.*]] = tt.descriptor_load %[[DESC0]]
+// CHECK-TDM-NOT:     tt.descriptor_store
 // CHECK-TDM:         tt.store
 
 // -----
@@ -335,7 +432,10 @@ module {
 
 // CHECK-TDM-LABEL: tt.func @incompatible_tma_dynamic_offset_not_divisible_by_16_bytes
 // CHECK-TDM:         tt.descriptor_load
-// CHECK-TDM:         tt.store
+// CHECK-TDM:         %[[PTR1:.*]] = tt.addptr %arg1, %{{.*}} : !tt.ptr<bf16>, i64
+// CHECK-TDM:         %[[DESC1:.*]] = tt.make_tensor_descriptor %[[PTR1]]
+// CHECK-TDM-SAME:       <bf16>, <16x16xbf16>
+// CHECK-TDM:         tt.descriptor_store %[[DESC1]]
 
 // -----
 

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_extract_insert_to_triton_pass.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_extract_insert_to_triton_pass.cc
@@ -17,9 +17,7 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 #include <numeric>
-#include <optional>
 #include <utility>
-#include <vector>
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Pass/Pass.h"
@@ -59,9 +57,9 @@ limitations under the License.
 #include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"
 #include "xla/backends/gpu/codegen/triton/lowering_util.h"
 #include "xla/backends/gpu/codegen/triton/transforms/passes.h"
+#include "xla/backends/gpu/codegen/triton/transforms/tdm_lowering_util.h"
 #include "xla/codegen/emitters/ir/xla_ops.h"  // IWYU pragma: keep
 #include "xla/codegen/xtile/codegen/emitter_helpers.h"
-#include "xla/permutation_util.h"
 #include "xla/stream_executor/gpu/tma_metadata.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 
@@ -230,139 +228,6 @@ void AddTmaAttributes(ImplicitLocOpBuilder& builder,
           pointer.getType().getPointeeType().getIntOrFloatBitWidth() / 8));
 }
 
-// Checks whether 'layout' is the default HLO layout in major-to-minor order,
-// i.e. iff it's [N-1, N-2, ... 1, 0].
-bool IsMajorToMinorLayout(ArrayRef<int64_t> layout) {
-  for (auto [i, value] : llvm::enumerate(layout)) {
-    if (value != layout.size() - 1 - i) {
-      return false;
-    }
-  }
-  return true;
-}
-
-// Returns 'values' in major-to-minor order given minor-to-major 'layout'.
-template <typename T>
-SmallVector<T> GetMajorToMinorOrder(ArrayRef<T> values,
-                                    ArrayRef<int64_t> layout) {
-  if (IsMajorToMinorLayout(layout)) {
-    return llvm::to_vector(values);
-  }
-
-  auto reversed_layout = llvm::to_vector(layout);
-  std::reverse(reversed_layout.begin(), reversed_layout.end());
-  std::vector<T> vector = ::xla::Permute(values, reversed_layout);
-  return SmallVector<T>(vector.begin(), vector.end());
-}
-
-// Returns 'values' in major-to-minor order given minor-to-major 'layout'.
-SmallVector<Value> GetMajorToMinorOrder(ValueRange values,
-                                        ArrayRef<int64_t> layout) {
-  return GetMajorToMinorOrder(ArrayRef<Value>(llvm::to_vector(values)), layout);
-}
-
-// Whether the tile shape is compatible with AMD TDM lowering. Rejects:
-//   - dynamic tile sizes or strides
-//   - non-unit tile strides
-//   - non-trailing singleton dims (violates upstream Triton's TDM legalizer
-//     contract: shared order must be [rank-1, ..., 0] with stride-1 dims
-//     consecutive trailing). A smarter pass could canonicalize the singleton
-//     out and lower to TDM. We reject conservatively for now.
-//
-// Not checked here, deferred to upstream Triton / hardware legalization:
-//   - Hardware rank cap (TDM supports ranks 1 to 5).
-//   - Innermost dim byte alignment requirements.
-//   - Per-dim box size limits.
-//   - Padding mode compatibility (this pass hardcodes PAD_ZERO).
-bool CanUseTdm(bool allow_tdm, const ArrayRef<int64_t>& tile_sizes,
-               const ArrayRef<int64_t>& tile_strides,
-               const ArrayRef<int64_t>& minor_to_major_layout) {
-  if (!allow_tdm) {
-    return false;
-  }
-  // Dynamic sizes or strides would feed sentinel values into the i32/i64
-  // descriptor constants and silently produce a malformed descriptor.
-  if (mlir::ShapedType::isDynamicShape(tile_sizes) ||
-      mlir::ShapedType::isDynamicShape(tile_strides)) {
-    VLOG(1) << "TDM is not compatible: dynamic tile sizes or strides.";
-    return false;
-  }
-  // TDM descriptors describe contiguous boxes; non-unit (or zero) tile strides
-  // cannot be expressed and would silently produce a contiguous load.
-  for (int64_t s : tile_strides) {
-    if (s != 1) {
-      VLOG(1) << "TDM is not compatible: non-unit tile stride.";
-      return false;
-    }
-  }
-  auto ordered_sizes = GetMajorToMinorOrder(tile_sizes, minor_to_major_layout);
-  bool seen_singleton = false;
-  for (int64_t s : ordered_sizes) {
-    if (s == 1) {
-      seen_singleton = true;
-    } else if (seen_singleton) {
-      // Non-singleton dim follows a singleton dim, TDM-incompatible.
-      VLOG(1) << "TDM is not compatible: non-trailing singleton dim in tile.";
-      return false;
-    }
-  }
-  return true;
-}
-
-// Builds a tt.make_tensor_descriptor for a contiguous box load/store from
-// `pointer`. Global shape and strides come from `shape` + `layout` (the source
-// memref geometry); the descriptor's block dims come from `tile_sizes`. All
-// arrays are reordered to major-to-minor as required by Triton's TDM
-// legalizer. Padding mode is hardcoded to PAD_ZERO.
-MakeTensorDescOp BuildTensorDescriptor(ImplicitLocOpBuilder& builder,
-                                       Value pointer, ArrayRef<int64_t> shape,
-                                       ArrayRef<int64_t> layout,
-                                       ArrayRef<int64_t> tile_sizes) {
-  // Global shape as i32 SSA values, in major-to-minor order.
-  auto ordered_shape = GetMajorToMinorOrder(shape, layout);
-  SmallVector<Value> shape_values;
-  for (int64_t dim : ordered_shape) {
-    shape_values.push_back(
-        arith::ConstantOp::create(builder, builder.getI32IntegerAttr(dim)));
-  }
-
-  // Global strides as i64 SSA values, in major-to-minor order.
-  auto global_strides = xtriton::ComputeStrides(shape, layout);
-  auto ordered_strides =
-      GetMajorToMinorOrder(ArrayRef<int64_t>(global_strides), layout);
-  SmallVector<Value> stride_values;
-  for (int64_t s : ordered_strides) {
-    stride_values.push_back(
-        arith::ConstantOp::create(builder, builder.getI64IntegerAttr(s)));
-  }
-
-  // Block shape in major-to-minor order as i32.
-  auto ordered_sizes = GetMajorToMinorOrder(tile_sizes, layout);
-  SmallVector<int32_t> block_shape;
-  for (int64_t s : ordered_sizes) {
-    CHECK_LE(s, INT32_MAX) << "tile dim " << s << " exceeds i32 range";
-    block_shape.push_back(static_cast<int32_t>(s));
-  }
-
-  auto element_type = cast<PointerType>(pointer.getType()).getPointeeType();
-  bool is_signed_integer =
-      mlir::isa<IntegerType>(element_type) && !element_type.isUnsignedInteger();
-
-  return MakeTensorDescOp::create(builder, pointer, shape_values, stride_values,
-                                  block_shape, is_signed_integer,
-                                  PaddingOption::PAD_ZERO);
-}
-
-// Given the layout of a tensor, return the inverse permutation required to
-// transpose an already major-to-minor tensor to the original tensor.
-SmallVector<int32_t> GetInverseLayoutPermutation(ArrayRef<int64_t> layout) {
-  auto reversed_layout = llvm::to_vector(layout);
-  std::reverse(reversed_layout.begin(), reversed_layout.end());
-  auto permutation =
-      llvm::to_vector_of<int32_t>(::xla::InversePermutation(reversed_layout));
-  return SmallVector<int32_t>(permutation.begin(), permutation.end());
-}
-
 // Rewrite func.func to tt.func.
 class RewriteFuncOp : public mlir::OpRewritePattern<func::FuncOp> {
  public:
@@ -388,7 +253,7 @@ class RewriteFuncOp : public mlir::OpRewritePattern<func::FuncOp> {
       auto layout = tma_descriptor.getLayout();
       auto block_shape = tma_descriptor.getTileShape();
       SmallVector<int64_t> ordered_block_shape =
-          GetMajorToMinorOrder(block_shape, layout);
+          xtriton::GetMajorToMinorOrder(block_shape, layout);
 
       auto result_type =
           RankedTensorType::get(ordered_block_shape, element_type);
@@ -493,10 +358,10 @@ class RewriteExtract : public mlir::OpRewritePattern<ExtractOp> {
       AddTmaAttributes(builder, op.getSrc(), src_shape, src_layout, sizes,
                        strides);
 
-      auto ordered_offsets = GetMajorToMinorOrder(offsets, src_layout);
-      auto ordered_sizes = GetMajorToMinorOrder(sizes, src_layout);
+      auto ordered_offsets = xtriton::GetMajorToMinorOrder(offsets, src_layout);
+      auto ordered_sizes = xtriton::GetMajorToMinorOrder(sizes, src_layout);
       auto ordered_type =
-          tile_type.clone(GetMajorToMinorOrder(sizes, src_layout));
+          tile_type.clone(xtriton::GetMajorToMinorOrder(sizes, src_layout));
 
       // ptr -> !tt.tensordesc<tile_type>
       auto desc_type = TensorDescType::get(ordered_type.getShape(),
@@ -510,9 +375,9 @@ class RewriteExtract : public mlir::OpRewritePattern<ExtractOp> {
           xtriton::IndexCast(builder, builder.getI32Type(), ordered_offsets));
 
       // Insert a transpose if the layout is not major-to-minor.
-      if (!IsMajorToMinorLayout(src_layout)) {
-        result = TransOp::create(builder, result,
-                                 GetInverseLayoutPermutation(src_layout));
+      if (!xtriton::IsMajorToMinorLayout(src_layout)) {
+        result = TransOp::create(
+            builder, result, xtriton::GetInverseLayoutPermutation(src_layout));
       }
       // Insert a reshape if the result is rank-reduced.
       if (sizes.size() != tile_shape.size()) {
@@ -524,23 +389,34 @@ class RewriteExtract : public mlir::OpRewritePattern<ExtractOp> {
       return mlir::success();
     }
 
-    if (CanUseTdm(allow_tdm_, sizes, strides, src_layout)) {
-      auto ordered_offsets = GetMajorToMinorOrder(offsets, src_layout);
-      auto ordered_type =
-          tile_type.clone(GetMajorToMinorOrder(sizes, src_layout));
+    if (TdmAllowed(
+            CanUseTdm(allow_tdm_, src_shape, sizes, strides, src_layout,
+                      tile_type.getElementType().getIntOrFloatBitWidth()))) {
+      SmallVector<int64_t> singleton_dims =
+          GetSingletonTileDims(sizes, src_layout);
+      TdmDescriptorOperands operands(op.getSrc(), src_shape, src_layout, sizes,
+                                     offsets);
+      if (!singleton_dims.empty()) {
+        operands = operands.DropSingletonTileDims(builder, singleton_dims);
+      }
 
-      auto desc = BuildTensorDescriptor(builder, op.getSrc(), src_shape,
-                                        src_layout, sizes);
+      auto desc = BuildTensorDescriptor(builder, operands);
+
+      auto ordered_offsets = xtriton::GetMajorToMinorOrder(
+          ValueRange(operands.offsets), operands.layout);
+      auto ordered_type = tile_type.clone(xtriton::GetMajorToMinorOrder(
+          ArrayRef<int64_t>(operands.sizes), operands.layout));
 
       Value result = DescriptorLoadOp::create(
           builder, ordered_type, desc.getResult(),
           xtriton::IndexCast(builder, builder.getI32Type(), ordered_offsets));
 
-      if (!IsMajorToMinorLayout(src_layout)) {
-        result = TransOp::create(builder, result,
-                                 GetInverseLayoutPermutation(src_layout));
+      if (!xtriton::IsMajorToMinorLayout(operands.layout)) {
+        result = TransOp::create(
+            builder, result,
+            xtriton::GetInverseLayoutPermutation(operands.layout));
       }
-      if (sizes.size() != tile_shape.size()) {
+      if (ArrayRef<int64_t>(operands.sizes) != tile_shape) {
         result = ReshapeOp::create(builder, tile_shape, result,
                                    /*allowReorder=*/false);
       }
@@ -632,7 +508,7 @@ class RewriteInsert : public mlir::OpRewritePattern<InsertOp> {
 
       // ptr -> !tt.tensordesc<tile_type>
       auto result_type =
-          tile_type.clone(GetMajorToMinorOrder(sizes, dst_layout));
+          tile_type.clone(xtriton::GetMajorToMinorOrder(sizes, dst_layout));
       auto desc_type = TensorDescType::get(result_type.getShape(),
                                            result_type.getElementType(),
                                            result_type.getEncoding());
@@ -645,29 +521,40 @@ class RewriteInsert : public mlir::OpRewritePattern<InsertOp> {
         src = ExpandDimsOp::create(builder, src, dim);
       }
       // Insert a transpose if the layout is not major-to-minor.
-      if (!IsMajorToMinorLayout(dst_layout)) {
+      if (!xtriton::IsMajorToMinorLayout(dst_layout)) {
         // Transpose to a major-to-minor tensor by simply reversing the layout.
         auto transpose_order = llvm::to_vector_of<int32_t>(dst_layout);
         std::reverse(transpose_order.begin(), transpose_order.end());
         src = TransOp::create(builder, src, transpose_order);
       }
 
-      auto ordered_offsets = GetMajorToMinorOrder(offsets, dst_layout);
+      auto ordered_offsets = xtriton::GetMajorToMinorOrder(offsets, dst_layout);
       DescriptorStoreOp::create(
           builder, cast_to_tensor_desc.getResult(0), src,
           xtriton::IndexCast(builder, builder.getI32Type(), ordered_offsets));
-    } else if (CanUseTdm(allow_tdm_, sizes, strides, dst_layout)) {
-      auto ordered_offsets = GetMajorToMinorOrder(offsets, dst_layout);
+    } else if (TdmAllowed(CanUseTdm(
+                   allow_tdm_, dst_shape, sizes, strides, dst_layout,
+                   tile_type.getElementType().getIntOrFloatBitWidth()))) {
+      SmallVector<int64_t> singleton_dims =
+          GetSingletonTileDims(sizes, dst_layout);
+      TdmDescriptorOperands operands(op.getDst(), dst_shape, dst_layout, sizes,
+                                     offsets);
+      if (!singleton_dims.empty()) {
+        operands = operands.DropSingletonTileDims(builder, singleton_dims);
+      }
 
-      auto desc = BuildTensorDescriptor(builder, op.getDst(), dst_shape,
-                                        dst_layout, sizes);
+      auto desc = BuildTensorDescriptor(builder, operands);
+
+      auto ordered_offsets = xtriton::GetMajorToMinorOrder(
+          ValueRange(operands.offsets), operands.layout);
 
       Value src = op.getSrc();
-      for (auto dim : reduced_dims) {
-        src = ExpandDimsOp::create(builder, src, dim);
+      if (ArrayRef<int64_t>(operands.sizes) != tile_shape) {
+        src = ReshapeOp::create(builder, operands.sizes, src,
+                                /*allowReorder=*/false);
       }
-      if (!IsMajorToMinorLayout(dst_layout)) {
-        auto transpose_order = llvm::to_vector_of<int32_t>(dst_layout);
+      if (!xtriton::IsMajorToMinorLayout(operands.layout)) {
+        auto transpose_order = llvm::to_vector_of<int32_t>(operands.layout);
         std::reverse(transpose_order.begin(), transpose_order.end());
         src = TransOp::create(builder, src, transpose_order);
       }

--- a/xla/backends/gpu/codegen/triton/triton_gemm_fusion_test.cc
+++ b/xla/backends/gpu/codegen/triton/triton_gemm_fusion_test.cc
@@ -1678,6 +1678,34 @@ ENTRY e {
       module->entry_computation()->root_instruction(),
       GmockMatch(m::Fusion(m::Parameter(), m::Parameter())
                      .WithFusionKind(HloInstruction::FusionKind::kCustom)));
+
+  EXPECT_TRUE(RunAndCompare(kHloText, ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
+}
+
+TEST_F(TritonGemmTest, BatchMajorSlicedBatchDimensionProducesCorrectResults) {
+  constexpr absl::string_view kHloText = R"(
+ENTRY e {
+  p0 = f16[4,32,256] parameter(0)
+  p1 = f16[4,256,32] parameter(1)
+  ROOT d = f16[4,32,32] dot(p0, p1),
+    lhs_batch_dims={0}, lhs_contracting_dims={2},
+    rhs_batch_dims={0}, rhs_contracting_dims={1}
+})";
+
+  EXPECT_TRUE(RunAndCompare(kHloText, ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
+}
+
+TEST_F(TritonGemmTest, DegenerateBatchDimensionProducesCorrectResults) {
+  constexpr absl::string_view kHloText = R"(
+ENTRY e {
+  p0 = f16[1,32,256] parameter(0)
+  p1 = f16[1,256,32] parameter(1)
+  ROOT d = f16[1,32,32] dot(p0, p1),
+    lhs_batch_dims={0}, lhs_contracting_dims={2},
+    rhs_batch_dims={0}, rhs_contracting_dims={1}
+})";
+
+  EXPECT_TRUE(RunAndCompare(kHloText, ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
 }
 
 // TODO(b/393299275): this should just be a fusion test and does not need to be


### PR DESCRIPTION
A tile can reach the extract/insert lowering with a size-1 dim at any position, e.g. when a dot with batch dims is tiled one batch per program. The TDM path handled these incorrectly. Fix it in two parts:

1. When the surviving minor-most dim has global stride 1, fold the singleton tile dims (at any position) into the descriptor base pointer and build a reduced-rank descriptor from the survivors, so no size-1 dim is left in the descriptor. Previously these tiles were rejected and fell back to plain load/store.

2. Otherwise skip TDM and fall back to plain load/store. Folding cannot help: the surviving minor-most dim inherits a non-unit stride that a TDM descriptor cannot express. Previously such a tile kept its size-1 dim in the descriptor and either read the wrong memory or failed Triton legalization:

     error: requires shared order [rank-1, rank-2, ..., 0]
     error: failed to legalize operation 'tt.make_tensor_descriptor' ...

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
