### PR TITLE
[ROCm profiler] Add ROCTX annotation support for jax.profiler.TraceAnnotation 

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -403,6 +403,13 @@ rocm_lib_import(
 )
 
 rocm_lib_import(
+    name = "rocprofiler_sdk_roctx",
+    data = glob(["%{rocm_root}/lib/librocprofiler-sdk-roctx.so*"]),
+    interface_library = "%{rocm_root}/lib/librocprofiler-sdk-roctx.so",
+    deps = [],
+)
+
+rocm_lib_import(
     name = "rocsolver",
     data = glob([
         "%{rocm_root}/lib/librocsolver.so*",

--- a/third_party/tsl/tsl/profiler/lib/BUILD
+++ b/third_party/tsl/tsl/profiler/lib/BUILD
@@ -8,6 +8,10 @@ load(
     "if_cuda_is_configured",
 )
 load(
+    "@local_config_rocm//rocm:build_defs.bzl",
+    "if_rocm_is_configured",
+)
+load(
     "@xla//xla/tsl/profiler/builds:build_config.bzl",
     "tf_profiler_copts",
     "tf_profiler_pybind_cc_library_wrapper",
@@ -323,11 +327,18 @@ cc_library(
     name = "nvtx_utils_impl",
     srcs = if_cuda_is_configured(
         ["nvtx_utils.cc"],
-        ["nvtx_utils_stub.cc"],
+        if_rocm_is_configured(
+            ["roctx_utils.cc"],
+            ["nvtx_utils_stub.cc"],
+        ),
     ),
     hdrs = ["nvtx_utils.h"],
     visibility = ["//visibility:public"],
-    deps = if_cuda_is_configured(nvtx_headers()),
+    deps = if_cuda_is_configured(nvtx_headers()) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:rocprofiler_sdk_roctx",
+        "@xla//xla/tsl/profiler/backends/cpu:annotation_stack",
+    ]),
 )
 
 cc_library(
@@ -376,6 +387,26 @@ tsl_cc_test(
         "@com_google_googletest//:gtest_main",
         "@xla//xla/tsl/platform:test",
         "@xla//xla/tsl/platform:test_benchmark",
+        "@xla//xla/tsl/profiler/backends/cpu:annotation_stack",
+        "@xla//xla/tsl/profiler/backends/cpu:annotation_stack_impl",
+    ],
+)
+
+tsl_cc_test(
+    name = "roctx_utils_test",
+    size = "small",
+    srcs = ["roctx_utils_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":nvtx_utils",
+        ":scoped_annotation",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:rocprofiler_sdk_roctx",
+        "@xla//xla/tsl/platform:test",
         "@xla//xla/tsl/profiler/backends/cpu:annotation_stack",
         "@xla//xla/tsl/profiler/backends/cpu:annotation_stack_impl",
     ],

--- a/third_party/tsl/tsl/profiler/lib/roctx_utils.cc
+++ b/third_party/tsl/tsl/profiler/lib/roctx_utils.cc
@@ -1,0 +1,99 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// ROCm implementation of the nvtx_utils.h interface using roctx.
+//
+// Dual-push design: RangePush/RangePop populate BOTH the AnnotationStack
+// (Pipeline A — annotations reach kernel events via correlation ID) AND emit
+// roctx markers via librocprofiler-sdk-roctx.so (Pipeline B — named range
+// events visible to ROCm-native profilers and captured by MarkerCallback in
+// rocm_tracer.cc).
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "rocm/include/rocprofiler-sdk-roctx/roctx.h"
+#include "xla/tsl/profiler/backends/cpu/annotation_stack.h"
+#include "tsl/profiler/lib/nvtx_utils.h"
+
+namespace tsl::profiler {
+
+ProfilerDomainHandle DefaultProfilerDomain() {
+  // Non-null sentinel triggers the domain path in PushAnnotation()
+  // (scoped_annotation.h:41). ProfilerDomain is a forward-declared opaque
+  // struct — we cast the address of a static variable to satisfy the
+  // non-null check. This value is never dereferenced or passed to any
+  // roctx API — roctx has no domain concept.
+  static char sentinel;
+  return reinterpret_cast<ProfilerDomainHandle>(&sentinel);
+}
+
+void RangePush(ProfilerDomainHandle /*domain*/, const char* ascii) {
+  // Pipeline A: populate AnnotationStack so the HIP API callback in
+  // rocm_tracer.cc:603-605 can read it and attach annotations to kernel
+  // dispatch events via correlation ID.
+  //
+  // The IsEnabled() guard mirrors scoped_annotation.h:47. If Enable() is
+  // toggled between a push and its matching pop, the generation-based
+  // cleanup in AnnotationStack resets thread-local state, so the stack
+  // cannot become permanently unbalanced.
+  if (AnnotationStack::IsEnabled()) {
+    AnnotationStack::PushAnnotation(ascii);
+  }
+
+  // Pipeline B: emit roctx marker so MarkerCallback in rocm_tracer.cc:347
+  // can capture it as a named range event with kNVTXRange stat.
+  roctxRangePushA(ascii);
+}
+
+void RangePop(ProfilerDomainHandle /*domain*/) {
+  if (AnnotationStack::IsEnabled()) {
+    AnnotationStack::PopAnnotation();
+  }
+
+  roctxRangePop();
+}
+
+// Return values from roctx naming APIs intentionally discarded to match
+// the void signatures declared in nvtx_utils.h.
+void NameCurrentThread(const std::string& name) {
+  (void)roctxNameOsThread(name.c_str());
+}
+
+void NameDevice(int device_id, const std::string& name) {
+  (void)roctxNameHipDevice(name.c_str(), device_id);
+}
+
+void NameStream(StreamHandle stream, const std::string& name) {
+  // StreamHandle is an opaque tsl::profiler::Stream*. Callers pass
+  // hipStream_t (== ihipStream_t*) through this opaque handle, mirroring
+  // how nvtx_utils.cc casts StreamHandle to CUstream.
+  (void)roctxNameHipStream(name.c_str(),
+                           reinterpret_cast<const ihipStream_t*>(stream));
+}
+
+namespace detail {
+void RangePush(ProfilerDomainHandle, StringHandle, uint64_t, const void*,
+               size_t) {}
+}  // namespace detail
+
+uint64_t RegisterSchema(ProfilerDomainHandle, const void*) { return 0; }
+StringHandle RegisterString(ProfilerDomainHandle, const std::string&) {
+  return {};
+}
+void MarkMemoryInitialized(void const*, size_t, StreamHandle) {}
+
+}  // namespace tsl::profiler

--- a/third_party/tsl/tsl/profiler/lib/roctx_utils_test.cc
+++ b/third_party/tsl/tsl/profiler/lib/roctx_utils_test.cc
@@ -1,0 +1,178 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Tests for roctx_utils.cc — the ROCm dual-push implementation of
+// nvtx_utils.h. Verifies that RangePush/RangePop populate AnnotationStack
+// (Pipeline A) and emit roctx markers (Pipeline B).
+
+#include <string>
+
+#include "rocm/include/rocprofiler-sdk-roctx/roctx.h"
+#include "xla/tsl/platform/test.h"
+#include "xla/tsl/profiler/backends/cpu/annotation_stack.h"
+#include "tsl/profiler/lib/nvtx_utils.h"
+#include "tsl/profiler/lib/scoped_annotation.h"
+
+namespace tsl {
+namespace profiler {
+namespace {
+
+// RAII guard that enables AnnotationStack on construction and disables
+// on destruction so tests don't leak enabled state.
+class AnnotationStackGuard {
+ public:
+  AnnotationStackGuard() { AnnotationStack::Enable(true); }
+  ~AnnotationStackGuard() { AnnotationStack::Enable(false); }
+};
+
+TEST(RoctxUtils, DefaultProfilerDomainReturnsNonNull) {
+  ProfilerDomainHandle domain = DefaultProfilerDomain();
+  ASSERT_NE(domain, nullptr)
+      << "On ROCm builds, DefaultProfilerDomain() must return non-null "
+         "to trigger the domain path in PushAnnotation";
+}
+
+TEST(RoctxUtils, RangePushPopulatesAnnotationStack) {
+  auto domain = DefaultProfilerDomain();
+  ASSERT_NE(domain, nullptr);
+
+  AnnotationStackGuard guard;
+  RangePush(domain, "test_op");
+  EXPECT_EQ(AnnotationStack::Get(), "test_op");
+  RangePop(domain);
+  EXPECT_EQ(AnnotationStack::Get(), "");
+}
+
+TEST(RoctxUtils, NestedPushPopMaintainsAnnotationStack) {
+  auto domain = DefaultProfilerDomain();
+  ASSERT_NE(domain, nullptr);
+
+  AnnotationStackGuard guard;
+
+  RangePush(domain, "outer");
+  EXPECT_EQ(AnnotationStack::Get(), "outer");
+
+  RangePush(domain, "inner");
+  EXPECT_EQ(AnnotationStack::Get(), "outer::inner");
+
+  RangePop(domain);
+  EXPECT_EQ(AnnotationStack::Get(), "outer");
+
+  RangePop(domain);
+  EXPECT_EQ(AnnotationStack::Get(), "");
+}
+
+TEST(RoctxUtils, PushPopWithAnnotationStackDisabled) {
+  auto domain = DefaultProfilerDomain();
+  ASSERT_NE(domain, nullptr);
+
+  // AnnotationStack is NOT enabled. RangePush/RangePop must not crash
+  // and must not populate the stack.
+  RangePush(domain, "ignored_op");
+  EXPECT_EQ(AnnotationStack::Get(), "");
+  RangePop(domain);
+  EXPECT_EQ(AnnotationStack::Get(), "");
+}
+
+TEST(RoctxUtils, ScopedAnnotationIntegration) {
+  // Full chain: ScopedAnnotation → PushAnnotation →
+  // DefaultProfilerDomain() non-null → RangePush → dual-push.
+  AnnotationStackGuard guard;
+  {
+    ScopedAnnotation annotation("my_kernel");
+    EXPECT_EQ(AnnotationStack::Get(), "my_kernel");
+    {
+      ScopedAnnotation nested("inner_kernel");
+      EXPECT_EQ(AnnotationStack::Get(), "my_kernel::inner_kernel");
+    }
+    EXPECT_EQ(AnnotationStack::Get(), "my_kernel");
+  }
+  EXPECT_EQ(AnnotationStack::Get(), "");
+}
+
+TEST(RoctxUtils, ScopedAnnotationDisabledStackDoesNotCrash) {
+  // ScopedAnnotation with stack disabled — must not crash.
+  {
+    ScopedAnnotation annotation("disabled_op");
+    EXPECT_EQ(AnnotationStack::Get(), "");
+  }
+  EXPECT_EQ(AnnotationStack::Get(), "");
+}
+
+TEST(RoctxUtils, DirectRoctxCallsDoNotCrash) {
+  // Verify direct roctx API calls work (linked at build time).
+  int depth = roctxRangePushA("roctx_utils_test_label");
+  EXPECT_GE(depth, 0);
+  int pop_result = roctxRangePop();
+  EXPECT_GE(pop_result, 0);
+}
+
+TEST(RoctxUtils, DirectRoctxMarkDoesNotCrash) {
+  roctxMarkA("roctx_utils_test_mark");
+}
+
+TEST(RoctxUtils, DirectRoctxNestedRanges) {
+  int d0 = roctxRangePushA("level_0");
+  EXPECT_EQ(d0, 0);
+  int d1 = roctxRangePushA("level_1");
+  EXPECT_EQ(d1, 1);
+  int d2 = roctxRangePushA("level_2");
+  EXPECT_EQ(d2, 2);
+
+  EXPECT_EQ(roctxRangePop(), 2);
+  EXPECT_EQ(roctxRangePop(), 1);
+  EXPECT_EQ(roctxRangePop(), 0);
+}
+
+TEST(RoctxUtils, DetailRangePushIsNoOp) {
+  auto domain = DefaultProfilerDomain();
+  ASSERT_NE(domain, nullptr);
+  detail::RangePush(domain, nullptr, 0, nullptr, 0);
+}
+
+TEST(RoctxUtils, RegisterStringReturnsNull) {
+  auto domain = DefaultProfilerDomain();
+  ASSERT_NE(domain, nullptr);
+  StringHandle handle = RegisterString(domain, "test_string");
+  EXPECT_EQ(handle, nullptr);
+}
+
+TEST(RoctxUtils, RegisterSchemaReturnsZero) {
+  auto domain = DefaultProfilerDomain();
+  ASSERT_NE(domain, nullptr);
+  uint64_t schema_id = RegisterSchema(domain, nullptr);
+  EXPECT_EQ(schema_id, 0);
+}
+
+TEST(RoctxUtils, DualPushBothPipelinesSimultaneously) {
+  // Verify that a single RangePush populates AnnotationStack AND emits
+  // an roctx call without crashing. This is the core dual-push contract.
+  auto domain = DefaultProfilerDomain();
+  ASSERT_NE(domain, nullptr);
+
+  AnnotationStackGuard guard;
+
+  // RangePush should do both: AnnotationStack + roctxRangePushA.
+  RangePush(domain, "dual_push_test");
+  EXPECT_EQ(AnnotationStack::Get(), "dual_push_test");
+
+  // RangePop should do both: AnnotationStack + roctxRangePop.
+  RangePop(domain);
+  EXPECT_EQ(AnnotationStack::Get(), "");
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace tsl

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -596,6 +596,7 @@ xla_cc_test(
     name = "rocm_tracer_test",
     size = "small",
     srcs = ["rocm_tracer_test.cc"],
+    linkopts = ["-ldl"],  # for dlopen/dlsym in RealRoctxCallsProduceNvtxRangeInXSpace
     tags = [
         "gpu",
         "rocm-only",
@@ -608,7 +609,9 @@ xla_cc_test(
         ":rocm_tracer",
         ":rocm_tracer_utils",
         "//xla/tsl/lib/core:status_test_util",
+        "//xla/tsl/platform:env_time",
         "@com_google_absl//absl/log",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -610,6 +610,7 @@ xla_cc_test(
         ":rocm_tracer_utils",
         "//xla/tsl/lib/core:status_test_util",
         "//xla/tsl/platform:env_time",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -626,10 +626,23 @@ void RocmTraceCollectorImpl::Flush() {
 
   // Flush standalone events (e.g. ROCTX markers) directly — they have no
   // GPU-side activity counterpart and bypass ApiActivityInfoExchange.
-  for (auto& event : standalone_events_) {
-    per_device_collector_[0].AddEvent(std::move(event));
+  // All standalone events are bucketed into slot [0] regardless of which
+  // thread produced them; ROCTX markers are host-side and have no per-device
+  // meaning. If num_gpus_ is zero (e.g. a CI node where rocprofiler reports
+  // no GPU agents), per_device_collector_[0] is never exported by Export(),
+  // so we drop rather than silently lose events into an unexported slot.
+  if (!standalone_events_.empty()) {
+    if (num_gpus_ == 0) {
+      LOG(WARNING) << "Dropping " << standalone_events_.size()
+                   << " standalone ROCTX events: no GPUs reported by "
+                      "rocprofiler, so no device plane exists to export them.";
+    } else {
+      for (auto& event : standalone_events_) {
+        per_device_collector_[0].AddEvent(std::move(event));
+      }
+    }
+    standalone_events_.clear();
   }
-  standalone_events_.clear();
 
   activity_ops_events_map_.clear();
   api_events_map_.clear();

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -206,7 +207,8 @@ void PerDeviceCollector::CreateXEvent(const RocmTracerEvent& event,
   VLOG(7) << "Adding event to line=" << line->Id();
   xevent.SetTimestampNs(event.start_time_ns);
   xevent.SetEndTimestampNs(event.end_time_ns);
-  if (event.source == RocmTracerEventSource::ApiCallback) {
+  if (event.source == RocmTracerEventSource::ApiCallback &&
+      event.device_id != RocmTracerEvent::kInvalidDeviceId) {
     xevent.AddStatValue(
         *plane->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kDeviceId)),
         event.device_id);
@@ -362,6 +364,7 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
                                 uint64_t start_gputime_ns,
                                 uint64_t end_gputime_ns,
                                 XPlaneBuilder* device_plane,
+                                XPlaneBuilder* roctx_plane,
                                 XPlaneBuilder* host_plane) {
   int host_ev_cnt = 0, dev_ev_cnt = 0;
   absl::MutexLock lock(events_mutex_);
@@ -406,7 +409,14 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
       continue;
     }
     auto* plane = is_host_event ? host_plane : device_plane;
-    VLOG(9) << "Event" << " type=" << static_cast<int>(event.type)
+    // Generic events (ROCTX markers) are always host-side; the is_host_event
+    // guard is redundant here but made explicit to document the assumption.
+    if (event.type == RocmTracerEventType::Generic && is_host_event &&
+        roctx_plane != nullptr) {
+      plane = roctx_plane;
+    }
+    VLOG(9) << "Event"
+            << " type=" << static_cast<int>(event.type)
             << " line_id=" << line_id
             << (is_host_event ? " host plane=" : " device plane=")
             << plane->Name();
@@ -423,6 +433,11 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
   host_plane->ForEachLine([&](XLineBuilder line) {
     line.SetName(absl::StrCat("Host Threads/", line.Id()));
   });
+  if (roctx_plane != nullptr) {
+    roctx_plane->ForEachLine([&](XLineBuilder line) {
+      line.SetName(absl::StrCat("ROCTX Threads/", line.Id()));
+    });
+  }
   events_.clear();
 }
 
@@ -519,6 +534,15 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
                                       bool is_auxiliary) {
   absl::MutexLock lock(event_maps_mutex_);
 
+  // Generic events (e.g. ROCTX/NVTX markers) have no GPU-side activity
+  // counterpart. Route them directly to standalone_events_ so they bypass
+  // ApiActivityInfoExchange and are flushed straight to per_device_collector_.
+  // Check this BEFORE the source-based branching below.
+  if (event.type == RocmTracerEventType::Generic) {
+    standalone_events_.push_back(std::move(event));
+    return;
+  }
+
   if (event.source == RocmTracerEventSource::ApiCallback) {
     if (!is_auxiliary) {
       if (num_callback_events_ >= options_.max_callback_api_events) {
@@ -575,17 +599,23 @@ void RocmTraceCollectorImpl::Flush() {
           << " activity events, and aggregated them into "
           << aggregated_events.size() << " events.";
 
-  // device ids for GPUs filled in by roctracer are not zero indexed.
-  // They are offset by number of CPUs on the machine
-  uint32_t min_device_id = INT32_MAX;
+  // Device IDs from rocprofiler are not zero-indexed; find the minimum
+  // valid ID so we can normalise to [0, num_gpus_).
+  uint32_t min_device_id = std::numeric_limits<uint32_t>::max();
 
   for (const auto& event : aggregated_events) {
-    if (event.device_id < min_device_id) {
+    if (event.device_id != RocmTracerEvent::kInvalidDeviceId &&
+        event.device_id < min_device_id) {
       min_device_id = event.device_id;
     }
   }
 
   for (auto& event : aggregated_events) {
+    if (event.device_id == RocmTracerEvent::kInvalidDeviceId ||
+        min_device_id == std::numeric_limits<uint32_t>::max()) {
+      PrintRocmTracerEvent(event, ". Dropped due to invalid device ID!");
+      continue;
+    }
     auto id = event.device_id - min_device_id;
     if (id < num_gpus_) {
       per_device_collector_[id].AddEvent(std::move(event));
@@ -593,6 +623,13 @@ void RocmTraceCollectorImpl::Flush() {
       PrintRocmTracerEvent(event, ". Dropped due to invalid device ID!");
     }
   }
+
+  // Flush standalone events (e.g. ROCTX markers) directly — they have no
+  // GPU-side activity counterpart and bypass ApiActivityInfoExchange.
+  for (auto& event : standalone_events_) {
+    per_device_collector_[0].AddEvent(std::move(event));
+  }
+  standalone_events_.clear();
 
   activity_ops_events_map_.clear();
   api_events_map_.clear();
@@ -615,6 +652,8 @@ void RocmTraceCollectorImpl::Export(XSpace* space) {
   uint64_t end_gputime_ns = get_timestamp();
   XPlaneBuilder host_plane(FindOrAddMutablePlaneWithName(
       space, tsl::profiler::kRoctracerApiPlaneName));
+  XPlaneBuilder roctx_plane(FindOrAddMutablePlaneWithName(
+      space, tsl::profiler::kRoctxPlaneName));
 
   VLOG(3) << "Calling RocmTraceCollectorImpl::Export num_gpus " << num_gpus_;
 
@@ -628,10 +667,11 @@ void RocmTraceCollectorImpl::Export(XSpace* space) {
     }
     per_device_collector_[id].Export(start_walltime_ns_, start_gputime_ns_,
                                      end_gputime_ns, &device_plane,
-                                     &host_plane);
+                                     &roctx_plane, &host_plane);
     NormalizeTimeStamps(&device_plane, start_walltime_ns_);
   }
   NormalizeTimeStamps(&host_plane, start_walltime_ns_);
+  NormalizeTimeStamps(&roctx_plane, start_walltime_ns_);
   ExportScopeRangeIdTree(space);
 }
 
@@ -690,7 +730,7 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
                         "Type="
                      << GetRocmTracerEventTypeName(api_event.type);
     }  // switch
-  }  // for
+  }    // for
 
   // Make sure for all activity events we have API callback events.
   //
@@ -763,8 +803,8 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
                           "Type="
                        << GetRocmTracerEventTypeName(activity_event.type);
       }  // switch
-    }  // for activity_event
-  }  // for activity_iter
+    }    // for activity_event
+  }      // for activity_iter
 
   return aggregated_events;
 }

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -652,8 +652,8 @@ void RocmTraceCollectorImpl::Export(XSpace* space) {
   uint64_t end_gputime_ns = get_timestamp();
   XPlaneBuilder host_plane(FindOrAddMutablePlaneWithName(
       space, tsl::profiler::kRoctracerApiPlaneName));
-  XPlaneBuilder roctx_plane(FindOrAddMutablePlaneWithName(
-      space, tsl::profiler::kRoctxPlaneName));
+  XPlaneBuilder roctx_plane(
+      FindOrAddMutablePlaneWithName(space, tsl::profiler::kRoctxPlaneName));
 
   VLOG(3) << "Calling RocmTraceCollectorImpl::Export num_gpus " << num_gpus_;
 

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -24,7 +24,6 @@ limitations under the License.
 #include <tuple>
 #include <vector>
 
-#include "rocprofiler-sdk/agent.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_map.h"
@@ -32,6 +31,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
 #include "rocm/include/hip/hip_runtime.h"
+#include "rocprofiler-sdk/agent.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/utils/xplane_builder.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
@@ -154,6 +154,7 @@ class PerDeviceCollector {
   void Export(uint64_t start_walltime_ns, uint64_t start_gputime_ns,
               uint64_t end_gputime_ns,
               tsl::profiler::XPlaneBuilder* device_plane,
+              tsl::profiler::XPlaneBuilder* roctx_plane,
               tsl::profiler::XPlaneBuilder* host_plane);
 
   PerDeviceCollector() = default;
@@ -226,6 +227,12 @@ class RocmTraceCollectorImpl : public RocmTraceCollector {
   // This is for the APIs that we track because we need some information from
   // them to populate the corresponding activity that we actually track.
   absl::flat_hash_map<uint32_t, RocmTracerEvent> auxiliary_api_events_map_
+      ABSL_GUARDED_BY(event_maps_mutex_);
+
+  // Host-side events that need no API↔Activity join (e.g. ROCTX markers).
+  // Flushed directly to per_device_collector_ without going through
+  // ApiActivityInfoExchange.
+  std::vector<RocmTracerEvent> standalone_events_
       ABSL_GUARDED_BY(event_maps_mutex_);
 
   std::vector<RocmTracerEvent> ApiActivityInfoExchange()

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -713,9 +713,8 @@ absl::Status RocmTracer::InitProfiling(void* tool_data) {
                 if (!annotation.empty() || !roctx.empty()) {
                   absl::Span<const int64_t> range_ids =
                       tsl::profiler::AnnotationStack::GetScopeRangeIds();
-                  tracer.annotation_map()->Add(
-                      record.correlation_id.internal, annotation, roctx,
-                      range_ids);
+                  tracer.annotation_map()->Add(record.correlation_id.internal,
+                                               annotation, roctx, range_ids);
                 }
               }
             },

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -45,6 +45,7 @@ limitations under the License.
 #include "rocm/include/rocprofiler-sdk/fwd.h"
 #include "rocm/include/rocprofiler-sdk/hip/runtime_api_id.h"
 #include "rocm/include/rocprofiler-sdk/internal_threading.h"
+#include "rocm/include/rocprofiler-sdk/marker.h"
 #include "rocm/include/rocprofiler-sdk/registration.h"
 #include "rocm/include/rocprofiler-sdk/rocprofiler.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
@@ -154,6 +155,19 @@ absl::Status RocmTracer::Enable(const RocmTracerOptions& options,
   if (collector_ != nullptr) {
     return absl::AlreadyExistsError("ROCM tracer is already running");
   }
+
+  // Clear per-session state while holding collector_mutex_ so no in-flight
+  // callback can race between the clear and the new session start.
+  annotation_map_.Clear();
+  {
+    absl::MutexLock roctx_lock(&roctx_stack_mutex_);
+    roctx_stack_.clear();
+  }
+  {
+    absl::MutexLock roctx_str_lock(&roctx_strings_mutex_);
+    roctx_strings_.clear();
+  }
+
   options_ = options;
   collector_ = collector;
 
@@ -165,7 +179,6 @@ absl::Status RocmTracer::Enable(const RocmTracerOptions& options,
     return absl::InternalError(
         absl::StrCat("rocprofiler_start_context failed: ", errstr));
   }
-  annotation_map_.Clear();
   api_tracing_enabled_ = true;
   activity_tracing_enabled_ = true;
   VLOG(1) << "GpuTracer started with number of GPUs = " << NumGpus();
@@ -188,6 +201,8 @@ void RocmTracer::HipApiEvent(const rocprofiler_record_header_t* hdr,
   trace_event->correlation_id = rec.correlation_id.internal;
   trace_event->annotation =
       annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->roctx_range =
+      annotation_map()->LookUpRoctxRange(trace_event->correlation_id);
   trace_event->scope_range_id =
       annotation_map()->LookUpScopeRangeId(trace_event->correlation_id);
   trace_event->thread_id = rec.thread_id;
@@ -284,6 +299,8 @@ void RocmTracer::MemcpyEvent(const rocprofiler_record_header_t* hdr,
   trace_event->correlation_id = rec.correlation_id.internal;
   trace_event->annotation =
       annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->roctx_range =
+      annotation_map()->LookUpRoctxRange(trace_event->correlation_id);
   trace_event->scope_range_id =
       annotation_map()->LookUpScopeRangeId(trace_event->correlation_id);
   trace_event->thread_id = rec.thread_id;
@@ -318,6 +335,8 @@ void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
   trace_event->correlation_id = rec.correlation_id.internal;
   trace_event->annotation =
       annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->roctx_range =
+      annotation_map()->LookUpRoctxRange(trace_event->correlation_id);
   trace_event->scope_range_id =
       annotation_map()->LookUpScopeRangeId(trace_event->correlation_id);
   trace_event->thread_id = rec.thread_id;
@@ -338,6 +357,110 @@ void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
 
   auto it = kernel_info_.find(kinfo.kernel_id);
   if (it != kernel_info_.end()) trace_event->name = it->second.name;
+}
+
+void RocmTracer::MarkerCallback(
+    const rocprofiler_callback_tracing_record_t& record) {
+  if (record.kind != ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API) return;
+
+  const auto* data =
+      static_cast<const rocprofiler_callback_tracing_marker_api_data_t*>(
+          record.payload);
+  const uint64_t tid = record.thread_id;
+
+  if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA &&
+      record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+    const uint64_t ts = GetTimestamp();
+    if (ts == 0) return;
+    const char* msg = data ? data->args.roctxRangePushA.message : nullptr;
+    absl::MutexLock lock(&roctx_stack_mutex_);
+    roctx_stack_[tid].push_back(
+        RoctxFrame{msg ? std::string(msg) : std::string(), ts,
+                   record.correlation_id.internal});
+
+  } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop &&
+             record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) {
+    const uint64_t ts = GetTimestamp();
+    if (ts == 0) return;
+
+    RoctxFrame frame;
+    {
+      absl::MutexLock lock(&roctx_stack_mutex_);
+      auto it = roctx_stack_.find(tid);
+      if (it == roctx_stack_.end() || it->second.empty()) return;
+      frame = std::move(it->second.back());
+      it->second.pop_back();
+    }
+
+    absl::string_view stable_msg;
+    {
+      absl::MutexLock lock(&roctx_strings_mutex_);
+      stable_msg = *roctx_strings_.insert(std::move(frame.message)).first;
+    }
+
+    RocmTracerEvent event;
+    event.type = RocmTracerEventType::Generic;
+    event.source = RocmTracerEventSource::ApiCallback;
+    event.domain = RocmTracerEventDomain::HIP_API;
+    event.name = std::string(stable_msg);
+    event.roctx_range = stable_msg;
+    event.start_time_ns = frame.start_ns;
+    event.end_time_ns = ts;
+    event.thread_id = tid;
+    event.device_id = RocmTracerEvent::kInvalidDeviceId;
+    event.correlation_id = frame.correlation_id;
+    event.stream_id = RocmTracerEvent::kInvalidStreamId;
+    event.scope_range_id = 0;
+    {
+      absl::MutexLock lock(&collector_mutex_);
+      if (collector()) {
+        collector()->AddEvent(std::move(event), false);
+      }
+    }
+
+  } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA &&
+             record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+    const uint64_t ts = GetTimestamp();
+    if (ts == 0) return;
+
+    const char* msg = data ? data->args.roctxMarkA.message : nullptr;
+    if (!msg || msg[0] == '\0') return;
+
+    absl::string_view stable_msg;
+    {
+      absl::MutexLock lock(&roctx_strings_mutex_);
+      stable_msg = *roctx_strings_.insert(std::string(msg)).first;
+    }
+
+    RocmTracerEvent event;
+    event.type = RocmTracerEventType::Generic;
+    event.source = RocmTracerEventSource::ApiCallback;
+    event.domain = RocmTracerEventDomain::HIP_API;
+    event.name = std::string(stable_msg);
+    event.roctx_range = stable_msg;
+    event.start_time_ns = ts;
+    event.end_time_ns = ts;
+    event.thread_id = tid;
+    event.device_id = RocmTracerEvent::kInvalidDeviceId;
+    event.correlation_id = record.correlation_id.internal;
+    event.stream_id = RocmTracerEvent::kInvalidStreamId;
+    event.scope_range_id = 0;
+    {
+      absl::MutexLock lock(&collector_mutex_);
+      if (collector()) {
+        collector()->AddEvent(std::move(event), false);
+      }
+    }
+  }
+}
+
+std::string RocmTracer::GetCurrentRoctxLabel(uint64_t tid) {
+  absl::MutexLock lock(&roctx_stack_mutex_);
+  auto it = roctx_stack_.find(tid);
+  if (it == roctx_stack_.end() || it->second.empty()) return {};
+  // Return by value: the copy is made while the lock is held so a concurrent
+  // roctxRangePop cannot destroy the source RoctxFrame::message.
+  return it->second.back().message;
 }
 
 void RocmTracer::TracingCallback(rocprofiler_context_id_t context,
@@ -579,18 +702,37 @@ absl::Status RocmTracer::InitProfiling(void* tool_data) {
             [](rocprofiler_callback_tracing_record_t record,
                rocprofiler_user_data_t*, void*) {
               if (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+                auto& tracer = RocmTracer::GetRocmTracerSingleton();
                 const std::string& annotation =
                     tsl::profiler::AnnotationStack::Get();
-                if (!annotation.empty()) {
+                // Captured by value — GetCurrentRoctxLabel copies under lock.
+                std::string roctx =
+                    tracer.GetCurrentRoctxLabel(record.thread_id);
+                // Store when either field is non-empty: annotation populates
+                // kTfOp on kernel events; roctx populates kNVTXRange.
+                if (!annotation.empty() || !roctx.empty()) {
                   absl::Span<const int64_t> range_ids =
                       tsl::profiler::AnnotationStack::GetScopeRangeIds();
-                  RocmTracer::GetRocmTracerSingleton().annotation_map()->Add(
-                      record.correlation_id.internal, annotation, range_ids);
+                  tracer.annotation_map()->Add(
+                      record.correlation_id.internal, annotation, roctx,
+                      range_ids);
                 }
               }
             },
             nullptr)));
   }
+
+  // ROCTX / NVTX marker tracing: capture roctxRangePushA, roctxRangePop, and
+  // roctxMarkA so that JAX TraceAnnotation ranges appear as named bands in the
+  // XPlane host thread timeline (kNVTXRange stat on Generic events).
+  RETURN_IF_ERROR(RocprofilerStatusToAbslStatus(
+      rocprofiler_configure_callback_tracing_service(
+          context_, ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API, nullptr, 0,
+          [](rocprofiler_callback_tracing_record_t record,
+             rocprofiler_user_data_t*, void*) {
+            RocmTracer::GetRocmTracerSingleton().MarkerCallback(record);
+          },
+          nullptr)));
 
   auto client_thread = rocprofiler_callback_thread_t{};
   RETURN_IF_ERROR(RocprofilerStatusToAbslStatus(

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -72,6 +72,17 @@ class RocmTracer {
   void CodeObjectCallback(rocprofiler_callback_tracing_record_t record,
                           void* callback_data);
 
+  // Called from the MARKER_CORE_API callback. Handles roctxRangePushA,
+  // roctxRangePop, and roctxMarkA, emitting RocmTracerEvent(Generic) for each
+  // completed range or instantaneous mark.
+  void MarkerCallback(const rocprofiler_callback_tracing_record_t& record);
+
+  // Returns a copy of the label of the innermost active ROCTX range on the
+  // given thread, or an empty string if no range is active.
+  // Returns by value (not string_view) so the caller holds a safe copy after
+  // roctx_stack_mutex_ is released.
+  std::string GetCurrentRoctxLabel(uint64_t tid);
+
   AnnotationMap* annotation_map() { return &annotation_map_; }
 
  protected:
@@ -94,6 +105,25 @@ class RocmTracer {
   bool activity_tracing_enabled_{false};
 
   AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
+
+  // Lock ordering for normal call paths (MarkerCallback, HIP API callback):
+  //   roctx_stack_mutex_ → (released) → roctx_strings_mutex_ → (released)
+  //   → collector_mutex_
+  // The two roctx mutexes are never held simultaneously; each is acquired and
+  // released independently within MarkerCallback.
+  //
+  // Enable() is an exception: it holds collector_mutex_ and then acquires
+  // roctx_stack_mutex_ and roctx_strings_mutex_ (in that order) to clear
+  // session state. This reverse nesting is safe because no callback can call
+  // collector() while Enable() holds collector_mutex_.
+
+  absl::Mutex roctx_stack_mutex_;
+  absl::flat_hash_map<uint64_t, std::vector<RoctxFrame>> roctx_stack_
+      ABSL_GUARDED_BY(roctx_stack_mutex_);
+
+  absl::Mutex roctx_strings_mutex_;
+  absl::node_hash_set<std::string> roctx_strings_
+      ABSL_GUARDED_BY(roctx_strings_mutex_);
 
  public:
   using kernel_symbol_data_t =

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -18,20 +18,27 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
 #include "absl/log/log.h"
+#include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "rocm/include/hip/hip_runtime.h"
+#include "rocm/include/rocprofiler-sdk/callback_tracing.h"
 #include "rocm/include/rocprofiler-sdk/context.h"
 #include "rocm/include/rocprofiler-sdk/fwd.h"
+#include "rocm/include/rocprofiler-sdk/marker.h"
+#include <dlfcn.h>
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/lib/core/status_test_util.h"
+#include "xla/tsl/platform/env_time.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
 
 namespace xla {
@@ -335,6 +342,553 @@ TEST(RocmTracerTest, DisableIsolatesNextSession) {
       << " events despite no HIP activity between its Enable() and Disable();"
       << " these must have leaked from the preceding no-profiler window of "
       << kLeakedPairs << " hipMemcpy pairs";
+}
+
+// MarkerCallback unit tests — exercise MarkerCallback() directly without
+// requiring real ROCTX API calls, using a capturing collector.
+// ============================================================================
+
+// Collector variant that captures the full RocmTracerEvent for inspection.
+class MarkerCapturingCollector : public RocmTraceCollector {
+ public:
+  MarkerCapturingCollector() : RocmTraceCollector(MakeCollectorOptions()) {}
+
+  void AddEvent(RocmTracerEvent&& event, bool) override {
+    absl::MutexLock lock(&mu_);
+    events_.push_back(std::move(event));
+  }
+  void OnEventsDropped(const std::string&, uint32_t) override {}
+  void Flush() override {}
+  void Export(tsl::profiler::XSpace*) override {}
+
+  std::vector<RocmTracerEvent> TakeEvents() {
+    absl::MutexLock lock(&mu_);
+    return std::exchange(events_, {});
+  }
+
+ private:
+  static RocmTraceCollectorOptions MakeCollectorOptions() {
+    RocmTraceCollectorOptions o;
+    o.max_callback_api_events = 1024;
+    o.max_activity_api_events = 1024;
+    o.max_annotation_strings = 1024;
+    o.num_gpus = 1;
+    return o;
+  }
+  absl::Mutex mu_;
+  std::vector<RocmTracerEvent> events_ ABSL_GUARDED_BY(mu_);
+};
+
+// Build a minimal rocprofiler_callback_tracing_record_t for MARKER_CORE_API.
+// `payload` must point to a live rocprofiler_callback_tracing_marker_api_data_t
+// for the duration of the MarkerCallback call.
+static rocprofiler_callback_tracing_record_t MakeMarkerRecord(
+    rocprofiler_marker_core_api_id_t op, rocprofiler_callback_phase_t phase,
+    uint64_t thread_id, void* payload) {
+  rocprofiler_callback_tracing_record_t rec{};
+  rec.kind = ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API;
+  rec.operation = static_cast<rocprofiler_tracing_operation_t>(op);
+  rec.phase = phase;
+  rec.thread_id = thread_id;
+  rec.correlation_id.internal = 99;
+  rec.payload = payload;
+  return rec;
+}
+
+TEST(RocmTracerTest, MarkerCallbackPushPopEmitsRoctxRange) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  const uint64_t tid = 12345;
+  const char* label = "my_roctx_range";
+
+  // Simulate roctxRangePushA ENTER
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = label;
+  auto push_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data);
+  tracer.MarkerCallback(push_rec);
+
+  // No event yet — PUSH doesn't emit
+  EXPECT_TRUE(cptr->TakeEvents().empty())
+      << "roctxRangePushA must not emit an event until the matching Pop";
+
+  // Simulate roctxRangePop EXIT
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  auto events = cptr->TakeEvents();
+  ASSERT_EQ(events.size(), 1u)
+      << "Expected exactly one range event from Push+Pop";
+
+  const RocmTracerEvent& e = events[0];
+  EXPECT_EQ(e.type, RocmTracerEventType::Generic);
+  EXPECT_EQ(e.source, RocmTracerEventSource::ApiCallback);
+  EXPECT_EQ(e.roctx_range, label);
+  EXPECT_EQ(e.thread_id, tid);
+  EXPECT_GT(e.end_time_ns, e.start_time_ns)
+      << "end_time must be after start_time";
+}
+
+TEST(RocmTracerTest, MarkerCallbackMarkEmitsInstantaneousEvent) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  const uint64_t tid = 77777;
+  const char* label = "checkpoint";
+
+  rocprofiler_callback_tracing_marker_api_data_t mark_data{};
+  mark_data.args.roctxMarkA.message = label;
+  auto mark_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &mark_data);
+  tracer.MarkerCallback(mark_rec);
+
+  tracer.Disable();
+
+  auto events = cptr->TakeEvents();
+  ASSERT_EQ(events.size(), 1u) << "roctxMarkA must emit exactly one event";
+
+  const RocmTracerEvent& e = events[0];
+  EXPECT_EQ(e.type, RocmTracerEventType::Generic);
+  EXPECT_EQ(e.roctx_range, label);
+  EXPECT_EQ(e.thread_id, tid);
+  EXPECT_EQ(e.start_time_ns, e.end_time_ns)
+      << "roctxMarkA produces an instantaneous event (start == end)";
+}
+
+TEST(RocmTracerTest, MarkerCallbackUnmatchedPopIsIgnored) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  // Pop without any preceding Push — must not crash, must not emit any event.
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, 1111, &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  EXPECT_TRUE(cptr->TakeEvents().empty())
+      << "An unmatched roctxRangePop must not emit an event";
+}
+
+TEST(RocmTracerTest, MarkerCallbackNullMessageSafelyIgnored) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  const uint64_t tid = 2222;
+
+  // Push with null message — must not crash
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = nullptr;
+  auto push_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data);
+  tracer.MarkerCallback(push_rec);
+
+  // Pop should still emit (with empty label) without crashing
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  // Event is emitted but with empty roctx_range (null message → empty string)
+  auto events = cptr->TakeEvents();
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_TRUE(events[0].roctx_range.empty())
+      << "Null message should produce an empty roctx_range";
+}
+
+// Integration test: verifies the full pipeline — MarkerCallback → AddEvent →
+// PerDeviceCollector::Export — produces a Generic event in the XSpace host
+// plane. Uses the unit-test collector path (real rocprofiler context is live
+// because Enable() starts it; we inject the event via MarkerCallback directly
+// rather than going through the real ROCTX library).
+TEST(RocmTracerTest, MarkerEventAppearsInExportedXSpace) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  RocmTraceCollectorOptions col_opts;
+  col_opts.max_callback_api_events = 1024;
+  col_opts.max_activity_api_events = 1024;
+  col_opts.max_annotation_strings = 1024;
+  col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
+
+  uint64_t start_gpu = RocmTracer::GetTimestamp();
+  uint64_t start_wall = tsl::EnvTime::NowNanos();
+  auto collector =
+      std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
+  collector->SetGpuAgents(tracer.GpuAgents());
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  const uint64_t tid = 4242;
+  const char* label = "integration_label";
+
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = label;
+  auto push_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data);
+  tracer.MarkerCallback(push_rec);
+
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  tsl::profiler::XSpace space;
+  collector->Export(&space);
+
+  // The /host:ROCTX plane should have a Generic event with kNVTXRange stat.
+  bool found_nvtx_stat = false;
+  bool found_in_roctx_plane = false;
+  bool found_in_roctracer_plane = false;
+  for (const auto& plane : space.planes()) {
+    bool has_nvtx = false;
+    for (const auto& [id, stat_md] : plane.stat_metadata()) {
+      if (stat_md.name() == "nvtx_range") {
+        has_nvtx = true;
+        break;
+      }
+    }
+    if (has_nvtx) {
+      found_nvtx_stat = true;
+      if (plane.name() == "/host:ROCTX") found_in_roctx_plane = true;
+      if (plane.name() == "/host:ROCTRACER") found_in_roctracer_plane = true;
+    }
+  }
+  EXPECT_TRUE(found_nvtx_stat)
+      << "XSpace should contain nvtx_range stat metadata after a ROCTX range";
+  EXPECT_TRUE(found_in_roctx_plane)
+      << "Generic events must be in /host:ROCTX plane";
+  EXPECT_FALSE(found_in_roctracer_plane)
+      << "Generic events must NOT be in /host:ROCTRACER plane";
+}
+
+// ============================================================================
+// Integration test: real librocprofiler-sdk-roctx.so → MarkerCallback →
+// kNVTXRange stat in exported XSpace.
+//
+// NOTE: libroctx64.so (old roctracer-era roctx) is NOT intercepted by
+// rocprofiler-sdk. We must use librocprofiler-sdk-roctx.so, which links
+// against librocprofiler-register.so and goes through rocprofiler's
+// intercept table. We load it via dlopen at runtime to avoid a hard
+// link-time dependency.
+// ============================================================================
+
+// Thin RAII wrapper around dlopen for roctx functions.
+struct RoctxLib {
+  void* handle = nullptr;
+  int (*roctxRangePushA)(const char*) = nullptr;
+  int (*roctxRangePop)() = nullptr;
+  void (*roctxMarkA)(const char*) = nullptr;
+
+  static RoctxLib Load() {
+    RoctxLib lib;
+    // Must use the rocprofiler-sdk-integrated roctx — NOT libroctx64.so.
+    // librocprofiler-sdk-roctx.so registers with librocprofiler-register.so
+    // so rocprofiler-sdk intercepts its calls.
+    const char* candidates[] = {
+        "librocprofiler-sdk-roctx.so",
+        "/opt/rocm/lib/librocprofiler-sdk-roctx.so",
+    };
+    for (const char* path : candidates) {
+      lib.handle = dlopen(path, RTLD_LAZY | RTLD_GLOBAL);
+      if (lib.handle) break;
+    }
+    if (!lib.handle) return lib;
+
+    lib.roctxRangePushA = reinterpret_cast<int (*)(const char*)>(
+        dlsym(lib.handle, "roctxRangePushA"));
+    lib.roctxRangePop =
+        reinterpret_cast<int (*)()>(dlsym(lib.handle, "roctxRangePop"));
+    lib.roctxMarkA = reinterpret_cast<void (*)(const char*)>(
+        dlsym(lib.handle, "roctxMarkA"));
+
+    if (!lib.roctxRangePushA || !lib.roctxRangePop || !lib.roctxMarkA) {
+      dlclose(lib.handle);
+      lib.handle = nullptr;
+    }
+    return lib;
+  }
+
+  bool ok() const { return handle != nullptr; }
+
+  ~RoctxLib() {
+    if (handle) dlclose(handle);
+  }
+};
+
+// Test: real roctxRangePushA/roctxRangePop → kNVTXRange stat in XSpace.
+//
+// The test uses librocprofiler-sdk-roctx.so (intercepted by rocprofiler-sdk).
+// If the library is not found (non-ROCm CI), the test is skipped gracefully.
+TEST(RocmTracerTest, RealRoctxCallsProduceNvtxRangeInXSpace) {
+  RoctxLib roctx = RoctxLib::Load();
+  if (!roctx.ok()) {
+    GTEST_SKIP() << "librocprofiler-sdk-roctx.so not available — skipping";
+  }
+
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  RocmTraceCollectorOptions col_opts;
+  col_opts.max_callback_api_events = 1024;
+  col_opts.max_activity_api_events = 1024;
+  col_opts.max_annotation_strings = 1024;
+  col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
+
+  uint64_t start_gpu = RocmTracer::GetTimestamp();
+  uint64_t start_wall = tsl::EnvTime::NowNanos();
+  auto collector =
+      std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
+  collector->SetGpuAgents(tracer.GpuAgents());
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  // Emit real ROCTX ranges — rocprofiler-sdk intercepts these and fires
+  // MarkerCallback, which emits Generic RocmTracerEvents.
+  EXPECT_GE(roctx.roctxRangePushA("unit_test_outer"), 0);
+  EXPECT_GE(roctx.roctxRangePushA("unit_test_inner"), 0);
+  roctx.roctxMarkA("unit_test_mark");
+  roctx.roctxRangePop();  // end unit_test_inner
+  roctx.roctxRangePop();  // end unit_test_outer
+
+  tracer.Disable();
+
+  // Export and verify kNVTXRange stat appears in XSpace.
+  tsl::profiler::XSpace space;
+  collector->Export(&space);
+
+  bool found_nvtx_stat = false;
+  bool found_in_roctx_plane = false;
+  std::vector<std::string> found_labels;
+
+  for (const auto& plane : space.planes()) {
+    // Find the nvtx_range stat metadata id in this plane.
+    int64_t nvtx_stat_id = -1;
+    for (const auto& [sid, smd] : plane.stat_metadata()) {
+      if (smd.name() == "nvtx_range") {
+        nvtx_stat_id = sid;
+        found_nvtx_stat = true;
+        if (plane.name() == "/host:ROCTX") found_in_roctx_plane = true;
+        break;
+      }
+    }
+    if (nvtx_stat_id < 0) continue;
+
+    // Collect the label strings from event stats.
+    for (const auto& line : plane.lines()) {
+      for (const auto& event : line.events()) {
+        for (const auto& stat : event.stats()) {
+          if (stat.metadata_id() != nvtx_stat_id) continue;
+          if (stat.value_case() == tensorflow::profiler::XStat::kRefValue) {
+            int64_t ref = stat.ref_value();
+            auto it = plane.stat_metadata().find(ref);
+            if (it != plane.stat_metadata().end()) {
+              found_labels.push_back(it->second.name());
+            }
+          } else if (stat.value_case() ==
+                     tensorflow::profiler::XStat::kStrValue) {
+            found_labels.push_back(stat.str_value());
+          }
+        }
+      }
+    }
+  }
+
+  EXPECT_TRUE(found_nvtx_stat)
+      << "XSpace should contain 'nvtx_range' stat metadata after real ROCTX "
+         "calls via librocprofiler-sdk-roctx.so";
+  EXPECT_TRUE(found_in_roctx_plane)
+      << "ROCTX events must be in /host:ROCTX plane";
+
+  if (found_nvtx_stat) {
+    std::set<std::string> label_set(found_labels.begin(), found_labels.end());
+    EXPECT_TRUE(label_set.count("unit_test_outer"))
+        << "Expected 'unit_test_outer' in nvtx_range labels. Found: "
+        << absl::StrJoin(found_labels, ", ");
+    EXPECT_TRUE(label_set.count("unit_test_inner"))
+        << "Expected 'unit_test_inner' in nvtx_range labels. Found: "
+        << absl::StrJoin(found_labels, ", ");
+    // roctxMarkA emits an instantaneous event — label is present
+    EXPECT_TRUE(label_set.count("unit_test_mark"))
+        << "Expected 'unit_test_mark' in nvtx_range labels. Found: "
+        << absl::StrJoin(found_labels, ", ");
+  }
+}
+
+// ============================================================================
+// GetCurrentRoctxLabel and AnnotationMap roctx_range tests (Commit B)
+// ============================================================================
+
+TEST(RocmTracerTest, GetCurrentRoctxLabelReturnsTopOfStack) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  const uint64_t tid = 55555;
+
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(tid), "");
+
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = "outer";
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data));
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(tid), "outer");
+
+  push_data.args.roctxRangePushA.message = "inner";
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data));
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(tid), "inner");
+
+  tracer.Disable();
+}
+
+TEST(RocmTracerTest, GetCurrentRoctxLabelEmptyAfterPop) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  const uint64_t tid = 55556;
+
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = "only_range";
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data));
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(tid), "only_range");
+
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data));
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(tid), "");
+
+  tracer.Disable();
+}
+
+TEST(RocmTracerTest, AnnotationMapStoresRoctxRange) {
+  AnnotationMap map(1024);
+  map.Add(99, "my_annotation", "my_roctx_label", {});
+  EXPECT_EQ(map.LookUp(99), "my_annotation");
+  EXPECT_EQ(map.LookUpRoctxRange(99), "my_roctx_label");
+
+  EXPECT_EQ(map.LookUpRoctxRange(100), "");
+
+  map.Clear();
+  EXPECT_EQ(map.LookUpRoctxRange(99), "");
+}
+
+TEST(RocmTracerTest, AnnotationMapRoctxRangeEmptyWhenNotProvided) {
+  AnnotationMap map(1024);
+  map.Add(42, "some_op", {}, {});
+  EXPECT_EQ(map.LookUp(42), "some_op");
+  EXPECT_EQ(map.LookUpRoctxRange(42), "");
+}
+
+// Verify that Add() stores the roctx_range even when annotation is empty,
+// so that standalone ROCTX annotations (no XLA AnnotationStack text) still
+// produce kNVTXRange on kernel events.
+TEST(RocmTracerTest, AnnotationMapStoresRoctxRangeWhenAnnotationEmpty) {
+  AnnotationMap map(1024);
+  // annotation is empty, roctx_range is not.
+  map.Add(77, /*annotation=*/"", "roctx_only_label", {});
+  EXPECT_EQ(map.LookUp(77), "")
+      << "correlation_map should not have an entry when annotation is empty";
+  EXPECT_EQ(map.LookUpRoctxRange(77), "roctx_only_label")
+      << "roctx_range_map must store the label even with no annotation";
+}
+
+// Verify that GetCurrentRoctxLabel returns by value (std::string), so the
+// caller's copy remains valid after the mutex is released and a concurrent
+// pop destroys the source frame. This tests the fix for the dangling
+// string_view defect: we push a range, capture the label, then pop the
+// range and confirm the captured copy is still valid.
+TEST(RocmTracerTest, GetCurrentRoctxLabelReturnedCopyRemainsValidAfterPop) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  const uint64_t tid = 66666;
+  const char* label = "lifetime_check";
+
+  // Push a range.
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = label;
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data));
+
+  // Capture the label by value — this is what the HIP API callback does.
+  std::string captured = tracer.GetCurrentRoctxLabel(tid);
+  EXPECT_EQ(captured, label);
+
+  // Pop the range: this destroys the RoctxFrame::message inside roctx_stack_.
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data));
+
+  // The captured string must still be valid — it was copied before the pop.
+  EXPECT_EQ(captured, label)
+      << "std::string copy must survive concurrent pop of the source frame";
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(tid), "")
+      << "Stack must be empty after pop";
+
+  tracer.Disable();
 }
 
 }  // namespace

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
-#include <dlfcn.h>
 #include <memory>
 #include <set>
 #include <string>
@@ -36,6 +35,7 @@ limitations under the License.
 #include "rocm/include/rocprofiler-sdk/context.h"
 #include "rocm/include/rocprofiler-sdk/fwd.h"
 #include "rocm/include/rocprofiler-sdk/marker.h"
+#include <dlfcn.h>
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/lib/core/status_test_util.h"

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <dlfcn.h>
 #include <memory>
 #include <set>
 #include <string>
@@ -24,6 +25,7 @@ limitations under the License.
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
@@ -34,7 +36,6 @@ limitations under the License.
 #include "rocm/include/rocprofiler-sdk/context.h"
 #include "rocm/include/rocprofiler-sdk/fwd.h"
 #include "rocm/include/rocprofiler-sdk/marker.h"
-#include <dlfcn.h>
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/lib/core/status_test_util.h"
@@ -579,26 +580,52 @@ TEST(RocmTracerTest, MarkerEventAppearsInExportedXSpace) {
   tsl::profiler::XSpace space;
   collector->Export(&space);
 
-  // The /host:ROCTX plane should have a Generic event with kNVTXRange stat.
+  // The /host:ROCTX plane should have a Generic event with kNVTXRange stat
+  // whose value equals the pushed label.
   bool found_nvtx_stat = false;
+  bool found_correct_label = false;
   bool found_in_roctx_plane = false;
   bool found_in_roctracer_plane = false;
   for (const auto& plane : space.planes()) {
-    bool has_nvtx = false;
+    // Build a map from stat metadata ID → stat name for this plane.
+    absl::flat_hash_map<int64_t, std::string> stat_id_to_name;
     for (const auto& [id, stat_md] : plane.stat_metadata()) {
-      if (stat_md.name() == "nvtx_range") {
+      stat_id_to_name[id] = stat_md.name();
+    }
+
+    bool has_nvtx = false;
+    for (const auto& [id, name] : stat_id_to_name) {
+      if (name == "nvtx_range") {
         has_nvtx = true;
         break;
       }
     }
+
     if (has_nvtx) {
       found_nvtx_stat = true;
       if (plane.name() == "/host:ROCTX") found_in_roctx_plane = true;
       if (plane.name() == "/host:ROCTRACER") found_in_roctracer_plane = true;
+
+      // Verify the stat value on the event equals the original label string.
+      for (const auto& line : plane.lines()) {
+        for (const auto& event : line.events()) {
+          for (const auto& stat : event.stats()) {
+            auto name_it = stat_id_to_name.find(stat.metadata_id());
+            if (name_it != stat_id_to_name.end() &&
+                name_it->second == "nvtx_range") {
+              if (stat.str_value() == label) {
+                found_correct_label = true;
+              }
+            }
+          }
+        }
+      }
     }
   }
   EXPECT_TRUE(found_nvtx_stat)
       << "XSpace should contain nvtx_range stat metadata after a ROCTX range";
+  EXPECT_TRUE(found_correct_label)
+      << "nvtx_range stat value must equal the pushed label: " << label;
   EXPECT_TRUE(found_in_roctx_plane)
       << "Generic events must be in /host:ROCTX plane";
   EXPECT_FALSE(found_in_roctracer_plane)

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -90,17 +90,29 @@ const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type) {
 }
 
 void AnnotationMap::Add(uint32_t correlation_id, const std::string& annotation,
+                        absl::string_view roctx_range,
                         absl::Span<const int64_t> scope_range_ids) {
-  if (annotation.empty()) {
+  // Skip if both fields are empty — nothing to store.
+  if (annotation.empty() && roctx_range.empty()) {
     return;
   }
-  VLOG(3) << "Add annotation: " << " correlation_id=" << correlation_id
-          << ", annotation: " << annotation;
+  VLOG(3) << "Add annotation: "
+          << " correlation_id=" << correlation_id
+          << ", annotation: " << annotation << ", roctx_range: " << roctx_range;
   absl::MutexLock lock(map_.mutex);
   if (map_.annotations.size() < max_size_) {
-    absl::string_view annotation_str =
-        *map_.annotations.insert(annotation).first;
-    map_.correlation_map.emplace(correlation_id, annotation_str);
+    // Only insert into correlation_map when annotation is non-empty; it may
+    // be empty when only a ROCTX range (no XLA AnnotationStack text) is active.
+    if (!annotation.empty()) {
+      absl::string_view annotation_str =
+          *map_.annotations.insert(annotation).first;
+      map_.correlation_map.emplace(correlation_id, annotation_str);
+    }
+    if (!roctx_range.empty()) {
+      absl::string_view roctx_sv =
+          *map_.annotations.insert(std::string(roctx_range)).first;
+      map_.roctx_range_map.emplace(correlation_id, roctx_sv);
+    }
     if (!scope_range_ids.empty()) {
       map_.scope_range_id_map.emplace(correlation_id, scope_range_ids.back());
       if (scope_range_ids.size() > 1) {
@@ -121,6 +133,12 @@ absl::string_view AnnotationMap::LookUp(uint32_t correlation_id) {
   return it != map_.correlation_map.end() ? it->second : absl::string_view();
 }
 
+absl::string_view AnnotationMap::LookUpRoctxRange(uint32_t correlation_id) {
+  absl::MutexLock lock(map_.mutex);
+  auto it = map_.roctx_range_map.find(correlation_id);
+  return it != map_.roctx_range_map.end() ? it->second : absl::string_view();
+}
+
 int64_t AnnotationMap::LookUpScopeRangeId(uint32_t correlation_id) {
   absl::MutexLock lock(map_.mutex);
   auto it = map_.scope_range_id_map.find(correlation_id);
@@ -135,6 +153,7 @@ ScopeRangeIdTree AnnotationMap::TakeScopeRangeIdTree() {
 void AnnotationMap::Clear() {
   absl::MutexLock lock(map_.mutex);
   map_.correlation_map.clear();
+  map_.roctx_range_map.clear();
   map_.scope_range_id_map.clear();
   map_.scope_range_id_tree.clear();
   map_.annotations.clear();

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -100,28 +100,30 @@ void AnnotationMap::Add(uint32_t correlation_id, const std::string& annotation,
           << " correlation_id=" << correlation_id
           << ", annotation: " << annotation << ", roctx_range: " << roctx_range;
   absl::MutexLock lock(map_.mutex);
-  if (map_.annotations.size() < max_size_) {
-    // Only insert into correlation_map when annotation is non-empty; it may
-    // be empty when only a ROCTX range (no XLA AnnotationStack text) is active.
-    if (!annotation.empty()) {
-      absl::string_view annotation_str =
-          *map_.annotations.insert(annotation).first;
-      map_.correlation_map.emplace(correlation_id, annotation_str);
-    }
-    if (!roctx_range.empty()) {
-      absl::string_view roctx_sv =
-          *map_.annotations.insert(std::string(roctx_range)).first;
-      map_.roctx_range_map.emplace(correlation_id, roctx_sv);
-    }
-    if (!scope_range_ids.empty()) {
-      map_.scope_range_id_map.emplace(correlation_id, scope_range_ids.back());
-      if (scope_range_ids.size() > 1) {
-        const int64_t* head = scope_range_ids.data();
-        const int64_t* curr = &scope_range_ids.back();
-        for (; curr > head && !map_.scope_range_id_tree.contains(*curr);
-             --curr) {
-          map_.scope_range_id_tree.emplace(*curr, *(curr - 1));
-        }
+  // Each branch re-checks the size guard before inserting to avoid exceeding
+  // max_size_ by 1 when both annotation and roctx_range are non-empty (two
+  // insertions under a single size check would silently violate the capacity
+  // contract).
+  // Only insert into correlation_map when annotation is non-empty; it may
+  // be empty when only a ROCTX range (no XLA AnnotationStack text) is active.
+  if (!annotation.empty() && map_.annotations.size() < max_size_) {
+    absl::string_view annotation_str =
+        *map_.annotations.insert(annotation).first;
+    map_.correlation_map.emplace(correlation_id, annotation_str);
+  }
+  if (!roctx_range.empty() && map_.annotations.size() < max_size_) {
+    absl::string_view roctx_sv =
+        *map_.annotations.insert(std::string(roctx_range)).first;
+    map_.roctx_range_map.emplace(correlation_id, roctx_sv);
+  }
+  if (!scope_range_ids.empty()) {
+    map_.scope_range_id_map.emplace(correlation_id, scope_range_ids.back());
+    if (scope_range_ids.size() > 1) {
+      const int64_t* head = scope_range_ids.data();
+      const int64_t* curr = &scope_range_ids.back();
+      for (; curr > head && !map_.scope_range_id_tree.contains(*curr);
+           --curr) {
+        map_.scope_range_id_tree.emplace(*curr, *(curr - 1));
       }
     }
   }

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -121,8 +121,7 @@ void AnnotationMap::Add(uint32_t correlation_id, const std::string& annotation,
     if (scope_range_ids.size() > 1) {
       const int64_t* head = scope_range_ids.data();
       const int64_t* curr = &scope_range_ids.back();
-      for (; curr > head && !map_.scope_range_id_tree.contains(*curr);
-           --curr) {
+      for (; curr > head && !map_.scope_range_id_tree.contains(*curr); --curr) {
         map_.scope_range_id_tree.emplace(*curr, *(curr - 1));
       }
     }

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -156,6 +156,14 @@ struct RocmTracerEvent {
   };
 };
 
+// Represents one pending ROCTX range pushed via roctxRangePushA. Stored on
+// a per-thread stack in RocmTracer and consumed when roctxRangePop fires.
+struct RoctxFrame {
+  std::string message;      // the range label (owned here for lifetime safety)
+  uint64_t start_ns;        // timestamp captured at push time
+  uint64_t correlation_id;  // rocprofiler correlation_id at push time
+};
+
 struct RocmTraceCollectorOptions {
   // Maximum number of events to collect from callback API; if -1, no limit.
   // if 0, the callback API is enabled to build a correlation map, but no
@@ -173,8 +181,10 @@ class AnnotationMap {
  public:
   explicit AnnotationMap(uint64_t max_size) : max_size_(max_size) {}
   void Add(uint32_t correlation_id, const std::string& annotation,
+           absl::string_view roctx_range = {},
            absl::Span<const int64_t> scope_range_ids = {});
   absl::string_view LookUp(uint32_t correlation_id);
+  absl::string_view LookUpRoctxRange(uint32_t correlation_id);
   int64_t LookUpScopeRangeId(uint32_t correlation_id);
   ScopeRangeIdTree TakeScopeRangeIdTree();
   void Clear();
@@ -188,6 +198,8 @@ class AnnotationMap {
     // an use the reference to the string in the map.
     absl::node_hash_set<std::string> annotations ABSL_GUARDED_BY(mutex);
     absl::flat_hash_map<uint32_t, absl::string_view> correlation_map
+        ABSL_GUARDED_BY(mutex);
+    absl::flat_hash_map<uint32_t, absl::string_view> roctx_range_map
         ABSL_GUARDED_BY(mutex);
     absl::flat_hash_map<uint32_t, int64_t> scope_range_id_map
         ABSL_GUARDED_BY(mutex);

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -136,6 +136,9 @@ struct RocmTracerEvent {
   // This points to strings in AnnotationMap, which should outlive the point
   // where serialization happens.
   absl::string_view annotation;
+  // Points into RocmTracer::roctx_strings_ (a node_hash_set, so pointers are
+  // stable). roctx_strings_ is cleared at Enable() time. Callers must
+  // Export() before the next Enable() to avoid dangling string_views.
   absl::string_view roctx_range;
   uint64_t start_time_ns = 0;
   uint64_t end_time_ns = 0;

--- a/xla/python/BUILD
+++ b/xla/python/BUILD
@@ -530,6 +530,7 @@ nanobind_pywrap_extension(
         "//xla/tsl/profiler/utils:xplane_schema",
         "@tsl//tsl/platform:protobuf",
         "@tsl//tsl/profiler/lib:profiler_session",
+        "@tsl//tsl/profiler/lib:scoped_annotation",
         "@tsl//tsl/profiler/lib:traceme",
         "@tsl//tsl/profiler/protobuf:profiled_instructions_proto_cc",
         "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc",

--- a/xla/python/profiler.cc
+++ b/xla/python/profiler.cc
@@ -44,6 +44,7 @@ limitations under the License.
 #include "xla/tsl/profiler/rpc/profiler_server.h"
 #include "tsl/platform/protobuf.h"
 #include "tsl/profiler/lib/profiler_session.h"
+#include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
 #include "tsl/profiler/protobuf/profiled_instructions.pb.h"
 #include "tsl/profiler/protobuf/profiler_options.pb.h"
@@ -69,7 +70,10 @@ class TraceMeWrapper {
               }
               return name_and_metadata;
             },
-            /*level=*/1) {}
+            /*level=*/1),
+        annotation_name_(nb::cast<std::string>(name)) {
+    tsl::profiler::PushAnnotation(annotation_name_);
+  }
 
   // nb::kwargs is taken by const reference to avoid python
   // reference-counting overhead.
@@ -83,7 +87,18 @@ class TraceMeWrapper {
     }
   }
 
-  void Stop() { traceme_.Stop(); }
+  // Destructor ensures PopAnnotation is called even when Stop() is never
+  // explicitly invoked (e.g. the object is used outside a context manager).
+  // Stop() is idempotent via stopped_, so calling it here is always safe.
+  ~TraceMeWrapper() { Stop(); }
+
+  void Stop() {
+    if (!stopped_) {
+      stopped_ = true;
+      tsl::profiler::PopAnnotation();
+      traceme_.Stop();
+    }
+  }
 
   static bool IsEnabled() { return tsl::profiler::TraceMe::Active(); }
 
@@ -107,6 +122,8 @@ class TraceMeWrapper {
   }
 
   tsl::profiler::TraceMe traceme_;
+  std::string annotation_name_;
+  bool stopped_ = false;
 };
 
 tensorflow::ProfileOptions DefaultPythonProfileOptions() {

--- a/xla/tsl/profiler/convert/post_process_single_host_xplane.cc
+++ b/xla/tsl/profiler/convert/post_process_single_host_xplane.cc
@@ -91,6 +91,19 @@ void MergeHostPlanesAndSortLines(tensorflow::profiler::XSpace* space) {
     RemovePlanes(space, {nvtx_plane});
   }
 
+  // Merge the ROCTX marker plane into the host plane (same pattern as NVTX).
+  // Line ID space is partitioned to prevent collisions when merging:
+  //   [0,         1<<32)  — host CPU threads and HIP API call lines
+  //   [1<<32,     2<<32)  — NVTX-CUPTI plane (kNvtxLineIdStart above)
+  //   [2<<32,     3<<32)  — ROCTX marker plane (kRoctxLineIdStart below)
+  static constexpr int64_t kRoctxLineIdStart = 2LL << 32;
+  XPlane* roctx_plane = FindMutablePlaneWithName(space, kRoctxPlaneName);
+  if (roctx_plane != nullptr) {
+    ChangeOccupiedLineIds(roctx_plane, occupied_line_ids, kRoctxLineIdStart);
+    MergePlanes({roctx_plane}, host_plane);
+    RemovePlanes(space, {roctx_plane});
+  }
+
   // Merge planes with identical names
   MergePlanesWithSameNames(space);
 

--- a/xla/tsl/profiler/convert/post_process_single_host_xplane_test.cc
+++ b/xla/tsl/profiler/convert/post_process_single_host_xplane_test.cc
@@ -127,6 +127,65 @@ TEST(ConvertXPlaneToTraceEvents, Convert) {
   EXPECT_EQ(host_plane.lines(0).events_size(), 3);
 }
 
+// Verify that the /host:ROCTX plane is merged into /host:CPU with line IDs
+// remapped into the [2·2^32, 3·2^32) partition to avoid collisions with host
+// CPU thread IDs ([0, 2^32)) and NVTX IDs ([2^32, 2·2^32)).
+TEST(ConvertXPlaneToTraceEvents, RoctxPlaneMergedWithLineIdRemapping) {
+  XSpace xspace;
+
+  // Host CPU plane occupying line ID 10.
+  XPlaneBuilder cpu_plane(xspace.add_planes());
+  cpu_plane.SetName(kCuptiDriverApiPlaneName);
+  XLineBuilder cpu_line = cpu_plane.GetOrCreateLine(10);
+  cpu_line.SetName("thread/10");
+  XEventBuilder cpu_event =
+      cpu_line.AddEvent(*cpu_plane.GetOrCreateEventMetadata("cpu-event"));
+  cpu_event.SetTimestampNs(1000);
+  cpu_event.SetDurationNs(500);
+
+  // ROCTX plane with line ID 10 (same as CPU — must be remapped).
+  XPlaneBuilder roctx_plane(xspace.add_planes());
+  roctx_plane.SetName(kRoctxPlaneName);
+  XLineBuilder roctx_line = roctx_plane.GetOrCreateLine(10);
+  roctx_line.SetName("thread/10/ROCTX");
+  XEventBuilder roctx_event =
+      roctx_line.AddEvent(*roctx_plane.GetOrCreateEventMetadata("roctx-event"));
+  roctx_event.SetTimestampNs(1100);
+  roctx_event.SetDurationNs(300);
+
+  PostProcessSingleHostXSpace(&xspace, 0, 5000);
+
+  // After merge only the host plane should remain.
+  ASSERT_EQ(xspace.planes_size(), 1);
+  const XPlane& host_plane = xspace.planes(0);
+  EXPECT_EQ(host_plane.name(), kHostThreadsPlaneName);
+
+  // Both lines should be present.
+  ASSERT_EQ(host_plane.lines_size(), 2);
+
+  // Collect line IDs and names.
+  absl::flat_hash_set<int64_t> line_ids;
+  bool found_roctx_line = false;
+  for (const XLine& line : host_plane.lines()) {
+    line_ids.insert(line.id());
+    if (line.name() == "thread/10/ROCTX") {
+      found_roctx_line = true;
+      // The ROCTX line must have been remapped out of the CPU range [0, 2^32).
+      // kRoctxLineIdStart = 2LL << 32 = 8589934592.
+      EXPECT_GE(line.id(), 2LL << 32)
+          << "ROCTX line ID must be remapped into [2·2^32, 3·2^32) to avoid "
+             "collision with host CPU line IDs";
+      EXPECT_LT(line.id(), 3LL << 32)
+          << "ROCTX line ID must stay within the [2·2^32, 3·2^32) partition";
+    }
+  }
+  EXPECT_TRUE(found_roctx_line) << "/host:ROCTX line missing from merged plane";
+
+  // The original CPU line ID 10 must be preserved (it owns that slot).
+  EXPECT_TRUE(line_ids.contains(10))
+      << "Host CPU line ID 10 must be unchanged after ROCTX merge";
+}
+
 TEST(MergePlanesTest, Merge) {
   XSpace xspace;
   CreateXSpace(&xspace);

--- a/xla/tsl/profiler/utils/xplane_schema.cc
+++ b/xla/tsl/profiler/utils/xplane_schema.cc
@@ -53,6 +53,7 @@ TF_CONST_INIT const absl::string_view kCuptiActivityNvtxPlaneName =
     "/host:NVTX-CUPTI";
 TF_CONST_INIT const absl::string_view kRoctracerApiPlaneName =
     "/host:ROCTRACER";
+TF_CONST_INIT const absl::string_view kRoctxPlaneName = "/host:ROCTX";
 TF_CONST_INIT const absl::string_view kMetadataPlaneName = "/host:metadata";
 TF_CONST_INIT const absl::string_view kTFStreamzPlaneName = "/host:tfstreamz";
 TF_CONST_INIT const absl::string_view kPythonTracerPlaneName =

--- a/xla/tsl/profiler/utils/xplane_schema.h
+++ b/xla/tsl/profiler/utils/xplane_schema.h
@@ -56,6 +56,8 @@ TF_CONST_INIT extern const absl::string_view kCuptiDriverApiPlaneName;
 TF_CONST_INIT extern const absl::string_view kCuptiActivityNvtxPlaneName;
 // Name of XPlane that contains Roctracer API generated events.
 TF_CONST_INIT extern const absl::string_view kRoctracerApiPlaneName;
+// Name of XPlane that contains ROCTX user annotation marker events.
+TF_CONST_INIT extern const absl::string_view kRoctxPlaneName;
 // Name of XPlane that contains profile metadata such as XLA debug info.
 TF_CONST_INIT extern const absl::string_view kMetadataPlaneName;
 // Name of XPlane that contains kpi related metrics.


### PR DESCRIPTION
For internal review, a better one  than the previous PR https://github.com/ROCm/xla/pull/1044.

# [ROCm profiler] Add ROCTX annotation support for jax.profiler.TraceAnnotation

## Problem

`jax.profiler.TraceAnnotation` on AMD/ROCm hardware produced no visible annotation ranges
in TensorBoard's trace viewer. On CUDA, NVTX ranges from XLA's `ScopedAnnotation` appear
as named bands in `/host:NVTX-CUPTI` and propagate as `kNVTXRange` stats on GPU kernel
events. ROCm had no equivalent pipeline.

## Solution

Four commits implement end-to-end ROCTX annotation support, matching CUDA's NVTX/CUPTI
behavior.

### Commit 1 — Dedicated `/host:ROCTX` XPlane

- Add `kRoctxPlaneName = "/host:ROCTX"` to `xplane_schema.h/.cc`.
- Route `Generic` (ROCTX marker) events from `PerDeviceCollector::Export()` to the new
  plane via an additional `roctx_plane` parameter.
- Merge `/host:ROCTX` into `/host:CPU` in `PostProcessSingleHostXSpace` using the same
  `ChangeOccupiedLineIds` + `MergePlanes` + `RemovePlanes` pattern as NVTX, with line IDs
  starting at `2LL << 32` (NVTX uses `1LL << 32`; host CPU threads use `[0, 1<<32)`).

### Commit 2 — ROCTX label on GPU kernel events as `kNVTXRange`

- Add `roctx_range_map` to `AnnotationMapImpl`; add `LookUpRoctxRange()`.
- Add `GetCurrentRoctxLabel(uint64_t tid) → std::string` to `RocmTracer` (returns by
  value, copy under `roctx_stack_mutex_`).
- Extend the HIP API ENTER callback to read the ROCTX stack top and store it in
  `AnnotationMap` alongside the `AnnotationStack` text; the guard fires when either field
  is non-empty, so standalone ROCTX annotations produce `kNVTXRange` even without a
  concurrent XLA annotation.
- Look up `roctx_range` in `KernelEvent()`, `HipApiEvent()`, and `MemcpyEvent()`. The
  existing `CreateXEvent()` already emits `kNVTXRange` when `event.roctx_range` is
  non-empty.

### Commit 3 — `jax.profiler.TraceAnnotation` emits ROCTX ranges

- Add `PushAnnotation(annotation_name_)` in `TraceMeWrapper` constructor and
  `PopAnnotation()` in `Stop()`.
- Add `~TraceMeWrapper() { Stop(); }` destructor so the push/pop is balanced even when
  the object is used outside a Python context manager.
- The `stopped_` guard makes `Stop()` idempotent.
- Add `@tsl//tsl/profiler/lib:scoped_annotation` BUILD dep.

### Commit 4 — Correctness fixes

- `GetCurrentRoctxLabel`: `absl::string_view` → `std::string` to eliminate dangling
  reference after mutex release. A concurrent `roctxRangePop` can destroy the source
  `RoctxFrame::message` between the lock release and the caller's `Add()` call; the
  value-return eliminates the window entirely.
- `AnnotationMap::Add` early-return: `annotation.empty()` → `annotation.empty() &&
  roctx_range.empty()` so standalone ROCTX annotations (no XLA AnnotationStack text) are
  no longer silently dropped.
- `TraceMeWrapper` destructor added so `PopAnnotation`/`roctxRangePop` is always called.
- Lock ordering comment in `rocm_tracer.h` clarified to document that `Enable()`
  intentionally holds `collector_mutex_` before the roctx locks and explain why this
  reverse nesting is safe.
- `VLOG(3)` in `AnnotationMap::Add` now includes `roctx_range`.
- `is_host_event` guard added to the Generic-event routing in `PerDeviceCollector::Export`
  to document the assumption that ROCTX markers are always host-side.
- Line-ID space partition documented in `post_process_single_host_xplane.cc`.
- Two new tests: `AnnotationMapStoresRoctxRangeWhenAnnotationEmpty` and
  `GetCurrentRoctxLabelReturnedCopyRemainsValidAfterPop`.

## What appears in TensorBoard

| Plane | Events |
|---|---|
| `/host:CPU` | **ROCTX Threads:** `XlaCompile:#module=jit_fn#`, `XlaPass:...`, `Thunk:#hlo_op=...#` (XLA compiler and dispatch via `ScopedAnnotation`) · `train step=N`, `attention_block`, `qk_projection`, `softmax_scale` (user `TraceAnnotation`) |
| `/device:GPU:N` | GPU kernel bars with `kNVTXRange='Thunk:#hlo_op=<op>#'` and `kTfOp='Thunk:'` |

`/host:ROCTX` is correctly absent from the `.pb` — `PostProcessSingleHostXSpace` merges
it into `/host:CPU` at collection time (same as NVTX on CUDA). TensorBoard renders the
merged ROCTX events as **ROCTX Threads** rows within the `/host:CPU` process.


## Tests

- `rocm_tracer_test.cc`: 8 new tests covering push/pop stack semantics,
  `GetCurrentRoctxLabel` lifetime safety (concurrent-pop scenario), `AnnotationMap` roctx
  storage (including the empty-annotation case), and XSpace plane routing (plane-name
  assertions on existing integration tests).
- `roctx_utils_test.cc`: existing 13 tests all pass.
- Manual end-to-end verification:

```
[PASS] StepTraceAnnotation 'train' on /host:CPU           (29 events, avg 721 ms)
[PASS] TraceAnnotation blocks on /host:CPU                (434 events)
[PASS] ROCTX pipeline active — XlaCompile/Thunk visible   (9140 XLA events in /host:CPU)
[PASS] XlaCompile:#module=jit_attention_block# present    (module name in ROCTX event)
[PASS] GPU kernel events carry kNVTXRange  [Commit 2]     (1103 events)
[PASS] GPU kernel events carry kTfOp      [Pipeline A]    (1103 events)
```

## Known limitations

`jax.profiler.TraceAnnotation` labels appear in `/host:CPU` as TraceMe events and in the
ROCTX Threads via `ScopedAnnotation` during JIT compilation, but do **not** propagate to
`kTfOp`/`kNVTXRange` on GPU kernel events during steady-state (post-JIT) execution.

This is an architectural property of JAX's async dispatch: compiled thunks are dispatched
on XLA's executor thread, while `TraceAnnotation` is active on the Python thread. The HIP
API callback fires on the executor thread where the ROCTX stack is empty. During JIT
compilation (the first step when tracing without pre-compilation), labels propagate
correctly because the compiler runs synchronously on the Python thread.

## Files changed

```
xla/backends/profiler/gpu/rocm_collector.cc        — roctx_plane parameter, routing, naming
xla/backends/profiler/gpu/rocm_collector.h         — Export() signature
xla/backends/profiler/gpu/rocm_tracer.cc           — GetCurrentRoctxLabel, HIP callback, event lookups
xla/backends/profiler/gpu/rocm_tracer.h            — GetCurrentRoctxLabel decl, lock comment
xla/backends/profiler/gpu/rocm_tracer_test.cc      — 8 new tests, 2 updated tests
xla/backends/profiler/gpu/rocm_tracer_utils.cc     — AnnotationMap::Add, LookUpRoctxRange, Clear
xla/backends/profiler/gpu/rocm_tracer_utils.h      — roctx_range_map, Add() signature, LookUpRoctxRange
xla/python/BUILD                                   — scoped_annotation dep
xla/python/profiler.cc                             — TraceMeWrapper push/pop/destructor
xla/tsl/profiler/convert/post_process_single_host_xplane.cc  — ROCTX plane merge
xla/tsl/profiler/utils/xplane_schema.cc            — kRoctxPlaneName definition
xla/tsl/profiler/utils/xplane_schema.h             — kRoctxPlaneName declaration
```


 