### PR TITLE
[ROCm] Reject autotuning candidates that write out of bounds via warm-up redzoning

### DIFF
--- a/xla/backends/gpu/autotuner/BUILD
+++ b/xla/backends/gpu/autotuner/BUILD
@@ -711,6 +711,7 @@ xla_test(
         "//xla/service:transfer_manager",
         "//xla/service/gpu:gpu_compiler",
         "//xla/service/gpu:nvptx_compiler_impl",
+        "//xla/stream_executor:device_address",
         "//xla/stream_executor:device_address_allocator",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:stream_executor_address_allocator",

--- a/xla/backends/gpu/autotuner/gpu_profiler.cc
+++ b/xla/backends/gpu/autotuner/gpu_profiler.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -66,6 +67,55 @@ namespace xla {
 namespace gpu {
 
 namespace {
+
+// Wraps a DeviceAddressAllocator so that every buffer allocated through it
+// during the untimed warm-up run is surrounded by redzones (via an internal
+// RedzoneAllocator). This covers *all* buffers the executable allocates
+// on-demand while warming up, including both the result/output buffers and
+// any workspace/scratch buffers requested through the same allocator -- not
+// just the literal kernel output. A candidate that writes out of bounds
+// lands in the post-redzone of that allocation and is caught by
+// CheckRedzones(), causing the autotuner to reject the candidate instead of
+// letting it corrupt production memory.
+class WarmupRedzoneAllocator : public se::DeviceAddressAllocator {
+ public:
+  WarmupRedzoneAllocator(se::Stream* stream,
+                         se::DeviceAddressAllocator* underlying,
+                         int64_t redzone_size)
+      : se::DeviceAddressAllocator(underlying->platform()),
+        underlying_(underlying),
+        rz_alloc_(stream, underlying,
+                  /*memory_limit=*/static_cast<int64_t>(8) << 30,
+                  redzone_size) {}
+
+  absl::StatusOr<se::ScopedDeviceAddress<uint8_t>> Allocate(
+      int device_ordinal, uint64_t size, bool /*retry_on_failure*/,
+      int64_t /*memory_space*/) override {
+    ASSIGN_OR_RETURN(se::DeviceAddress<uint8_t> ptr,
+                     rz_alloc_.AllocateBytes(static_cast<int64_t>(size)));
+    return se::ScopedDeviceAddress<uint8_t>(ptr, device_ordinal, this);
+  }
+
+  absl::Status Deallocate(int /*device_ordinal*/,
+                          se::DeviceAddressBase /*mem*/) override {
+    // rz_alloc_ owns all memory; it is freed when this object is destroyed.
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<se::Stream*> GetStream(int device_ordinal) override {
+    return underlying_->GetStream(device_ordinal);
+  }
+
+  bool AllowsAsynchronousDeallocation() const override { return true; }
+
+  absl::StatusOr<se::RedzoneAllocator::RedzoneCheckStatus> CheckRedzones() {
+    return rz_alloc_.CheckRedzones();
+  }
+
+ private:
+  se::DeviceAddressAllocator* underlying_;
+  se::RedzoneAllocator rz_alloc_;
+};
 
 std::vector<ExecutionInput> CreateExecutionInputsFromBuffers(
     absl::Span<se::DeviceAddressBase const> buffers,
@@ -289,15 +339,37 @@ absl::StatusOr<ProfileResult> GpuProfiler::Profile(
     result.scratch_bytes = GetScratchBytes(*gpu_executable);
   }
   {
-    // Warm up run.
+    // Warm-up run: route every buffer the executable allocates on-demand
+    // (result/output buffers and workspace/scratch buffers alike) through a
+    // WarmupRedzoneAllocator, so that any out-of-bounds write lands in a
+    // mapped post-redzone rather than causing a GPU VM fault.
+    std::optional<WarmupRedzoneAllocator> warmup_rz;
+    se::DeviceAddressAllocator* warmup_alloc = allocator_;
+    if (options_.redzone_padding_bytes > 0) {
+      warmup_rz.emplace(stream_, allocator_, options_.redzone_padding_bytes);
+      warmup_alloc = &warmup_rz.value();
+    }
     std::vector<ExecutionInput> execution_inputs =
         CreateExecutionInputsFromBuffers(rz_buffers.input_buffers(),
                                          rz_buffers.input_shapes());
     RETURN_IF_ERROR(Execute(executable, std::move(execution_inputs),
-                            /*profile=*/nullptr)
+                            /*profile=*/nullptr, warmup_alloc)
                         .status());
-
     RETURN_IF_ERROR(stream_->BlockHostUntilDone());
+    if (warmup_rz.has_value()) {
+      ASSIGN_OR_RETURN(se::RedzoneAllocator::RedzoneCheckStatus rz_check,
+                       warmup_rz->CheckRedzones());
+      if (!rz_check.ok()) {
+        std::string redzone_failure_msg = rz_check.RedzoneFailureMsg();
+        VLOG(1) << "Autotuning candidate discarded: out-of-bounds write "
+                   "detected past an allocated buffer. "
+                << redzone_failure_msg;
+        return absl::InternalError(absl::StrCat(
+            "Autotuning candidate rejected: kernel wrote past its allocated "
+            "buffer. ",
+            redzone_failure_msg));
+      }
+    }
   }
 
   ExecutionProfile profile;
@@ -316,7 +388,7 @@ absl::StatusOr<ProfileResult> GpuProfiler::Profile(
 
 absl::StatusOr<ExecutionOutput> GpuProfiler::Execute(
     Executable* executable, std::vector<ExecutionInput> inputs,
-    ExecutionProfile* profile) {
+    ExecutionProfile* profile, se::DeviceAddressAllocator* allocator_override) {
   // Require exclusive GPU lock to prevent other runs during autotuning.
   GpuExecutableRunOptions gpu_opts;
   gpu_opts.set_requires_exclusive_lock_on_gpu();
@@ -324,7 +396,8 @@ absl::StatusOr<ExecutionOutput> GpuProfiler::Execute(
   ExecutableRunOptions run_options;
   run_options.set_device_ordinal(stream_executor_->device_ordinal());
   run_options.set_stream(stream_);
-  run_options.set_allocator(allocator_);
+  run_options.set_allocator(allocator_override != nullptr ? allocator_override
+                                                          : allocator_);
   run_options.set_gpu_executable_run_options(&gpu_opts);
   run_options.set_execution_profile(profile);
   ServiceExecutableRunOptions service_run_options(run_options);

--- a/xla/backends/gpu/autotuner/gpu_profiler.h
+++ b/xla/backends/gpu/autotuner/gpu_profiler.h
@@ -72,9 +72,10 @@ class GpuProfiler : public Profiler {
         stream_(stream),
         options_(options) {}
 
-  absl::StatusOr<ExecutionOutput> Execute(Executable* executable,
-                                          std::vector<ExecutionInput> inputs,
-                                          ExecutionProfile* profile);
+  absl::StatusOr<ExecutionOutput> Execute(
+      Executable* executable, std::vector<ExecutionInput> inputs,
+      ExecutionProfile* profile,
+      se::DeviceAddressAllocator* allocator_override = nullptr);
 
   se::StreamExecutor* stream_executor_;
   se::DeviceAddressAllocator* allocator_;

--- a/xla/backends/gpu/autotuner/gpu_profiler_test.cc
+++ b/xla/backends/gpu/autotuner/gpu_profiler_test.cc
@@ -46,6 +46,7 @@ limitations under the License.
 #include "xla/service/shaped_buffer.h"
 #include "xla/service/transfer_manager.h"
 #include "xla/shape_util.h"
+#include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/device_address_allocator.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/stream_executor.h"
@@ -67,10 +68,12 @@ constexpr absl::string_view kGemmBackendConfig =
 class MockExecutable : public Executable {
  public:
   explicit MockExecutable(std::shared_ptr<HloModule> module, int duration_ns,
-                          bool should_fail = false)
+                          bool should_fail = false,
+                          bool write_past_allocated_buffer = false)
       : Executable(module),
         duration_ns_(duration_ns),
-        should_fail_(should_fail) {}
+        should_fail_(should_fail),
+        write_past_allocated_buffer_(write_past_allocated_buffer) {}
   absl::StatusOr<ExecutionOutput> ExecuteAsyncOnStream(
       const ServiceExecutableRunOptions* run_options,
       std::vector<ExecutionInput> arguments) override {
@@ -81,6 +84,9 @@ class MockExecutable : public Executable {
     if (profile != nullptr) {
       profile->set_compute_time_ns(duration_ns_);
     }
+    if (write_past_allocated_buffer_) {
+      RETURN_IF_ERROR(WriteOutOfBounds(*run_options));
+    }
     const Shape& result_shape =
         module().entry_computation()->root_instruction()->shape();
     return ExecutionOutput(result_shape, result_shape,
@@ -89,8 +95,32 @@ class MockExecutable : public Executable {
   }
 
  private:
+  // Simulates a kernel that writes past the end of an allocated buffer:
+  // allocates a buffer through the run's allocator and then writes a few
+  // bytes past the end of it. When the allocator handed to us is a
+  // redzone-wrapping allocator (as GpuProfiler::Profile uses during its
+  // warm-up run when ProfileOptions.redzone_padding_bytes > 0), this lands
+  // in the mapped post-redzone instead of faulting, so it can be detected by
+  // CheckRedzones() instead of crashing the process.
+  absl::Status WriteOutOfBounds(
+      const ServiceExecutableRunOptions& run_options) {
+    constexpr int64_t kBufferBytes = 1024;
+    constexpr int64_t kOverrunBytes = 64;
+    se::DeviceAddressAllocator* allocator =
+        run_options.run_options().allocator();
+    ASSIGN_OR_RETURN(
+        se::ScopedDeviceAddress<uint8_t> buffer,
+        allocator->Allocate(run_options.run_options().device_ordinal(),
+                            kBufferBytes));
+    se::DeviceAddressBase oob_region(
+        static_cast<char*>(buffer->opaque()) + kBufferBytes, kOverrunBytes);
+    return run_options.run_options().stream()->MemZero(&oob_region,
+                                                       kOverrunBytes);
+  }
+
   int duration_ns_;
   bool should_fail_;
+  bool write_past_allocated_buffer_;
 };
 
 absl::StatusOr<ScopedShapedBuffer> CreateTestBuffer(
@@ -182,6 +212,29 @@ TEST_F(GpuProfilerTest, CreateInputBuffersAndProfile) {
   EXPECT_EQ(profile.output_buffer->on_device_shape(),
             ShapeUtil::MakeShape(S32, {}));
   EXPECT_EQ(profile.scratch_bytes, 0);
+}
+
+TEST_F(GpuProfilerTest, RejectsCandidateThatWritesPastAllocatedBuffer) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule module
+    ENTRY main {
+      ROOT c = s32[] constant(1)
+    }
+  )";
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule));
+  MockExecutable mock_executable(module, /*duration_ns=*/1000,
+                                 /*should_fail=*/false,
+                                 /*write_past_allocated_buffer=*/true);
+
+  ProfileOptions options;
+  options.redzone_padding_bytes = 1024;
+  auto profiler = GpuProfiler::Create(stream_exec_, options, allocator_.get());
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<InputBuffers> buffers,
+                       profiler->CreateInputBuffers(&mock_executable));
+  EXPECT_THAT(profiler->Profile(&mock_executable, *buffers),
+              StatusIs(absl::StatusCode::kInternal,
+                       ::testing::HasSubstr("Redzone mismatch")));
 }
 
 TEST_F(GpuProfilerTest, FailingExecutablesReturnStatus) {


### PR DESCRIPTION
## Summary
- Some autotuning candidates can write past the end of their allocated buffers. Under `XLA_PYTHON_CLIENT_ALLOCATOR=platform`, where buffers are sized exactly to their logical extent with no guard pages, such a write lands in unmapped GPU virtual address space and faults the GPU process.
- During the autotuner's warm-up run, `GpuProfiler` now wraps the allocator with a `RedzoneAllocator` so every candidate's buffers get a guard region. After the warm-up execution completes, `CheckRedzones()` verifies the guard regions are untouched; a violation causes the candidate to be rejected with an `InternalError` instead of crashing the process, and a `VLOG(1)` records the discarded candidate along with the redzone failure detail.
- This works uniformly regardless of which allocator is configured underneath, since it wraps whatever allocator is already selected.

## Test plan
- [x] Verified the fix resolves the GPU VM fault under `XLA_PYTHON_CLIENT_ALLOCATOR=platform`
- [x] Confirmed `VLOG(1)` output correctly reports the discarded candidate and redzone failure detail