### PR TITLE
[ROCm CI] 

### DIFF
--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -85,7 +85,9 @@ jobs:
             --bes_keywords=xla \
             --bes_keywords=release \
             --bes_keywords=single_gpu \
-            --bes_keywords=pull_request
+            --bes_keywords=pull_request \
+            -- \
+            //xla/...
 
       - name: Test XLA [${{ matrix.mode.name }}] [multi_gpu]
         if: always() && !cancelled()
@@ -99,7 +101,9 @@ jobs:
             --bes_keywords=xla \
             --bes_keywords=release \
             --bes_keywords=multi_gpu \
-            --bes_keywords=pull_request
+            --bes_keywords=pull_request \
+            -- \
+            //xla/...
       - name: Test XLA [rocm_cpu]
         if: always() && !cancelled()
         run: |
@@ -112,4 +116,6 @@ jobs:
             --bes_keywords=xla \
             --bes_keywords=release \
             --bes_keywords=cpu \
-            --bes_keywords=pull_request
+            --bes_keywords=pull_request \
+            -- \
+            //xla/...


### PR DESCRIPTION
## Summary

All three test steps in `.github/workflows/rocm_xla_ci.yml` call
`build_tools/rocm/run_xla_ci_build.sh` with flags only and no Bazel target
pattern. That script ends with a bare `"$@"`, so Bazel gets a `test` command
with zero targets and bails out during the loading phase:

```
Analyzing: 0 targets (7 packages loaded, 8 targets configured)
INFO: Found 0 test targets...
INFO: 1 process: 1 internal.
ERROR: No test targets were found, yet testing was requested
Error: Process completed with exit code 4.
```

`set -e` in the script plus `shell: sh -e {0}` propagates exit 4, so the step
fails. It happens in all three steps, and nothing is ever built or run — the
`[multi_gpu]` and `[rocm_cpu]` steps die in under a second.

This PR appends `-- //xla/...` to each of the three invocations.

## Root cause

The targets used to arrive indirectly via `--config=xla_sgpu` and
`--config=xla_mgpu`. Those configs are defined in the upstream tree at
`build_tools/rocm/rocm_xla.bazelrc:58` and `:78`, and carry target patterns
after a `--` separator:

```
test:xla_sgpu -- \
//xla/... \
-//xla/tests:iota_test_amdgpu_any \
...
```

Commit `9e5a3ad` — *"Remove XLA configurations from ROCM CI workflow" (#946,
2026-06-10)* — deleted both flags:

```diff
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=${{ vars.DOCKER_IMAGE }} \
-            --config=xla_sgpu \
             --jobs=30 \
```

Nothing replaced them, so target selection has been empty ever since.

The two sibling workflows were subsequently fixed to pass the targets
explicitly and are working today:

| Workflow | Passes `-- //xla/...`? | Fixed in |
|---|---|---|
| `rocm_xla_ci_nightly.yml` | yes, all 3 steps | `776533e` (2026-06-15) |
| `rocm_xla_ci_sanitizers.yml` | yes, all 3 steps | `c318d55` (2026-07-04) |
| `rocm_xla_ci.yml` | **no** | — this PR |

So this is not a new convention; it restores parity with the rest of the
directory.

### Why PRs into `main` are the ones that break

`rocm_xla_ci.yml` also runs on `push` to `rocm-jaxlib-v*`. On those release
branches `build_tools/rocm/run_xla_ci_build.sh` is a ROCm-modified copy that
hardcodes its own `//xla/...` plus an exclusion list, so no targets are needed
from the caller. But the `pull_request_target` trigger (`branches-ignore:
[rocm-dev-infra]`) also fires for PRs into `main`, and `main` mirrors
openxla/xla `main`, where that script has never contained a target pattern
(`git log -S '//xla/...'` on that file returns nothing across its whole
history). Same workflow, two different flavors of the script, only one of which
supplies targets.

## Verification

Run locally against openxla/xla at `4ca64a5c`, using the exact CI configs minus
the RBE cert flags:

| Step | Before | After |
|---|---|---|
| `--config=ci_single_gpu` | `Found 0 test targets` | **412** test targets |
| `--config=ci_multi_gpu` | `Found 0 test targets` | **21** test targets |
| `--config=ci_rocm_cpu` | `Found 0 test targets` | **73** test targets |

The 73 for `rocm_cpu` matches what openxla/xla's own presubmit reports for the
same tag-filter set, which is a good cross-check.

The tag filters that `run_xla_ci_build.sh` builds already narrow `//xla/...`
correctly per step — `requires-gpu-rocm,requires-gpu-amd,-multi_gpu` for
single_gpu, `multi_gpu` for multi_gpu, `gpu,-requires-gpu-rocm,-requires-gpu-amd`
for rocm_cpu — so no per-step target list is needed.

`yaml.safe_load` parses the result cleanly.

## Alternative considered

Restoring `--config=xla_sgpu` / `--config=xla_mgpu` would also work and would
additionally apply the curated exclusion lists in `rocm_xla.bazelrc`. Not chosen
because #946 removed those deliberately, and because the sibling workflows
settled on explicit `-- //xla/...`. Happy to switch if the reviewer prefers the
exclusion lists — note there is no `xla_cpu` config, so the `[rocm_cpu]` step
would still need an explicit pattern either way.

