### PR TITLE
[ROCm profiler] Plumb `ProfileOptions.advanced_configuration` into the ROCm tracer

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -524,6 +524,43 @@ cc_library(
     ],
 )
 
+# Deliberately carries no rocm-only/gpu/manual tag: this target has no ROCm
+# dependency, which is what lets its test run on ordinary presubmit machines.
+# Keep it that way.
+cc_library(
+    name = "rocm_tracer_options_utils",
+    srcs = ["rocm_tracer_options_utils.cc"],
+    hdrs = ["rocm_tracer_options_utils.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":rocm_tracer_utils",
+        "//xla/tsl/profiler/utils:profiler_options_util",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc",
+        "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_tracer_options_utils_test",
+    size = "small",
+    srcs = ["rocm_tracer_options_utils_test.cc"],
+    deps = [
+        ":rocm_tracer_options_utils",
+        ":rocm_tracer_utils",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc",
+        "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
 cc_library(
     name = "rocm_collector",
     srcs = ["rocm_collector.cc"],

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -82,6 +82,7 @@ cc_library(
     deps = [
         ":rocm_collector",
         ":rocm_tracer",
+        ":rocm_tracer_options_utils",
         ":rocm_tracer_utils",
         "//xla:debug_options_flags",
         "//xla/stream_executor/rocm:roctracer_wrapper",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -667,6 +667,31 @@ xla_cc_test(
 )
 
 xla_cc_test(
+    name = "device_tracer_rocm_test",
+    size = "small",
+    srcs = ["device_tracer_rocm_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ] + if_google([
+        "manual",
+    ]),
+    deps = [
+        ":device_tracer_rocm",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/profiler/lib:profiler_interface",
+        "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc",
+        "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
+xla_cc_test(
     name = "rocm_collector_test",
     size = "small",
     srcs = ["rocm_collector_test.cc"],

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -525,6 +525,16 @@ cc_library(
     ],
 )
 
+xla_cc_test(
+    name = "rocm_tracer_utils_test",
+    size = "small",
+    srcs = ["rocm_tracer_utils_test.cc"],
+    deps = [
+        ":rocm_tracer_utils",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 # Deliberately carries no rocm-only/gpu/manual tag: this target has no ROCm
 # dependency, which is what lets its test run on ordinary presubmit machines.
 # Keep it that way.

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -19,8 +19,10 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_options_utils.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/debug_options_flags.h"
 #include "xla/tsl/platform/env_time.h"
@@ -42,7 +44,8 @@ using tsl::profiler::XSpace;
 // GpuTracer for ROCm GPU.
 class GpuTracer : public profiler::ProfilerInterface {
  public:
-  explicit GpuTracer(RocmTracer* rocm_tracer) : rocm_tracer_(rocm_tracer) {
+  GpuTracer(RocmTracer* rocm_tracer, const ProfileOptions& profile_options)
+      : profile_options_(profile_options), rocm_tracer_(rocm_tracer) {
     LOG(INFO) << "GpuTracer created.";
   }
   ~GpuTracer() override {}
@@ -56,8 +59,12 @@ class GpuTracer : public profiler::ProfilerInterface {
   absl::Status DoStart();
   absl::Status DoStop();
 
-  RocmTracerOptions GetRocmTracerOptions();
-  RocmTraceCollectorOptions GetRocmTraceCollectorOptions(uint32_t num_gpus);
+  // Seeds both option structs from the hardcoded defaults and the
+  // --xla_gpu_rocm_max_trace_events flag, then applies
+  // ProfileOptions.advanced_configuration on top. Records any complaint in
+  // option_diagnostics_ instead of failing.
+  void BuildOptions(uint32_t num_gpus, RocmTracerOptions& tracer_options,
+                    RocmTraceCollectorOptions& collector_options);
 
   enum State {
     kNotStarted,
@@ -68,21 +75,21 @@ class GpuTracer : public profiler::ProfilerInterface {
   };
   State profiling_state_ = State::kNotStarted;
 
+  const ProfileOptions profile_options_;
+  RocmTracerOptionDiagnostics option_diagnostics_;
   RocmTracer* rocm_tracer_;
   std::unique_ptr<RocmTraceCollector> rocm_trace_collector_;
 };
 
-RocmTracerOptions GpuTracer::GetRocmTracerOptions() {
-  RocmTracerOptions options;
-  options.max_annotation_strings = 4 * 1024 * 1024;
-  return options;
-}
+void GpuTracer::BuildOptions(uint32_t num_gpus,
+                             RocmTracerOptions& tracer_options,
+                             RocmTraceCollectorOptions& collector_options) {
+  // Layer 1: hardcoded defaults, unchanged from what this file used before
+  // advanced_configuration existed.
+  collector_options.num_gpus = num_gpus;
 
-RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
-    uint32_t num_gpus) {
-  RocmTraceCollectorOptions options;
-  options.num_gpus = num_gpus;
-
+  // Layer 2: the legacy flag. Retained as a fallback for users who already
+  // depend on it; each advanced_configuration key overrides its own field.
   const auto& dbg = xla::GetDebugOptionsFromFlags();
   int64_t max_events = dbg.xla_gpu_rocm_max_trace_events();
   VLOG(2) << "max number of events to be trace from flag = " << max_events;
@@ -94,10 +101,42 @@ RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
   }
   VLOG(3) << "maximum number of events to be traced = " << max_events;
 
-  options.max_callback_api_events = max_events;
-  options.max_activity_api_events = max_events;
-  options.max_annotation_strings = max_events;
-  return options;
+  collector_options.max_callback_api_events = max_events;
+  collector_options.max_activity_api_events = max_events;
+  collector_options.max_annotation_strings = max_events;
+  // Seeded from the same source as the collector's annotation limit, so that
+  // the two stay consistent whether they are set by the flag or by the
+  // gpu_max_annotation_strings key, which writes both.
+  tracer_options.max_annotation_strings = max_events;
+
+  // Layer 3: ProfileOptions.advanced_configuration.
+  if (profile_options_.version() == 0 &&
+      !profile_options_.advanced_configuration().empty()) {
+    // Unreachable in practice: ProfilerSession::GetOptions drops the map
+    // before we ever see it when version() is zero. Logged in case a caller
+    // reaches the tracer factory directly with a hand-built proto.
+    VLOG(1) << "ProfileOptions.version() is 0; advanced_configuration is "
+               "normally stripped by ProfilerSession for such options.";
+  }
+  UpdateRocmTracerOptionsFromProfilerOptions(
+      profile_options_, tracer_options, collector_options, option_diagnostics_);
+
+  // Post-parse fixup for num_gpus, mirroring device_tracer_cuda.cc.
+  if (collector_options.num_gpus <= 0 ||
+      collector_options.num_gpus > num_gpus) {
+    if (collector_options.num_gpus != 0) {
+      LOG(WARNING) << "The provided number of GPUs ("
+                   << collector_options.num_gpus
+                   << ") is invalid. Profiling will be done on all available "
+                      "GPUs ("
+                   << num_gpus << ").";
+      option_diagnostics_.warnings.push_back(absl::StrCat(
+          "advanced_configuration key 'gpu_num_chips_to_profile_per_task'=",
+          collector_options.num_gpus, " is out of range; profiling all ",
+          num_gpus, " GPUs."));
+    }
+    collector_options.num_gpus = num_gpus;
+  }
 }
 
 absl::Status GpuTracer::DoStart() {
@@ -105,9 +144,23 @@ absl::Status GpuTracer::DoStart() {
   uint64_t start_gputime_ns = RocmTracer::GetTimestamp();
   uint64_t start_walltime_ns = tsl::EnvTime::NowNanos();
 
-  RocmTracerOptions tracer_options = GetRocmTracerOptions();
-  RocmTraceCollectorOptions trace_collector_options =
-      GetRocmTraceCollectorOptions(rocm_tracer_->NumGpus());
+  RocmTracerOptions tracer_options;
+  RocmTraceCollectorOptions trace_collector_options;
+  BuildOptions(rocm_tracer_->NumGpus(), tracer_options,
+               trace_collector_options);
+
+  // Deliberately different from the CUPTI path. A bad key does not abort the
+  // session, because on the default JAX path that costs the user the entire
+  // GPU plane with nothing in the trace to explain it. The diagnostics are
+  // carried to CollectData instead. Callers that explicitly asked for start
+  // failures to be fatal still get that.
+  if (!option_diagnostics_.errors.empty() &&
+      profile_options_.raise_error_on_start_failure()) {
+    AnnotationStack::Enable(false);
+    return absl::InvalidArgumentError(
+        absl::StrJoin(option_diagnostics_.errors, " "));
+  }
+
   rocm_trace_collector_ = CreateRocmCollector(
       trace_collector_options, start_walltime_ns, start_gputime_ns);
   rocm_trace_collector_->SetGpuAgents(rocm_tracer_->GpuAgents());
@@ -147,6 +200,10 @@ absl::Status GpuTracer::Stop() {
 }
 
 absl::Status GpuTracer::CollectData(XSpace* space) {
+  // Delivered from every terminal state, including the failure states. This is
+  // the property the CUPTI path lacks: its add_errors/add_warnings calls sit
+  // under kStoppedOk and are unreachable when the tracer failed to start.
+  AppendOptionDiagnostics(option_diagnostics_, space);
   switch (profiling_state_) {
     case State::kNotStarted:
       VLOG(3) << "No trace data collected, session wasn't started";
@@ -181,7 +238,7 @@ std::unique_ptr<profiler::ProfilerInterface> CreateGpuTracer(
     return nullptr;
   auto& rocm_tracer = profiler::RocmTracer::GetRocmTracerSingleton();
   if (!rocm_tracer.IsAvailable()) return nullptr;
-  return std::make_unique<profiler::GpuTracer>(&rocm_tracer);
+  return std::make_unique<profiler::GpuTracer>(&rocm_tracer, options);
 }
 
 auto register_rocm_gpu_tracer_factory = [] {

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -84,6 +84,10 @@ class GpuTracer : public profiler::ProfilerInterface {
 void GpuTracer::BuildOptions(uint32_t num_gpus,
                              RocmTracerOptions& tracer_options,
                              RocmTraceCollectorOptions& collector_options) {
+  // Rebuilt from scratch on every start, so that a second Start() on the same
+  // tracer does not report the first session's complaints a second time.
+  option_diagnostics_ = RocmTracerOptionDiagnostics{};
+
   // Layer 1: hardcoded defaults, unchanged from what this file used before
   // advanced_configuration existed.
   collector_options.num_gpus = num_gpus;

--- a/xla/backends/profiler/gpu/device_tracer_rocm_test.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm_test.cc
@@ -1,0 +1,194 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// End-to-end tests for the ROCm GpuTracer's handling of
+// ProfileOptions.advanced_configuration. Requires a ROCm GPU; tagged
+// gpu + rocm-only like its siblings in this package.
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/strings/match.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/profiler/lib/profiler_interface.h"
+#include "tsl/profiler/protobuf/profiler_options.pb.h"
+#include "tsl/profiler/protobuf/xplane.pb.h"
+
+namespace xla {
+namespace profiler {
+
+// Defined in device_tracer_rocm.cc, which is deliberately header-less. The
+// comment there ("Not in anonymous namespace for testing purposes") is the
+// standing invitation for this declaration.
+std::unique_ptr<tsl::profiler::ProfilerInterface> CreateGpuTracer(
+    const tensorflow::ProfileOptions& options);
+
+namespace {
+
+using ::tensorflow::ProfileOptions;
+using ::tensorflow::profiler::XSpace;
+
+constexpr char kBogusKey[] = "gpu_max_callbac_api_events";  // realistic typo
+
+// A ProfileOptions the tracer factory will accept. version(1) matters: with
+// version 0, ProfilerSession::GetOptions strips advanced_configuration before
+// the tracer ever sees it, so a test built on a version-0 proto would pass
+// while asserting nothing.
+ProfileOptions MakeGpuOptions() {
+  ProfileOptions options;
+  options.set_version(1);
+  options.set_device_type(ProfileOptions::GPU);
+  return options;
+}
+
+void SetInt(ProfileOptions& options, const std::string& key, int64_t value) {
+  ProfileOptions::AdvancedConfigValue config_value;
+  config_value.set_int64_value(value);
+  (*options.mutable_advanced_configuration())[key] = config_value;
+}
+
+// A few HIP operations, enough to produce trace events. Copied in shape from
+// RocmTracerTest.CapturesHipEvents; no custom kernel is needed because the
+// memcpy API callbacks are what the caps and the exporter act on.
+void RunSomeHipWork(int iterations) {
+  constexpr size_t kNumFloats = 1024;
+  constexpr size_t kSize = kNumFloats * sizeof(float);
+  std::vector<float> host_data(kNumFloats, 1.0f);
+  void* device_data = nullptr;
+  ASSERT_EQ(hipMalloc(&device_data, kSize), hipSuccess);
+  for (int i = 0; i < iterations; ++i) {
+    ASSERT_EQ(
+        hipMemcpy(device_data, host_data.data(), kSize, hipMemcpyHostToDevice),
+        hipSuccess);
+    ASSERT_EQ(
+        hipMemcpy(host_data.data(), device_data, kSize, hipMemcpyDeviceToHost),
+        hipSuccess);
+  }
+  ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+  ASSERT_EQ(hipFree(device_data), hipSuccess);
+}
+
+bool HasGpu() {
+  int device_count = 0;
+  return hipGetDeviceCount(&device_count) == hipSuccess && device_count > 0;
+}
+
+size_t CountGpuPlaneEvents(const XSpace& space) {
+  size_t total = 0;
+  for (const auto& plane : space.planes()) {
+    if (!absl::StartsWith(plane.name(), "/device:GPU:")) {
+      continue;
+    }
+    for (const auto& line : plane.lines()) {
+      total += line.events_size();
+    }
+  }
+  return total;
+}
+
+// This is the whole point of the PR in one test. On the CUPTI path today the
+// equivalent assertion fails on both halves: DoStart returns an error, the
+// session swallows it, and the user gets an empty GPU plane with an empty
+// errors field and no way to tell that a typo was the cause.
+TEST(DeviceTracerRocmTest, BadKeyStillProducesATraceAndSaysWhy) {
+  if (!HasGpu()) GTEST_SKIP() << "No HIP devices available";
+
+  ProfileOptions options = MakeGpuOptions();
+  SetInt(options, kBogusKey, 5000);
+
+  auto tracer = CreateGpuTracer(options);
+  ASSERT_NE(tracer, nullptr);
+
+  TF_ASSERT_OK(tracer->Start());
+  RunSomeHipWork(/*iterations=*/4);
+  absl::SleepFor(absl::Milliseconds(100));
+  TF_ASSERT_OK(tracer->Stop());
+
+  XSpace space;
+  TF_ASSERT_OK(tracer->CollectData(&space));
+
+  EXPECT_GT(CountGpuPlaneEvents(space), 0u)
+      << "A bad advanced_configuration key must not cost the user the trace.";
+
+  bool named = false;
+  for (const auto& error : space.errors()) {
+    named |= absl::StrContains(error, kBogusKey);
+  }
+  EXPECT_TRUE(named) << "XSpace.errors must name the offending key; got "
+                     << space.errors_size() << " error(s).";
+}
+
+// The escape hatch. Callers that explicitly asked for start failures to be
+// fatal keep getting them; the leniency above is a default, not a policy.
+TEST(DeviceTracerRocmTest, RaiseErrorOnStartFailureMakesABadKeyFatal) {
+  if (!HasGpu()) GTEST_SKIP() << "No HIP devices available";
+
+  ProfileOptions options = MakeGpuOptions();
+  options.set_raise_error_on_start_failure(true);
+  SetInt(options, kBogusKey, 5000);
+
+  auto tracer = CreateGpuTracer(options);
+  ASSERT_NE(tracer, nullptr);
+
+  const absl::Status status = tracer->Start();
+  EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+  EXPECT_TRUE(absl::StrContains(status.message(), kBogusKey)) << status;
+
+  // Start failed before the tracer was enabled, so Stop is a no-op and the
+  // singleton is left available for the next test.
+  TF_EXPECT_OK(tracer->Stop());
+}
+
+// Pins the precedence order in BuildOptions, which is otherwise only asserted
+// by reading it top to bottom. The flag default is 4M; if
+// advanced_configuration were ignored, all the events below would survive.
+TEST(DeviceTracerRocmTest, AdvancedConfigurationOverridesTheFlagDefault) {
+  if (!HasGpu()) GTEST_SKIP() << "No HIP devices available";
+
+  constexpr int64_t kCallbackCap = 3;
+  constexpr int kIterations = 20;  // >= 40 API callbacks, far above the cap
+
+  ProfileOptions options = MakeGpuOptions();
+  SetInt(options, "gpu_max_callback_api_events", kCallbackCap);
+
+  auto tracer = CreateGpuTracer(options);
+  ASSERT_NE(tracer, nullptr);
+
+  TF_ASSERT_OK(tracer->Start());
+  RunSomeHipWork(kIterations);
+  absl::SleepFor(absl::Milliseconds(100));
+  TF_ASSERT_OK(tracer->Stop());
+
+  XSpace space;
+  TF_ASSERT_OK(tracer->CollectData(&space));
+
+  EXPECT_TRUE(space.errors().empty())
+      << "A documented key must not be reported as a problem.";
+  EXPECT_LE(CountGpuPlaneEvents(space), static_cast<size_t>(kCallbackCap))
+      << "gpu_max_callback_api_events did not take precedence over the "
+         "xla_gpu_rocm_max_trace_events default.";
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_collector_test.cc
+++ b/xla/backends/profiler/gpu/rocm_collector_test.cc
@@ -201,6 +201,83 @@ TEST(RocmCollectorTest, MultipleActivitiesPerCorrelationIdAllExported) {
   EXPECT_TRUE(seen_names.contains("kernel_c"));
 }
 
+// The max_callback_api_events limit has existed since the collector was
+// written and no test has ever proved it fires: both cases above set it to 100
+// and never come near it. It matters more now that
+// ProfileOptions.advanced_configuration can set it per-session through
+// gpu_max_callback_api_events, so a silent regression here would turn a
+// user-facing knob into a no-op.
+TEST(RocmCollectorTest, CallbackCapDropsEventsBeyondLimit) {
+  constexpr uint64_t kMaxCallbackEvents = 3;
+  constexpr int kEventsOffered = 5;
+
+  RocmTraceCollectorOptions options;
+  options.max_callback_api_events = kMaxCallbackEvents;
+  options.max_activity_api_events = 100;
+  options.max_annotation_strings = 100;
+  options.num_gpus = 1;
+
+  constexpr uint64_t kStartWallTimeNs = 1000;
+  constexpr uint64_t kStartGpuTimeNs = 2000;
+  RocmTraceCollectorImpl collector(options, kStartWallTimeNs, kStartGpuTimeNs);
+
+  constexpr uint32_t kDeviceId = 100;
+  constexpr uint64_t kStreamId = 123;
+
+  // Five complete API/activity pairs, distinct correlation ids. The field
+  // combination is copied from TestAddKernelEventAndExport above: the cap sits
+  // behind `source == ApiCallback && !is_auxiliary`, and a Generic (ROCTX)
+  // event would bypass it entirely and make this test vacuous.
+  for (int i = 0; i < kEventsOffered; ++i) {
+    const uint32_t correlation_id = 500 + i;
+
+    RocmTracerEvent api_event;
+    api_event.type = RocmTracerEventType::Kernel;
+    api_event.source = RocmTracerEventSource::ApiCallback;
+    api_event.domain = RocmTracerEventDomain::HIP_API;
+    api_event.name = "capped_kernel";
+    api_event.correlation_id = correlation_id;
+    api_event.thread_id = 999;
+    api_event.kernel_info = KernelDetails{};
+    api_event.kernel_info.func_ptr = reinterpret_cast<void*>(0xdeadbeef);
+    collector.AddEvent(std::move(api_event), /*is_auxiliary=*/false);
+
+    RocmTracerEvent activity;
+    activity.type = RocmTracerEventType::Kernel;
+    activity.source = RocmTracerEventSource::Activity;
+    activity.domain = RocmTracerEventDomain::HIP_OPS;
+    activity.name = "capped_kernel";
+    activity.correlation_id = correlation_id;
+    activity.start_time_ns = 3000 + i * 100;
+    activity.end_time_ns = 3050 + i * 100;
+    activity.device_id = kDeviceId;
+    activity.stream_id = kStreamId;
+    collector.AddEvent(std::move(activity), /*is_auxiliary=*/false);
+  }
+
+  collector.Flush();
+  tensorflow::profiler::XSpace space;
+  collector.Export(&space);
+
+  const auto* gpu_plane =
+      FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu_plane, nullptr);
+
+  size_t exported = 0;
+  for (const auto& line : gpu_plane->lines()) {
+    if (line.id() != static_cast<int64_t>(kStreamId)) {
+      continue;
+    }
+    exported += line.events_size();
+  }
+
+  // The two over-cap API callbacks are refused, and their activity records are
+  // then dropped for having no API counterpart, so neither half leaks through.
+  EXPECT_EQ(exported, kMaxCallbackEvents)
+      << "Offered " << kEventsOffered << " events under a cap of "
+      << kMaxCallbackEvents << "; the cap is not being enforced.";
+}
+
 }  // namespace test
 }  // namespace profiler
 }  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -158,6 +158,10 @@ absl::Status RocmTracer::Enable(const RocmTracerOptions& options,
         absl::StrCat("rocprofiler_start_context failed: ", errstr));
   }
   annotation_map_.Clear();
+  // Applied after Clear() so the new capacity takes effect on an empty map.
+  if (options.max_annotation_strings > 0) {
+    annotation_map_.SetMaxSize(options.max_annotation_strings);
+  }
   api_tracing_enabled_ = true;
   activity_tracing_enabled_ = true;
   VLOG(1) << "GpuTracer started with number of GPUs = " << NumGpus();

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -29,11 +29,10 @@ namespace profiler {
 // forward declare (interface)
 class RocmTraceCollector;
 
-struct RocmTracerOptions {
-  // maximum number of annotation strings that AnnotationMap in RocmTracer can
-  // store. e.g. 1M
-  uint64_t max_annotation_strings;
-};
+// NOTE: RocmTracerOptions lives in rocm_tracer_utils.h, next to
+// RocmTraceCollectorOptions, so that code which only needs to manipulate the
+// option structs does not have to depend on rocprofiler-sdk headers. It is
+// reachable from here through the include above.
 
 // The class use to enable rocprofiler-sdk buffered callback/activity tracing
 // and forward the collected trace events to RocmTraceCollector. There should be

--- a/xla/backends/profiler/gpu/rocm_tracer_options_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_options_utils.cc
@@ -1,4 +1,4 @@
-/* Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -150,13 +150,29 @@ void UpdateRocmTracerOptionsFromProfilerOptions(
                  });
 
   // Matches the CUPTI backend, including its reset-to-all disposition for
-  // out-of-range values. The reset itself is performed by the caller, which is
-  // the only place that knows how many GPUs are present.
+  // values above the device count. That reset is performed by the caller,
+  // which is the only place that knows how many GPUs are present -- but only
+  // for values that fit in the uint32_t field. A value that does not fit never
+  // reaches the caller's fixup, so it has to be reported here or not at all.
   Apply<int64_t>(
       profile_options, "gpu_num_chips_to_profile_per_task", input_keys,
       diagnostics, [&](int64_t value) {
-        if (value >= 0 && value <= std::numeric_limits<uint32_t>::max()) {
-          collector_options.num_gpus = static_cast<uint32_t>(value);
+        if (value < 0 || value > std::numeric_limits<uint32_t>::max()) {
+          diagnostics.errors.push_back(absl::StrCat(
+              "advanced_configuration key "
+              "'gpu_num_chips_to_profile_per_task': ",
+              value, " is outside the representable range [0, ",
+              std::numeric_limits<uint32_t>::max(),
+              "]. The key was ignored."));
+          return;
+        }
+        collector_options.num_gpus = static_cast<uint32_t>(value);
+        if (value == 0) {
+          diagnostics.warnings.push_back(
+              "advanced_configuration key 'gpu_num_chips_to_profile_per_task' "
+              "is 0, which is treated as 'all GPUs' rather than 'none'. This "
+              "matches the CUDA backend.");
+          return;
         }
         diagnostics.warnings.push_back(
             "advanced_configuration key 'gpu_num_chips_to_profile_per_task' "

--- a/xla/backends/profiler/gpu/rocm_tracer_options_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_options_utils.cc
@@ -1,0 +1,195 @@
+/* Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/rocm_tracer_options_utils.h"
+
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "xla/tsl/profiler/utils/profiler_options_util.h"
+#include "tsl/profiler/protobuf/profiler_options.pb.h"
+#include "tsl/profiler/protobuf/xplane.pb.h"
+
+namespace xla {
+namespace profiler {
+namespace {
+
+using tensorflow::ProfileOptions;
+
+// Keys the CUPTI backend recognises that have no ROCm implementation yet.
+// Each carries the type it is documented with, so that a wrong-typed value is
+// still reported now rather than in the release that implements the key.
+struct UnimplementedKey {
+  enum Type { kInt64, kBool, kString };
+
+  absl::string_view name;
+  Type type;
+  absl::string_view reason;
+};
+
+constexpr UnimplementedKey kUnimplementedOnRocm[] = {
+    {"gpu_enable_nvtx_tracking", UnimplementedKey::kBool,
+     "ROCTX marker tracing is currently always on and cannot be toggled; a "
+     "dedicated rocprofiler context is required to make it switchable"},
+    {"gpu_enable_cupti_activity_graph_trace", UnimplementedKey::kBool,
+     "HIP graph tracing is not yet wired into the ROCm tracer"},
+    {"gpu_dump_graph_node_mapping", UnimplementedKey::kBool,
+     "not implemented on any backend, including CUDA"},
+    {"gpu_pm_sample_counters", UnimplementedKey::kString,
+     "performance-monitor counter sampling is not yet available on ROCm"},
+    {"gpu_pm_sample_interval_us", UnimplementedKey::kInt64,
+     "performance-monitor counter sampling is not yet available on ROCm"},
+    {"gpu_pm_sample_buffer_size_per_gpu_mb", UnimplementedKey::kInt64,
+     "performance-monitor counter sampling is not yet available on ROCm"},
+    {"gpu_aggregated_tracing", UnimplementedKey::kBool,
+     "the ROCm collector has no aggregated-tracing mode"},
+};
+
+// Wrapper around tsl::profiler::SetValue that accumulates instead of returning
+// early, so that one bad key does not hide the others.
+//
+// SetValue returns its type error *before* erasing the key from the working
+// set, so the erase below is load-bearing: without it a wrong-typed key would
+// be reported twice, once as a type error and once as unrecognised. The CUPTI
+// parser never hits this because RETURN_IF_ERROR stops at the first failure.
+template <typename T>
+void Apply(const ProfileOptions& options, absl::string_view key,
+           absl::flat_hash_set<absl::string_view>& keys,
+           RocmTracerOptionDiagnostics& diagnostics,
+           std::function<void(T)> setter) {
+  const absl::Status status = tsl::profiler::SetValue<T>(
+      options, std::string(key), keys, std::move(setter));
+  if (!status.ok()) {
+    keys.erase(key);
+    diagnostics.errors.push_back(
+        absl::StrCat("advanced_configuration key '", key,
+                     "': ", status.message(), " The key was ignored."));
+  }
+}
+
+void WarnUnimplemented(const ProfileOptions& options,
+                       absl::flat_hash_set<absl::string_view>& keys,
+                       RocmTracerOptionDiagnostics& diagnostics) {
+  for (const UnimplementedKey& key : kUnimplementedOnRocm) {
+    if (!keys.contains(key.name)) continue;
+    // Type-check even though the value is discarded.
+    switch (key.type) {
+      case UnimplementedKey::kInt64:
+        Apply<int64_t>(options, key.name, keys, diagnostics, [](int64_t) {});
+        break;
+      case UnimplementedKey::kBool:
+        Apply<bool>(options, key.name, keys, diagnostics, [](bool) {});
+        break;
+      case UnimplementedKey::kString:
+        Apply<std::string>(options, key.name, keys, diagnostics,
+                           [](const std::string&) {});
+        break;
+    }
+    keys.erase(key.name);
+    diagnostics.warnings.push_back(absl::StrCat(
+        "advanced_configuration key '", key.name,
+        "' is accepted but has no effect on the ROCm backend: ", key.reason,
+        "."));
+  }
+}
+
+}  // namespace
+
+void UpdateRocmTracerOptionsFromProfilerOptions(
+    const ProfileOptions& profile_options, RocmTracerOptions& tracer_options,
+    RocmTraceCollectorOptions& collector_options,
+    RocmTracerOptionDiagnostics& diagnostics) {
+  absl::flat_hash_set<absl::string_view> input_keys;
+  for (const auto& [key, unused_value] :
+       profile_options.advanced_configuration()) {
+    input_keys.insert(key);
+  }
+
+  Apply<int64_t>(profile_options, "gpu_max_callback_api_events", input_keys,
+                 diagnostics, [&](int64_t value) {
+                   collector_options.max_callback_api_events = value;
+                 });
+
+  // The cap that reads this field is currently gated on a predicate that no
+  // activity event satisfies, so the value lands but is not yet enforced. The
+  // fix is a separate change; no further plumbing is needed here.
+  Apply<int64_t>(profile_options, "gpu_max_activity_api_events", input_keys,
+                 diagnostics, [&](int64_t value) {
+                   collector_options.max_activity_api_events = value;
+                 });
+
+  // One key, two fields. The tracer-side field sizes the AnnotationMap; the
+  // collector-side field is currently unread and is set for consistency.
+  Apply<int64_t>(profile_options, "gpu_max_annotation_strings", input_keys,
+                 diagnostics, [&](int64_t value) {
+                   tracer_options.max_annotation_strings = value;
+                   collector_options.max_annotation_strings = value;
+                 });
+
+  // Matches the CUPTI backend, including its reset-to-all disposition for
+  // out-of-range values. The reset itself is performed by the caller, which is
+  // the only place that knows how many GPUs are present.
+  Apply<int64_t>(
+      profile_options, "gpu_num_chips_to_profile_per_task", input_keys,
+      diagnostics, [&](int64_t value) {
+        if (value >= 0 && value <= std::numeric_limits<uint32_t>::max()) {
+          collector_options.num_gpus = static_cast<uint32_t>(value);
+        }
+        diagnostics.warnings.push_back(
+            "advanced_configuration key 'gpu_num_chips_to_profile_per_task' "
+            "is applied post-hoc on ROCm: events from excluded devices are "
+            "discarded after collection, so tracing overhead is unchanged. "
+            "Devices are selected by ascending device id, not by topology.");
+      });
+
+  WarnUnimplemented(profile_options, input_keys, diagnostics);
+
+  // Report every remaining key, not just the first, and sort so that the
+  // output is stable across runs.
+  std::vector<absl::string_view> unknown(input_keys.begin(), input_keys.end());
+  absl::c_sort(unknown);
+  for (absl::string_view key : unknown) {
+    diagnostics.errors.push_back(absl::StrCat(
+        "advanced_configuration key '", key,
+        "' is not recognised by the ROCm GPU tracer and was ignored."));
+  }
+}
+
+void AppendOptionDiagnostics(const RocmTracerOptionDiagnostics& diagnostics,
+                             tensorflow::profiler::XSpace* space) {
+  if (space == nullptr) return;
+  for (const std::string& message : diagnostics.errors) {
+    LOG(ERROR) << message;
+    space->add_errors(message);
+  }
+  for (const std::string& message : diagnostics.warnings) {
+    LOG(WARNING) << message;
+    space->add_warnings(message);
+  }
+}
+
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_tracer_options_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_options_utils.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xla/backends/profiler/gpu/rocm_tracer_options_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_options_utils.h
@@ -1,0 +1,74 @@
+/* Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_OPTIONS_UTILS_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_OPTIONS_UTILS_H_
+
+#include <string>
+#include <vector>
+
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "tsl/profiler/protobuf/profiler_options.pb.h"
+#include "tsl/profiler/protobuf/xplane.pb.h"
+
+namespace xla {
+namespace profiler {
+
+// Diagnostics produced while interpreting
+// ProfileOptions.advanced_configuration. Recorded when the tracer starts and
+// delivered when it collects, so that a mistyped or unsupported key reaches
+// the XSpace the user opens rather than only the server's stderr.
+struct RocmTracerOptionDiagnostics {
+  // Keys that were not recognised, or whose value had the wrong oneof type.
+  std::vector<std::string> errors;
+  // Keys that are recognised but have no effect on the ROCm backend, plus
+  // caveats attached to keys that do.
+  std::vector<std::string> warnings;
+
+  bool empty() const { return errors.empty() && warnings.empty(); }
+};
+
+// Applies the gpu_* entries of profile_options.advanced_configuration() to the
+// two ROCm option structs. Both structs must already hold the caller's
+// defaults; only keys that are actually present are touched.
+//
+// This function never fails. Unlike the CUPTI equivalent
+// (UpdateCuptiTracerOptionsFromProfilerOptions), an unrecognised key neither
+// aborts parsing nor prevents the tracer from starting: it is recorded in
+// diagnostics.errors, and the remaining keys are still applied. The caller
+// decides what a non-empty error list means -- see GpuTracer::DoStart in
+// device_tracer_rocm.cc, which honours
+// ProfileOptions.raise_error_on_start_failure.
+//
+// The reason for the difference is that on the default JAX path a parse
+// failure is not visible to the user at all: it sets kStartedError, and that
+// branch of CollectData logs and returns OkStatus without ever reaching
+// XSpace.errors, so one typo silently costs the whole GPU plane. Reporting
+// into the XSpace and still producing a trace strictly dominates that.
+void UpdateRocmTracerOptionsFromProfilerOptions(
+    const tensorflow::ProfileOptions& profile_options,
+    RocmTracerOptions& tracer_options,
+    RocmTraceCollectorOptions& collector_options,
+    RocmTracerOptionDiagnostics& diagnostics);
+
+// Appends diagnostics to space->errors() and space->warnings(), and mirrors
+// them to LOG. Safe to call with empty diagnostics or a null space.
+void AppendOptionDiagnostics(const RocmTracerOptionDiagnostics& diagnostics,
+                             tensorflow::profiler::XSpace* space);
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_OPTIONS_UTILS_H_

--- a/xla/backends/profiler/gpu/rocm_tracer_options_utils_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_options_utils_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -143,6 +143,27 @@ TEST(RocmTracerOptionsUtilsTest, SetsNumGpusAndWarnsAboutPostHocDrop) {
   EXPECT_THAT(f.diagnostics.errors, IsEmpty());
   ASSERT_THAT(f.diagnostics.warnings, SizeIs(1));
   EXPECT_TRUE(absl::StrContains(f.diagnostics.warnings[0], "post-hoc"));
+}
+
+TEST(RocmTracerOptionsUtilsTest, OutOfRangeNumGpusIsReportedNotSilentlyDropped) {
+  // int64 values that cannot be represented in the uint32_t field. Neither is
+  // reachable through the caller's reset-to-all fixup, which only sees values
+  // that survived the narrowing -- so if this function stays quiet, nothing
+  // else will speak up and the user is told nothing at all.
+  for (int64_t value : {int64_t{-1}, int64_t{1} << 40}) {
+    Fixture f;
+    SetInt(f.options, "gpu_num_chips_to_profile_per_task", value);
+    f.Run();
+
+    EXPECT_EQ(f.collector.num_gpus, kNumGpusSentinel)
+        << "value " << value << " must not be applied";
+    ASSERT_THAT(f.diagnostics.errors, SizeIs(1)) << "value " << value;
+    EXPECT_THAT(f.diagnostics.errors[0],
+                MentionsKey("gpu_num_chips_to_profile_per_task"));
+    // The post-hoc caveat describes a key that took effect. Attaching it to a
+    // value that was thrown away tells the user the opposite of the truth.
+    EXPECT_THAT(f.diagnostics.warnings, IsEmpty()) << "value " << value;
+  }
 }
 
 TEST(RocmTracerOptionsUtilsTest, UnknownKeyIsReportedByName) {

--- a/xla/backends/profiler/gpu/rocm_tracer_options_utils_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_options_utils_test.cc
@@ -1,0 +1,277 @@
+/* Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/rocm_tracer_options_utils.h"
+
+#include <cstdint>
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "tsl/profiler/protobuf/profiler_options.pb.h"
+#include "tsl/profiler/protobuf/xplane.pb.h"
+
+namespace xla {
+namespace profiler {
+namespace {
+
+using ::tensorflow::ProfileOptions;
+using ::tensorflow::profiler::XSpace;
+using ::testing::Contains;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+
+void SetInt(ProfileOptions& options, absl::string_view key, int64_t value) {
+  ProfileOptions::AdvancedConfigValue config_value;
+  config_value.set_int64_value(value);
+  (*options.mutable_advanced_configuration())[std::string(key)] = config_value;
+}
+
+void SetBool(ProfileOptions& options, absl::string_view key, bool value) {
+  ProfileOptions::AdvancedConfigValue config_value;
+  config_value.set_bool_value(value);
+  (*options.mutable_advanced_configuration())[std::string(key)] = config_value;
+}
+
+void SetString(ProfileOptions& options, absl::string_view key,
+               absl::string_view value) {
+  ProfileOptions::AdvancedConfigValue config_value;
+  config_value.set_string_value(std::string(value));
+  (*options.mutable_advanced_configuration())[std::string(key)] = config_value;
+}
+
+MATCHER_P(MentionsKey, key, absl::StrCat("mentions the key '", key, "'")) {
+  return absl::StrContains(arg, absl::StrCat("'", key, "'"));
+}
+
+// Sentinel defaults, chosen so that "the field was never touched" is
+// distinguishable from "the field was set to a plausible value".
+constexpr uint64_t kTracerAnnotationSentinel = 111;
+constexpr uint64_t kCallbackSentinel = 222;
+constexpr uint64_t kActivitySentinel = 333;
+constexpr uint64_t kCollectorAnnotationSentinel = 444;
+constexpr uint32_t kNumGpusSentinel = 8;
+
+struct Fixture {
+  ProfileOptions options;
+  RocmTracerOptions tracer = {kTracerAnnotationSentinel};
+  RocmTraceCollectorOptions collector = {kCallbackSentinel, kActivitySentinel,
+                                         kCollectorAnnotationSentinel,
+                                         kNumGpusSentinel};
+  RocmTracerOptionDiagnostics diagnostics;
+
+  void Run() {
+    UpdateRocmTracerOptionsFromProfilerOptions(options, tracer, collector,
+                                               diagnostics);
+  }
+
+  // True when no option field was modified.
+  bool AllFieldsUntouched() const {
+    return tracer.max_annotation_strings == kTracerAnnotationSentinel &&
+           collector.max_callback_api_events == kCallbackSentinel &&
+           collector.max_activity_api_events == kActivitySentinel &&
+           collector.max_annotation_strings == kCollectorAnnotationSentinel &&
+           collector.num_gpus == kNumGpusSentinel;
+  }
+};
+
+TEST(RocmTracerOptionsUtilsTest, EmptyMapIsANoOp) {
+  Fixture f;
+  f.Run();
+
+  EXPECT_TRUE(f.AllFieldsUntouched());
+  EXPECT_TRUE(f.diagnostics.empty());
+}
+
+TEST(RocmTracerOptionsUtilsTest, SetsCallbackEventLimit) {
+  Fixture f;
+  SetInt(f.options, "gpu_max_callback_api_events", 4242);
+  f.Run();
+
+  EXPECT_EQ(f.collector.max_callback_api_events, 4242);
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  EXPECT_THAT(f.diagnostics.warnings, IsEmpty());
+}
+
+TEST(RocmTracerOptionsUtilsTest, SetsActivityEventLimit) {
+  Fixture f;
+  SetInt(f.options, "gpu_max_activity_api_events", 4242);
+  f.Run();
+
+  EXPECT_EQ(f.collector.max_activity_api_events, 4242);
+  // Wired silently: the cap that reads this field is not yet enforced, but
+  // fixing that requires no further plumbing, so there is no warning to
+  // retract later.
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  EXPECT_THAT(f.diagnostics.warnings, IsEmpty());
+}
+
+TEST(RocmTracerOptionsUtilsTest, SetsBothAnnotationLimitsFromOneKey) {
+  Fixture f;
+  SetInt(f.options, "gpu_max_annotation_strings", 777);
+  f.Run();
+
+  EXPECT_EQ(f.tracer.max_annotation_strings, 777);
+  EXPECT_EQ(f.collector.max_annotation_strings, 777);
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+}
+
+TEST(RocmTracerOptionsUtilsTest, SetsNumGpusAndWarnsAboutPostHocDrop) {
+  Fixture f;
+  SetInt(f.options, "gpu_num_chips_to_profile_per_task", 2);
+  f.Run();
+
+  // The reset-to-all for out-of-range values lives in the caller, so the raw
+  // value is visible here.
+  EXPECT_EQ(f.collector.num_gpus, 2);
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  ASSERT_THAT(f.diagnostics.warnings, SizeIs(1));
+  EXPECT_TRUE(absl::StrContains(f.diagnostics.warnings[0], "post-hoc"));
+}
+
+TEST(RocmTracerOptionsUtilsTest, UnknownKeyIsReportedByName) {
+  Fixture f;
+  SetInt(f.options, "gpu_max_callbac_api_events", 4242);  // realistic typo
+  f.Run();
+
+  ASSERT_THAT(f.diagnostics.errors, SizeIs(1));
+  EXPECT_THAT(f.diagnostics.errors[0], MentionsKey("gpu_max_callbac_api_events"));
+  EXPECT_TRUE(f.AllFieldsUntouched());
+}
+
+TEST(RocmTracerOptionsUtilsTest, AllUnknownKeysAreReported) {
+  Fixture f;
+  SetInt(f.options, "not_a_key", 1);
+  SetBool(f.options, "also_not_a_key", true);
+  SetString(f.options, "still_not_a_key", "x");
+  f.Run();
+
+  // Every unknown key is named. A parser that returns on the first failure --
+  // as the CUPTI one does -- reports only one of these.
+  EXPECT_THAT(f.diagnostics.errors, SizeIs(3));
+  EXPECT_THAT(f.diagnostics.errors, Contains(MentionsKey("not_a_key")));
+  EXPECT_THAT(f.diagnostics.errors, Contains(MentionsKey("also_not_a_key")));
+  EXPECT_THAT(f.diagnostics.errors, Contains(MentionsKey("still_not_a_key")));
+}
+
+TEST(RocmTracerOptionsUtilsTest, WrongTypeIsReportedOnce) {
+  Fixture f;
+  SetBool(f.options, "gpu_max_callback_api_events", true);  // documented int64
+  f.Run();
+
+  // Exactly one message. tsl::profiler::SetValue returns its type error before
+  // erasing the key from the working set, so a parser that forgets the
+  // explicit erase reports this key twice: once as a type error and once as
+  // unrecognised.
+  ASSERT_THAT(f.diagnostics.errors, SizeIs(1));
+  EXPECT_THAT(f.diagnostics.errors[0],
+              MentionsKey("gpu_max_callback_api_events"));
+  EXPECT_THAT(f.diagnostics.warnings, IsEmpty());
+  EXPECT_EQ(f.collector.max_callback_api_events, kCallbackSentinel);
+}
+
+TEST(RocmTracerOptionsUtilsTest, UnimplementedKeysAreAcceptedWithWarnings) {
+  Fixture f;
+  SetBool(f.options, "gpu_enable_nvtx_tracking", true);
+  SetBool(f.options, "gpu_enable_cupti_activity_graph_trace", true);
+  SetBool(f.options, "gpu_dump_graph_node_mapping", true);
+  SetString(f.options, "gpu_pm_sample_counters", "SQ_WAVES");
+  SetInt(f.options, "gpu_pm_sample_interval_us", 500);
+  SetInt(f.options, "gpu_pm_sample_buffer_size_per_gpu_mb", 64);
+  SetBool(f.options, "gpu_aggregated_tracing", true);
+  f.Run();
+
+  // A script written against CUDA must not fail on ROCm just because a key is
+  // not implemented here yet.
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  EXPECT_THAT(f.diagnostics.warnings, SizeIs(7));
+  EXPECT_THAT(f.diagnostics.warnings,
+              Contains(MentionsKey("gpu_enable_nvtx_tracking")));
+  EXPECT_THAT(f.diagnostics.warnings,
+              Contains(MentionsKey("gpu_pm_sample_counters")));
+  EXPECT_TRUE(f.AllFieldsUntouched());
+}
+
+TEST(RocmTracerOptionsUtilsTest, WrongTypeOnAnUnimplementedKeyStillErrors) {
+  Fixture f;
+  SetString(f.options, "gpu_pm_sample_interval_us", "500");  // documented int64
+  f.Run();
+
+  // Type-checking the unimplemented keys is not decorative: a user should hear
+  // about this now, not in the release that implements the key.
+  ASSERT_THAT(f.diagnostics.errors, SizeIs(1));
+  EXPECT_THAT(f.diagnostics.errors[0], MentionsKey("gpu_pm_sample_interval_us"));
+  EXPECT_THAT(f.diagnostics.warnings, SizeIs(1));
+}
+
+TEST(RocmTracerOptionsUtilsTest, AllDocumentedKeysAreRecognised) {
+  // The ten keys published at openxla.org/xprof/advanced_profiler_options,
+  // with their documented types. A user copying the page verbatim must not see
+  // a single error on ROCm. If the page grows an eleventh key, this test fails
+  // and someone has to look at it -- which is the point.
+  Fixture f;
+  SetInt(f.options, "gpu_max_callback_api_events", 2 * 1024 * 1024);
+  SetInt(f.options, "gpu_max_activity_api_events", 2 * 1024 * 1024);
+  SetInt(f.options, "gpu_max_annotation_strings", 1024 * 1024);
+  SetInt(f.options, "gpu_num_chips_to_profile_per_task", 4);
+  SetBool(f.options, "gpu_enable_nvtx_tracking", true);
+  SetBool(f.options, "gpu_enable_cupti_activity_graph_trace", true);
+  SetBool(f.options, "gpu_dump_graph_node_mapping", true);
+  SetString(f.options, "gpu_pm_sample_counters", "SQ_WAVES,GRBM_GUI_ACTIVE");
+  SetInt(f.options, "gpu_pm_sample_interval_us", 500);
+  SetInt(f.options, "gpu_pm_sample_buffer_size_per_gpu_mb", 64);
+  f.Run();
+
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  // Six unimplemented keys, plus the post-hoc caveat on num_chips.
+  EXPECT_THAT(f.diagnostics.warnings, SizeIs(7));
+  EXPECT_EQ(f.collector.max_callback_api_events, 2 * 1024 * 1024);
+  EXPECT_EQ(f.tracer.max_annotation_strings, 1024 * 1024);
+  EXPECT_EQ(f.collector.num_gpus, 4);
+}
+
+TEST(RocmTracerOptionsUtilsTest, AppendOptionDiagnosticsWritesToXSpace) {
+  RocmTracerOptionDiagnostics diagnostics;
+  diagnostics.errors = {"first error", "second error"};
+  diagnostics.warnings = {"a warning"};
+
+  XSpace space;
+  AppendOptionDiagnostics(diagnostics, &space);
+
+  ASSERT_EQ(space.errors_size(), 2);
+  EXPECT_EQ(space.errors(0), "first error");
+  EXPECT_EQ(space.errors(1), "second error");
+  ASSERT_EQ(space.warnings_size(), 1);
+  EXPECT_EQ(space.warnings(0), "a warning");
+}
+
+TEST(RocmTracerOptionsUtilsTest, AppendOptionDiagnosticsToleratesEmptyAndNull) {
+  XSpace space;
+  AppendOptionDiagnostics(RocmTracerOptionDiagnostics{}, &space);
+  EXPECT_EQ(space.errors_size(), 0);
+  EXPECT_EQ(space.warnings_size(), 0);
+
+  RocmTracerOptionDiagnostics diagnostics;
+  diagnostics.errors = {"dropped on the floor"};
+  AppendOptionDiagnostics(diagnostics, nullptr);  // must not crash
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -132,6 +132,11 @@ ScopeRangeIdTree AnnotationMap::TakeScopeRangeIdTree() {
   return std::move(map_.scope_range_id_tree);
 }
 
+void AnnotationMap::SetMaxSize(uint64_t max_size) {
+  absl::MutexLock lock(map_.mutex);
+  max_size_ = max_size;
+}
+
 void AnnotationMap::Clear() {
   absl::MutexLock lock(map_.mutex);
   map_.correlation_map.clear();

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -154,6 +154,12 @@ struct RocmTracerEvent {
   };
 };
 
+struct RocmTracerOptions {
+  // maximum number of annotation strings that AnnotationMap in RocmTracer can
+  // store. e.g. 1M
+  uint64_t max_annotation_strings;
+};
+
 struct RocmTraceCollectorOptions {
   // Maximum number of events to collect from callback API; if -1, no limit.
   // if 0, the callback API is enabled to build a correlation map, but no

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -183,6 +183,11 @@ class AnnotationMap {
   ScopeRangeIdTree TakeScopeRangeIdTree();
   void Clear();
 
+  // Sets the maximum number of distinct annotation strings retained. Intended
+  // to be called between profiling sessions, while the map is empty; entries
+  // already present are not evicted if the new size is smaller.
+  void SetMaxSize(uint64_t max_size);
+
  private:
   struct AnnotationMapImpl {
     // The population/consumption of annotations might happen from multiple
@@ -197,8 +202,8 @@ class AnnotationMap {
         ABSL_GUARDED_BY(mutex);
     ScopeRangeIdTree scope_range_id_tree ABSL_GUARDED_BY(mutex);
   };
-  const uint64_t max_size_;
   AnnotationMapImpl map_;
+  uint64_t max_size_ ABSL_GUARDED_BY(map_.mutex);
 
  public:
   // Disable copy and move.

--- a/xla/backends/profiler/gpu/rocm_tracer_utils_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils_test.cc
@@ -1,0 +1,114 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+
+#include <cstdint>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace xla {
+namespace profiler {
+namespace {
+
+// The AnnotationMap capacity is what gpu_max_annotation_strings ultimately
+// controls, so it needs a test that does not require a GPU. rocm_tracer_utils
+// has no ROCm dependency, which is what makes this file host-only.
+
+TEST(AnnotationMapTest, HonoursConfiguredSize) {
+  AnnotationMap map(/*max_size=*/2);
+  map.Add(1, "first");
+  map.Add(2, "second");
+  map.Add(3, "third");
+
+  EXPECT_EQ(map.LookUp(1), "first");
+  EXPECT_EQ(map.LookUp(2), "second");
+  // Over capacity: silently not retained. Add() is on the callback hot path
+  // and deliberately does not log per-drop.
+  EXPECT_TRUE(map.LookUp(3).empty());
+}
+
+TEST(AnnotationMapTest, FullStringSetAlsoStopsCorrelatingKnownStrings) {
+  // Characterisation test, not an endorsement. The size check gates the whole
+  // Add(), correlation-map insertion included, so once the distinct-string set
+  // is full, later events are left uncorrelated even when their annotation is
+  // one the map already holds. Repeating an annotation is therefore *not*
+  // free at the boundary.
+  //
+  // CUPTI does the same thing (cupti_buffer_events.cc:759 gates on
+  // annotation_deduper.Size() < max_size_ before the correlation_map.emplace),
+  // so this is shared cross-vendor behaviour rather than a ROCm defect, and
+  // changing it is out of scope here. Pinned so that a future change to either
+  // side is a deliberate one.
+  AnnotationMap map(/*max_size=*/1);
+  for (uint32_t i = 0; i < 100; ++i) {
+    map.Add(i, "same_annotation");
+  }
+  EXPECT_EQ(map.LookUp(0), "same_annotation");
+  EXPECT_TRUE(map.LookUp(99).empty());
+}
+
+TEST(AnnotationMapTest, SetMaxSizeRaisesTheCapForSubsequentAdds) {
+  // The path RocmTracer::Enable takes: Clear(), then SetMaxSize() with the
+  // value derived from the flag or from gpu_max_annotation_strings.
+  AnnotationMap map(/*max_size=*/1);
+  map.Add(1, "first");
+  ASSERT_TRUE(map.LookUp(2).empty()) << "precondition: cap of 1 is in force";
+
+  map.Clear();
+  map.SetMaxSize(3);
+  map.Add(1, "first");
+  map.Add(2, "second");
+  map.Add(3, "third");
+
+  EXPECT_EQ(map.LookUp(1), "first");
+  EXPECT_EQ(map.LookUp(2), "second");
+  EXPECT_EQ(map.LookUp(3), "third");
+}
+
+TEST(AnnotationMapTest, SetMaxSizeLowersTheCapForSubsequentAdds) {
+  AnnotationMap map(/*max_size=*/100);
+  map.SetMaxSize(1);
+  map.Add(1, "first");
+  map.Add(2, "second");
+
+  EXPECT_EQ(map.LookUp(1), "first");
+  EXPECT_TRUE(map.LookUp(2).empty());
+}
+
+TEST(AnnotationMapTest, EmptyAnnotationIsIgnored) {
+  // Empty annotations must not consume capacity; the ROCTX path can produce
+  // them and they would otherwise crowd out real ones.
+  AnnotationMap map(/*max_size=*/1);
+  map.Add(1, "");
+  map.Add(2, "real");
+
+  EXPECT_TRUE(map.LookUp(1).empty());
+  EXPECT_EQ(map.LookUp(2), "real");
+}
+
+TEST(AnnotationMapTest, ClearDropsEntries) {
+  AnnotationMap map(/*max_size=*/8);
+  map.Add(1, "first");
+  ASSERT_EQ(map.LookUp(1), "first");
+
+  map.Clear();
+  EXPECT_TRUE(map.LookUp(1).empty());
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace xla

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -3596,8 +3596,11 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "per-category limits. Individual categories are overridden by the "
       "gpu_max_callback_api_events, gpu_max_activity_api_events and "
       "gpu_max_annotation_strings keys of "
-      "ProfileOptions.advanced_configuration, which take precedence. Set as "
-      "high as memory allows; up to 1e9."));
+      "ProfileOptions.advanced_configuration, which take precedence. Note "
+      "that the activity-event limit is not currently enforced: its guard "
+      "requires an activity event in the HIP_API domain, and the tracer only "
+      "ever emits activity events in HIP_OPS. Set as high as memory allows; "
+      "up to 1e9."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_enable_tiling_propagation",
       bool_setter_for(

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -3592,8 +3592,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "xla_gpu_rocm_max_trace_events",
       int64_setter_for(&DebugOptions::set_xla_gpu_rocm_max_trace_events),
       debug_options->xla_gpu_rocm_max_trace_events(),
-      "Maximum number of ROCm trace events (applies to callback/activity/"
-      "annotation). Set as high as memory allows; up to 1e9."));
+      "Default maximum number of ROCm trace events, used to seed the "
+      "per-category limits. Individual categories are overridden by the "
+      "gpu_max_callback_api_events, gpu_max_activity_api_events and "
+      "gpu_max_annotation_strings keys of "
+      "ProfileOptions.advanced_configuration, which take precedence. Set as "
+      "high as memory allows; up to 1e9."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_enable_tiling_propagation",
       bool_setter_for(


### PR DESCRIPTION
## Summary

The ROCm GPU tracer ignores `ProfileOptions.advanced_configuration` entirely. A JAX
user who passes `gpu_max_activity_api_events`, or who misspells a key, gets the same
hardcoded trace either way and no indication that their request went nowhere. This
change reads the map, applies the keys ROCm can honour, and reports every key it
cannot — into the user's `XSpace`, not just the server log.

It also fixes the reason that reporting is worth doing at all. On the CUPTI path a bad
key aborts `DoStart()`; `ProfilerSession` ignores start errors by default; and the
`kStartedError` branch of `CollectData` logs and returns `OkStatus` without ever
reaching the `add_errors`/`add_warnings` calls, which sit under `kStoppedOk`. The
user's entire GPU plane disappears and nothing in the trace says why. The ROCm path
now records the complaint, produces the trace anyway, and delivers the diagnosis from
every terminal state.

---

## Design: strict detection, lenient disposition

Detection is copied from CUPTI — unknown keys, wrong `oneof` types, and keys naming
features ROCm has not implemented are all identified by name. Disposition is not: none
of them fail the session.

Three properties follow, each of which the CUPTI path currently lacks:

1. **A typo costs a warning, not the trace.** The trace is what the user came for.
2. **Diagnostics reach `XSpace`, from every terminal state.** `AppendOptionDiagnostics`
   is called at the top of `CollectData`, before the state switch, so the failure
   states are covered too.
3. **`raise_error_on_start_failure` still works.** Callers that explicitly asked for
   start failures to be fatal get an `InvalidArgumentError` naming the offending keys.
   Leniency is the default, not a policy.

### Key → sink

| Key | Effect on ROCm |
|---|---|
| `gpu_max_callback_api_events` | `RocmTraceCollectorOptions::max_callback_api_events` — enforced |
| `gpu_max_activity_api_events` | `RocmTraceCollectorOptions::max_activity_api_events` — wired, not yet enforced (see below) |
| `gpu_max_annotation_strings` | Writes **both** `RocmTracerOptions` (sizes the `AnnotationMap`) and `RocmTraceCollectorOptions` |
| `gpu_num_chips_to_profile_per_task` | `num_gpus`, with a warning that ROCm applies it post-hoc |
| `gpu_enable_nvtx_tracking` | Accepted, warned — ROCTX tracing is always on and not yet switchable |
| `gpu_enable_cupti_activity_graph_trace` | Accepted, warned — HIP graph tracing not wired up |
| `gpu_dump_graph_node_mapping` | Accepted, warned — unimplemented on every backend, CUDA included |
| `gpu_pm_sample_counters` / `_interval_us` / `_buffer_size_per_gpu_mb` | Accepted, warned — no PM counter sampling on ROCm |
| `gpu_aggregated_tracing` | Accepted, warned — no aggregated-tracing mode in the ROCm collector |
| anything else | Error naming the key; every other key still applied |

Unimplemented keys are still **type-checked**, so a wrong type is caught now rather
than in the release that implements the key. A user copying the published XProf options
page verbatim sees zero errors on ROCm — that is asserted by
`AllDocumentedKeysAreRecognised`, which fails if the doc grows an eleventh key.

### Layering in `GpuTracer::BuildOptions`

`hardcoded defaults` → `--xla_gpu_rocm_max_trace_events` → `advanced_configuration`.
Existing flag users are unaffected; per-key overrides win where present.
