### PR TITLE
[DO NOT MERGE] CI load test 4/5 - Upstream ROCm CI

### DIFF
--- a/build_tools/rocm/execute_ci_build_upstream.sh
+++ b/build_tools/rocm/execute_ci_build_upstream.sh
@@ -51,3 +51,5 @@ done
     --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_do_gfx950 \
     -- \
     //xla/...
+
+# CI load test 4 - no functional change


### PR DESCRIPTION
Automated CI load test, 4 of 5. Comment-only line added to `build_tools/rocm/execute_ci_build_upstream.sh` solely to satisfy the `paths` filter on `Upstream ROCm CI`. No functional change.

Will be closed and the branch deleted once CI reports.