### PR TITLE
Add libhipcxx include root for upcoming ROCm CCC path change

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -92,6 +92,15 @@ cc_library(
     }),
 )
 
+cc_library(
+    name = "libhipcxx_headers",
+    hdrs = glob(
+        ["%{rocm_root}/include/libhipcxx/**"],
+        allow_empty = True,
+    ),
+    strip_include_prefix = "%{rocm_root}/include/libhipcxx",
+)
+
 # This target is required to
 # add includes that are used by rocm headers themself
 # through the virtual includes
@@ -105,6 +114,7 @@ cc_library(
     defines = {"__HIP_DISABLE_CPP_FUNCTIONS__": "1"},
     strip_include_prefix = "%{rocm_root}/include",
     deps = [
+        ":libhipcxx_headers",
         "@xla//third_party/libdrm:drm_headers",
     ],
 )


### PR DESCRIPTION
An upcoming ROCm version installs the CCC libs (libhipcxx) under
`include/libhipcxx/` instead of `include/`, so `<cuda/std/...>` no longer
resolves off the default search path. hipCUB probes for that header and
silently falls back to the host std when it is missing, which breaks the JAX
wheel build with `fatal error: 'bit' file not found`.

This exposes `include/libhipcxx` as its own include root and adds it to
`rocm_headers_includes`, so hipCUB keeps resolving libhipcxx.

Verified against ROCm/TheRock#7024 on gfx942: the JAX plugin/pjrt wheels fail
to build without this and build clean with it, and sort / argsort / cumsum /
top_k pass while still lowering to the hipCUB custom calls.