### PR TITLE
[ROCm] Pick the rocBLAS complex GEMM fallback at runtime

### DIFF
--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -313,10 +313,11 @@ auto BlasLt::RegularMatmulPlan::GetAlgorithms(size_t max_algorithm_count,
 
 absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
     const gpu::GemmConfig& cfg, Epilogue epilogue) const {
-  // hipBLASLt has no complex GEMM kernels; redirect C64/C128 to rocBLAS while
-  // still consuming the cublasLt matmul custom call emitted by GemmRewriter.
-  // TODO(magaonka-amd): Once we get a hipBLASLt that supports complex GEMMs,
-  // clean up this routing code.
+  // This hipBLASLt has no complex GEMM kernels (it has them in ROCm 7.14 and in
+  // 10 and newer); redirect C64/C128 to rocBLAS while still consuming the
+  // cublasLt matmul custom call emitted by GemmRewriter. Elsewhere the redirect
+  // is compiled out and complex matmuls use the regular plan below.
+#if !(TF_ROCM_VERSION == 71400 || TF_ROCM_VERSION >= 100000)
   if (cfg.output_layout.dtype == xla::C64 ||
       cfg.output_layout.dtype == xla::C128) {
     TF_RET_CHECK(epilogue == Epilogue::kDefault)
@@ -325,6 +326,7 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
         << static_cast<int>(epilogue);
     return std::make_unique<RocBlasGemmPlan>(*this, cfg);
   }
+#endif  // no hipBLASLt complex GEMM
 
   auto lhs_layout = cfg.lhs_layout, rhs_layout = cfg.rhs_layout,
        output_layout = cfg.output_layout, c_layout = cfg.c_layout;
@@ -566,6 +568,7 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
   return plan;
 }
 
+#if !(TF_ROCM_VERSION == 71400 || TF_ROCM_VERSION >= 100000)
 absl::Status BlasLt::RocBlasGemmPlan::ExecuteOnStream(
     Stream* stream, const gpu::BlasLt::MemoryArgs& args,
     blas::ProfileResult* profile_result) const {
@@ -637,6 +640,7 @@ absl::Status BlasLt::RocBlasGemmPlan::ExecuteOnStream(
   xla::complex128 beta(cfg_.beta, 0.0);
   return run(alpha, beta);
 }
+#endif  // no hipBLASLt complex GEMM
 
 absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
     Stream* stream, const gpu::BlasLt::MemoryArgs& args,

--- a/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/xla/stream_executor/rocm/hip_blas_lt.h
@@ -193,8 +193,10 @@ class BlasLt : public gpu::BlasLt {
     int8_t bias_type_ = 0;
   };  // class GroupedMatmulPlan
 
-  // Executes complex (C64/C128) matmuls via rocBLAS (rocblas_cgemm/zgemm),
-  // since hipBLASLt has no complex GEMM kernels in current ROCm releases.
+#if !(TF_ROCM_VERSION == 71400 || TF_ROCM_VERSION >= 100000)
+  // Executes complex (C64/C128) matmuls via rocBLAS (rocblas_cgemm/zgemm) on
+  // the ROCm releases whose hipBLASLt has no complex GEMM kernels; hipBLASLt
+  // has them in 7.14 and in 10 and newer, so only the rest compile this.
   class RocBlasGemmPlan : public gpu::BlasLt::MatmulPlan {
    public:
     friend class BlasLt;
@@ -224,6 +226,7 @@ class BlasLt : public gpu::BlasLt {
     const BlasLt& blas_lt_;
     gpu::GemmConfig cfg_;
   };  // class RocBlasGemmPlan
+#endif  // no hipBLASLt complex GEMM
 
   explicit BlasLt(StreamExecutor* executor)
       : executor_(executor), handle_(nullptr, hipblasLtDestroy) {}


### PR DESCRIPTION
## 📝 Summary of Changes

Replace the compile-time `TF_ROCM_VERSION` gate on the C64/C128 rocBLAS
redirect from openxla/xla#44047 with a runtime capability check. Complex
matmuls take the hipBLASLt plan when the descriptor builds and the heuristic
offers an algorithm, and fall back to rocBLAS (`rocblas_cgemm`/`zgemm`)
otherwise.

## 🎯 Justification

hipBLASLt gained complex GEMM kernels in ROCm 10, but a build-time macro
describes the ROCm that XLA was compiled against, not the hipBLASLt loaded at
runtime, so a wheel built against one ROCm and run on another lands on the
wrong path in both directions. A runtime ROCm version comparison would not fix
this either: ROCm 10.0.0 reports HIP 7.15 through `hipRuntimeGetVersion()`, so
a `>= 10` test never fires. Asking hipBLASLt directly avoids the version
mapping entirely and also covers architectures where the Tensile kernels are
absent.

Both halves of the check are load-bearing: older hipBLASLt rejects the complex
matmul descriptor outright, while a newer one can accept the descriptor and
still offer no algorithm for a given GPU.

## 🚀 Kind of Contribution

♻️ Cleanup · 🐛 Bug Fix

## Downstream context

Mirrors openxla/xla#48110; same branch drives both pull requests.
