### PR TITLE
[ROCm] Make sure CreateOwningCudaCubinInMemorySpec interns its cubin buffer

### DIFF
--- a/xla/backends/gpu/codegen/kernels/ptx_custom_kernel.cc
+++ b/xla/backends/gpu/codegen/kernels/ptx_custom_kernel.cc
@@ -84,12 +84,24 @@ absl::StatusOr<CustomKernel> GetOwnedPtxCustomKernel(
 }
 
 absl::StatusOr<CustomKernel> CreateOwnedCubinCustomKernel(
-    std::string kernel_name, std::vector<uint8_t> cubin, int num_args,
+    std::string kernel_name, std::vector<uint8_t>&& cubin, int num_args,
     se::BlockDim block_dim, se::ThreadDim thread_dim,
     size_t shared_memory_bytes) {
   se::KernelLoaderSpec kernel_spec =
       se::KernelLoaderSpec::CreateOwningCudaCubinInMemorySpec(
           std::move(cubin), kernel_name, /*arity=*/num_args,
+          IdentityPackingSpec(num_args));
+  return CustomKernel(std::move(kernel_name), std::move(kernel_spec), block_dim,
+                      thread_dim, shared_memory_bytes);
+}
+
+absl::StatusOr<CustomKernel> CreateOwnedCubinCustomKernel(
+    std::string kernel_name, const std::vector<uint8_t>& cubin, int num_args,
+    se::BlockDim block_dim, se::ThreadDim thread_dim,
+    size_t shared_memory_bytes) {
+  se::KernelLoaderSpec kernel_spec =
+      se::KernelLoaderSpec::CreateOwningCudaCubinInMemorySpec(
+          cubin, kernel_name, /*arity=*/num_args,
           IdentityPackingSpec(num_args));
   return CustomKernel(std::move(kernel_name), std::move(kernel_spec), block_dim,
                       thread_dim, shared_memory_bytes);

--- a/xla/backends/gpu/codegen/kernels/ptx_custom_kernel.h
+++ b/xla/backends/gpu/codegen/kernels/ptx_custom_kernel.h
@@ -17,7 +17,9 @@ limitations under the License.
 #define XLA_BACKENDS_GPU_CODEGEN_KERNELS_PTX_CUSTOM_KERNEL_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
+#include <vector>
 
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
@@ -44,7 +46,12 @@ absl::StatusOr<CustomKernel> GetOwnedPtxCustomKernel(
     size_t shared_memory_bytes = 0);
 
 absl::StatusOr<CustomKernel> CreateOwnedCubinCustomKernel(
-    std::string kernel_name, std::vector<uint8_t> cubin, int num_args,
+    std::string kernel_name, std::vector<uint8_t>&& cubin, int num_args,
+    se::BlockDim block_dim, se::ThreadDim thread_dim,
+    size_t shared_memory_bytes);
+
+absl::StatusOr<CustomKernel> CreateOwnedCubinCustomKernel(
+    std::string kernel_name, const std::vector<uint8_t>& cubin, int num_args,
     se::BlockDim block_dim, se::ThreadDim thread_dim,
     size_t shared_memory_bytes);
 

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -773,12 +773,17 @@ cc_library(
         ":kernel_spec_proto_cc",
         "//xla/tsl/platform:status_macros",
         "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/base:no_destructor",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
+        "@tsl//tsl/platform:fingerprint",
     ],
 )
 

--- a/xla/stream_executor/kernel_spec.cc
+++ b/xla/stream_executor/kernel_spec.cc
@@ -17,23 +17,82 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
 #include <variant>
 #include <vector>
 
+#include "absl/base/attributes.h"
+#include "absl/base/const_init.h"
+#include "absl/base/no_destructor.h"
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/stream_executor/kernel_args_packing_spec.h"
 #include "xla/stream_executor/kernel_spec.pb.h"
 #include "xla/tsl/platform/statusor.h"
+#include "tsl/platform/fingerprint.h"
 
 namespace stream_executor {
+namespace {
+
+tsl::Fprint128 ComputeCubinFingerprint(absl::Span<const uint8_t> bytes) {
+  return tsl::Fingerprint128(absl::string_view(
+      reinterpret_cast<const char*>(bytes.data()), bytes.size()));
+}
+
+struct CubinCacheEntry {
+  CubinCacheEntry(const tsl::Fprint128& fingerprint,
+                  std::vector<uint8_t> binary)
+      : fingerprint(fingerprint), binary(std::move(binary)) {}
+  ~CubinCacheEntry();
+
+  const tsl::Fprint128 fingerprint;
+  const std::vector<uint8_t> binary;
+};
+
+ABSL_CONST_INIT absl::Mutex cubin_cache_mu(absl::kConstInit);
+absl::NoDestructor<absl::flat_hash_map<
+    tsl::Fprint128, std::weak_ptr<CubinCacheEntry>, tsl::Fprint128Hasher>>
+    cubin_cache ABSL_GUARDED_BY(cubin_cache_mu);
+
+CubinCacheEntry::~CubinCacheEntry() {
+  absl::MutexLock lock(cubin_cache_mu);
+  auto it = cubin_cache->find(fingerprint);
+  // A concurrent InternCubinBytes may have already replaced the
+  // slot with a fresh live entry for the same fingerprint.
+  if (it != cubin_cache->end() && it->second.expired()) {
+    cubin_cache->erase(it);
+  }
+}
+
+template <typename Bytes>
+std::shared_ptr<const std::vector<uint8_t>> InternCubinBytes(
+    Bytes&& cubin_bytes) {
+  const size_t cubin_bytes_size = cubin_bytes.size();
+  const tsl::Fprint128 fingerprint = ComputeCubinFingerprint(cubin_bytes);
+
+  absl::MutexLock lock(cubin_cache_mu);
+  std::weak_ptr<CubinCacheEntry>& slot = (*cubin_cache)[fingerprint];
+  std::shared_ptr<CubinCacheEntry> entry = slot.lock();
+  if (entry == nullptr) {
+    entry = std::make_shared<CubinCacheEntry>(fingerprint,
+                                              std::forward<Bytes>(cubin_bytes));
+    slot = entry;
+  }
+  CHECK_EQ(cubin_bytes_size, entry->binary.size());
+  return std::shared_ptr<const std::vector<uint8_t>>(entry, &entry->binary);
+}
+
+}  // namespace
 
 KernelLoaderSpec KernelLoaderSpec::CreateInProcessSymbolSpec(
     void* symbol, std::string kernel_name, size_t arity,
@@ -58,10 +117,19 @@ KernelLoaderSpec KernelLoaderSpec::CreateCudaCubinInMemorySpec(
 }
 
 KernelLoaderSpec KernelLoaderSpec::CreateOwningCudaCubinInMemorySpec(
-    std::vector<uint8_t> cubin_bytes, std::string kernel_name, size_t arity,
+    std::vector<uint8_t>&& cubin_bytes, std::string kernel_name, size_t arity,
     KernelArgsPacking kernel_args_packing) {
-  return KernelLoaderSpec{OwningCudaCubinInMemory{std::move(cubin_bytes)},
-                          std::move(kernel_name), arity, kernel_args_packing};
+  return KernelLoaderSpec{
+      OwningCudaCubinInMemory{InternCubinBytes(std::move(cubin_bytes))},
+      std::move(kernel_name), arity, kernel_args_packing};
+}
+
+KernelLoaderSpec KernelLoaderSpec::CreateOwningCudaCubinInMemorySpec(
+    const std::vector<uint8_t>& cubin_bytes, std::string kernel_name,
+    size_t arity, KernelArgsPacking kernel_args_packing) {
+  return KernelLoaderSpec{
+      OwningCudaCubinInMemory{InternCubinBytes(cubin_bytes)},
+      std::move(kernel_name), arity, kernel_args_packing};
 }
 
 KernelLoaderSpec KernelLoaderSpec::CreateCudaPtxInMemorySpec(

--- a/xla/stream_executor/kernel_spec.h
+++ b/xla/stream_executor/kernel_spec.h
@@ -83,8 +83,12 @@ struct CudaCubinInMemory {
 };
 
 // Like CudaCubinInMemory but the CUBIN data is owned by the loader spec.
+//
+// The bytes are held behind a shared_ptr so that identical CUBIN blobs are
+// deduplicated: specs created via CreateOwningCudaCubinInMemorySpec with byte
+// identical payloads share a single backing allocation (see kernel_spec.cc).
 struct OwningCudaCubinInMemory {
-  std::vector<uint8_t> cubin_bytes;
+  std::shared_ptr<const std::vector<uint8_t>> cubin_bytes;
 };
 
 // Describes how to load a kernel on any subset of a number of target platforms.
@@ -134,8 +138,9 @@ class KernelLoaderSpec {
       return std::get<CudaCubinInMemory>(payload_);
     }
     if (std::holds_alternative<OwningCudaCubinInMemory>(payload_)) {
-      return CudaCubinInMemory{
-          std::get<OwningCudaCubinInMemory>(payload_).cubin_bytes};
+      const OwningCudaCubinInMemory& owning =
+          std::get<OwningCudaCubinInMemory>(payload_);
+      return CudaCubinInMemory{absl::MakeConstSpan(*owning.cubin_bytes)};
     }
     return std::nullopt;
   }
@@ -166,7 +171,11 @@ class KernelLoaderSpec {
       size_t arity,
       KernelArgsPacking kernel_args_packing = KernelArgsPackingFunc{});
   static KernelLoaderSpec CreateOwningCudaCubinInMemorySpec(
-      std::vector<uint8_t> cubin_bytes, std::string kernel_name, size_t arity,
+      std::vector<uint8_t>&& cubin_bytes, std::string kernel_name, size_t arity,
+      KernelArgsPacking kernel_args_packing = KernelArgsPackingFunc{});
+  static KernelLoaderSpec CreateOwningCudaCubinInMemorySpec(
+      const std::vector<uint8_t>& cubin_bytes, std::string kernel_name,
+      size_t arity,
       KernelArgsPacking kernel_args_packing = KernelArgsPackingFunc{});
   static KernelLoaderSpec CreateCudaPtxInMemorySpec(
       absl::string_view ptx, std::string kernel_name, size_t arity,

--- a/xla/stream_executor/kernel_spec_test.cc
+++ b/xla/stream_executor/kernel_spec_test.cc
@@ -92,6 +92,28 @@ TEST(KernelLoaderSpec, OwningCudaCubin) {
   EXPECT_THAT(spec.kernel_name(), "kernel24");
 }
 
+TEST(KernelLoaderSpec, OwningCudaCubinInternsData) {
+  const std::vector<uint8_t> data = {0x11, 0x22, 0x33, 0x44, 0x55,
+                                     0x66, 0x77, 0x88, 0x99, 0xAA};
+
+  auto spec1 = KernelLoaderSpec::CreateOwningCudaCubinInMemorySpec(
+      data, "kernel_a", /*arity=*/1);
+  auto spec2 = KernelLoaderSpec::CreateOwningCudaCubinInMemorySpec(
+      std::vector(data), "kernel_b", /*arity=*/2);
+
+  ASSERT_THAT(spec1.cuda_cubin_in_memory(),
+              Optional(Field(&CudaCubinInMemory::cubin_bytes, data)));
+  ASSERT_THAT(spec2.cuda_cubin_in_memory(),
+              Optional(Field(&CudaCubinInMemory::cubin_bytes, data)));
+
+  const uint8_t* cubin_data1 = spec1.cuda_cubin_in_memory()->cubin_bytes.data();
+  const uint8_t* cubin_data2 = spec2.cuda_cubin_in_memory()->cubin_bytes.data();
+
+  // Two specs created from identical bytes share a single interned buffer.
+  EXPECT_EQ(cubin_data1, cubin_data2);
+  EXPECT_NE(cubin_data1, data.data());
+}
+
 TEST(KernelLoaderSpec, CudaPtx) {
   static constexpr absl::string_view kPtxData = "PTX DEADBEEF";
   auto spec = KernelLoaderSpec::CreateCudaPtxInMemorySpec(kPtxData, "kernel24",


### PR DESCRIPTION
This leads to reduced memory usage on cpu side and less cubins loaded on gpu since stream executor uses cubin buffer address as module identity. Beneficial for ROCm, where implementation deficiencies impose a limit on the number of binaries that can be loaded.