### PR TITLE
[WIP][XLA:GPU] Let callers supply memory for the redzone checker's mismatch counter

### DIFF
--- a/xla/backends/gpu/autotuner/BUILD
+++ b/xla/backends/gpu/autotuner/BUILD
@@ -417,6 +417,7 @@ cc_library(
         "//xla/service/gpu/autotuning:redzone_buffers",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:device_address_allocator",
+        "//xla/stream_executor:memory_allocation",
         "//xla/stream_executor:stream_executor_address_allocator",
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor/gpu:redzone_allocator",

--- a/xla/backends/gpu/autotuner/gpu_profiler.cc
+++ b/xla/backends/gpu/autotuner/gpu_profiler.cc
@@ -59,6 +59,7 @@ limitations under the License.
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/device_address_allocator.h"
 #include "xla/stream_executor/gpu/redzone_allocator.h"
+#include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/stream_executor/stream_executor_address_allocator.h"
 #include "xla/util/buffer_slice_merge.h"
@@ -291,6 +292,18 @@ absl::StatusOr<ProfileResult> GpuProfiler::Profile(
       gpu_executable != nullptr) {
     result.scratch_bytes = GetScratchBytes(*gpu_executable);
   }
+  // Scratch for the redzone check below, allocated here rather than left to
+  // CheckRedzones(). HostMemoryAllocate() is a driver call, and one landing
+  // between the warm-up run and the timed run perturbs the timed run unevenly
+  // across candidates, which skews the autotuner's comparison.
+  std::unique_ptr<se::MemoryAllocation> mismatch_counter_allocation;
+  std::optional<se::DeviceAddressBase> mismatch_counter;
+  if (options_.redzone_padding_bytes > 0) {
+    ASSIGN_OR_RETURN(mismatch_counter_allocation,
+                     stream_executor_->HostMemoryAllocate(sizeof(uint64_t)));
+    mismatch_counter = mismatch_counter_allocation->address();
+  }
+
   {
     // Warm-up run: route every buffer the executable allocates on-demand
     // (result/output buffers and workspace/scratch buffers alike) through a
@@ -311,7 +324,7 @@ absl::StatusOr<ProfileResult> GpuProfiler::Profile(
     RETURN_IF_ERROR(stream_->BlockHostUntilDone());
     if (warmup_rz.has_value()) {
       ASSIGN_OR_RETURN(se::RedzoneAllocator::RedzoneCheckStatus rz_check,
-                       warmup_rz->CheckRedzones());
+                       warmup_rz->CheckRedzones(mismatch_counter));
       if (!rz_check.ok()) {
         std::string redzone_failure_msg = rz_check.RedzoneFailureMsg();
         VLOG(1) << "Autotuning candidate discarded: out-of-bounds write "

--- a/xla/stream_executor/gpu/redzone_allocator.cc
+++ b/xla/stream_executor/gpu/redzone_allocator.cc
@@ -267,16 +267,21 @@ absl::StatusOr<DeviceAddressBase> RedzoneAllocator::CreateBuffer(
   return buffer;
 }
 
-absl::StatusOr<RedzoneCheckStatus> RedzoneAllocator::CheckRedzones() const {
+absl::StatusOr<RedzoneCheckStatus> RedzoneAllocator::CheckRedzones(
+    std::optional<DeviceAddressBase> mismatch_counter) const {
   StreamExecutor* executor = stream_->parent();
 
   ASSIGN_OR_RETURN(auto kernel,
                    gpu::GpuKernelRegistry::GetGlobalRegistry()
                        .LoadKernel<gpu::RedzoneAllocatorKernel>(executor));
 
-  ASSIGN_OR_RETURN(std::unique_ptr<MemoryAllocation> allocation,
-                   executor->HostMemoryAllocate(sizeof(uint64_t)));
-  DeviceAddressBase out_param_addr = allocation->address();
+  std::unique_ptr<MemoryAllocation> owned_counter;
+  if (!mismatch_counter.has_value()) {
+    ASSIGN_OR_RETURN(owned_counter,
+                     executor->HostMemoryAllocate(sizeof(uint64_t)));
+    mismatch_counter = owned_counter->address();
+  }
+  DeviceAddressBase out_param_addr = *mismatch_counter;
   RETURN_IF_ERROR(stream_->MemZero(&out_param_addr, sizeof(uint64_t)));
 
   for (const auto& buf_and_size : allocated_buffers_) {

--- a/xla/stream_executor/gpu/redzone_allocator.h
+++ b/xla/stream_executor/gpu/redzone_allocator.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -99,13 +100,19 @@ class RedzoneAllocator : public ScratchAllocator {
   // Reinitializes redzones to the expected value, so that the same buffer
   // can be reused for multiple checks.
   //
+  // If `mismatch_counter` is given, the checker kernels accumulate into it
+  // rather than into a buffer allocated here, so that the caller controls when
+  // that allocation happens. Must be at least sizeof(uint64_t),
+  // device-writable, and not shared by concurrent checks.
+  //
   // Returns:
   //
   //  - RedzoneCheckStatus::OK() if everything went well.
   //  - RedzoneCheckStatus with a non-empty error message iff a write into a
   //    redzone has been detected.
   //  - A stream error, if loading or launching the kernel has failed.
-  absl::StatusOr<RedzoneCheckStatus> CheckRedzones() const;
+  absl::StatusOr<RedzoneCheckStatus> CheckRedzones(
+      std::optional<DeviceAddressBase> mismatch_counter = std::nullopt) const;
 
   Stream* stream() const { return stream_; }
 
@@ -169,8 +176,9 @@ class RedzoneDeviceAddressAllocator : public DeviceAddressAllocator {
 
   bool AllowsAsynchronousDeallocation() const override { return true; }
 
-  absl::StatusOr<RedzoneAllocator::RedzoneCheckStatus> CheckRedzones() {
-    return rz_alloc_.CheckRedzones();
+  absl::StatusOr<RedzoneAllocator::RedzoneCheckStatus> CheckRedzones(
+      std::optional<DeviceAddressBase> mismatch_counter = std::nullopt) {
+    return rz_alloc_.CheckRedzones(mismatch_counter);
   }
 
  private:


### PR DESCRIPTION
## Motivation

To get review

## Technical Details

Add an optional parameter to RedzoneAllocator::CheckRedzones() so a caller can supply the memory for its 8-byte mismatch counter, and have GpuProfiler::Profile() allocate it before the warm-up run. It was previously allocated between an autotuning candidate's warm-up and timed run, where the HostMemoryAllocate() driver call perturbs the run being measured unevenly across candidates.

## Test Result

Measured on [lit/training](https://github.com/ROCm/xla/blob/rocm-dev-infra/perf_tools/hlo_eval_tools/multimodal/lit/training/module_3940.jit_train_step.before_optimizations.txt), MI350X

 |                         | before                | after                 | pre-regression        |
 |-------------------------|-----------------------|-----------------------|-----------------------|
 | live autotune           | 18.95 | 17.89 | 17.74 |
 | two-phase replay | 18.65                 | 17.69        | 17.63          |


On the HLOs (1 gpu ones) from [hlo_eval_tools](https://github.com/ROCm/xla/blob/rocm-dev-infra/perf_tools/hlo_eval_tools), results that bigger than noise are following:

  | model / leaf | module | before (ms) | after (ms) | Δ% |
  |---|---|---|---|---|
  | flan_t5_large training | module_0211 | 50.37 | 46.58 | -7.52% |
  | multimodal_lit training | module_3940 | 18.91 | 17.60 | -6.93%| 
  | vision_diffusion_clip training | module_3940 | 34.35 | 32.31 | -5.94%| 
  | multimodal_siglip training | module_3940 | 33.65 | 32.36 | -3.83% | 
  | vision_diffusion_mlp_mixer training | module_1707 | 26.83 | 25.87 | -3.58% | 

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
