### PR TITLE
[ROCm CI] Backport #950 + #1069 test targets to rocm-jaxlib-v0.11.0

### DIFF
--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -23,6 +23,39 @@ TAG_FILTERS=$($SCRIPT_DIR/rocm_tag_filters.sh)
 
 mkdir -p /tf/pkg
 
+EXCLUDED_TESTS=(
+    "F8E4M3FNTests/DotAlgorithmSupportTest.AlgorithmIsSupportedFromCudaCapability/dot_any_f8_any_f8_f32_fast_accum_with_lhs_f8e4m3fn_rhs_f8e4m3fn_output_f8e5m2_from_cc_8_9_rocm_63_no_restriction_c_32_nc_32"
+    "F8E4M3FNTests/DotAlgorithmSupportTest.AlgorithmIsSupportedFromCudaCapability/dot_any_f8_any_f8_f32_fast_accum_with_lhs_f8e4m3fn_rhs_f8e4m3fn_output_f8e5m2_from_cc_8_9_rocm_63_no_restriction_c_16_nc_2"
+    "F8E4M3FNTests/DotAlgorithmSupportTest.AlgorithmIsSupportedFromCudaCapability/dot_any_f8_any_f8_f32_fast_accum_with_lhs_f8e4m3fn_rhs_f8e4m3fn_output_f32_from_cc_8_9_rocm_63_no_restriction_c_32_nc_32"
+    "F8E4M3FNTests/DotAlgorithmSupportTest.AlgorithmIsSupportedFromCudaCapability/dot_any_f8_any_f8_f32_fast_accum_with_lhs_f8e4m3fn_rhs_f8e4m3fn_output_f32_from_cc_8_9_rocm_63_no_restriction_c_16_nc_2"
+    "F8E4M3FNTests/DotAlgorithmSupportTest.AlgorithmIsSupportedFromCudaCapability/dot_any_f8_any_f8_f32_with_lhs_f8e4m3fn_rhs_f8e4m3fn_output_f32_from_cc_8_9_rocm_63_no_restriction_c_16_nc_2"
+    "F8E4M3FNTests/DotAlgorithmSupportTest.AlgorithmIsSupportedFromCudaCapability/dot_any_f8_any_f8_f32_with_lhs_f8e4m3fn_rhs_f8e4m3fn_output_f32_from_cc_8_9_rocm_63_no_restriction_c_32_nc_32"
+    # Aligned with upstream openxla/xla ROCm CI EXCLUDED_TESTS: known
+    # ROCm-unsupported / hipBLASLt-gap cases (e.g. f64 cublasLt + activation).
+    "HostMemoryAllocateTest.Numa"
+    "*IotaR1Test*"
+    "NumericTestsForBlas/NumericTestsForBlas.Infinity/dot_tf32_tf32_f32_x3"
+    "TritonAndBlasSupportForDifferentTensorSizes/TritonAndBlasSupportForDifferentTensorSizes.IsDotAlgorithmSupportedByTriton/dot_bf16_bf16_f32_x*"
+    "F8E5M2Tests/DotAlgorithmSupportTest.AlgorithmIsSupportedFromCudaCapability/dot_any_f8_any_f8_f32_*"
+    "DotOperationTestWithCublasLt_F16F32F64CF64/1.GeneralMatMulActivation"
+    "MatmulTestWithCublas.GemmRewriter_RegressionTestF64"
+    "TritonEmitterTest.ScaledDotIsSupportedByReferencePlatform"
+    "TritonBackendTestSuite/TritonBackendTest.CostModelOptions_*"
+    "StreamExecutorGpuClientTest.GetAbiVersion"
+    "CublasFissionBackendTest.CublasFallbackForBf16Bf16F32Algorithm"
+    "BlasAlgorithmTest.Algorithm_BF16_BF16_F32_X6"
+    "BlasAlgorithmTest.Algorithm_BF16_BF16_F32_X3"
+    "BlasAlgorithmTest.Algorithm_BF16_BF16_F32"
+    "FloatSupportTestWithCublas.MixedTypeDotIsNotUpcasted"
+    "GemmRewriteTest.CheckCustomCallHipblasLtBF16"
+    "ParameterizedGemmRewriteTest.GemmTypeCombinationCheck"
+    "SampleFileTest.Convolution"
+    "GroupedConvolution2DTestWithRandomIndices*"
+    "LocalClientExecuteTest.CompilePartitionedExecutable"
+    "RaggedAllToAllThunkMultiGpuTest.ExecuteOnStream"
+    "AllReduceLayoutAwareTest*"
+)
+
 for arg in "$@"; do
     if [[ "$arg" == "--config=ci_multi_gpu" ]]; then
         TAG_FILTERS="${TAG_FILTERS},multi_gpu"
@@ -35,7 +68,6 @@ for arg in "$@"; do
     fi
 done
 
-SCRIPT_DIR=$(dirname $0)
 bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \
     --build_tag_filters=$TAG_FILTERS \
     --test_tag_filters=$TAG_FILTERS \
@@ -48,4 +80,10 @@ bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \
     --action_env=XLA_FLAGS="--xla_gpu_force_compilation_parallelism=16" \
     --test_output=errors \
     --run_under=//build_tools/rocm:parallel_gpu_execute \
-    "$@"
+    --test_filter=-$(
+        IFS=:
+        echo "${EXCLUDED_TESTS[*]}"
+    ) \
+    --color=yes \
+    "$@" \
+    //xla/...


### PR DESCRIPTION
run_xla_ci_build.sh on this branch ends in a bare "$@". rocm_xla_ci.yml (resolved from rocm-dev-infra) passes flags only and no Bazel target pattern, so every CI ROCm run on this branch selects zero targets:

    INFO: Found 0 test targets...
    ERROR: No test targets were found, yet testing was requested

and exits 4 in ~2s for all three steps.

#946 removed --config=xla_sgpu/xla_mgpu from the workflow; #950 moved the target pattern and the ROCm exclusion list into the release branch's own copy of the script. v0.10.1 and v0.10.2 (#1069) carry it; v0.11.0 was branched without it. This restores parity.

The EXCLUDED_TESTS list is taken verbatim from rocm-jaxlib-v0.10.2. v0.11.0's existing flags are left untouched to keep the diff minimal.

Verified locally (bazel --nobuild, no targets passed by the caller):
  --config=ci_single_gpu   0 -> 412 test targets
  --config=ci_multi_gpu    0 ->  21 test targets
  --config=ci_rocm_cpu     0 ->  74 test targets

