### PR TITLE
[rocm-jaxlib-v0.9.0] Clean up release branch 0.9.0

### DIFF
--- a/.github/workflows/check_contents.yml
+++ b/.github/workflows/check_contents.yml
@@ -22,13 +22,7 @@ name: Check Contents
 permissions:
   contents: read
 on:
-  pull_request:
-    branches-ignore:
-      - rocm-dev-infra
-      - rocm-jaxlib-v*
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 env:
   # A bit tricky here: this lets us invoke python files outside of `bazel run`

--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -65,7 +65,11 @@ build:ci_multi_gpu --experimental_guard_against_concurrent_changes
 build:ci_multi_gpu --test_env=HIP_VISIBLE_DEVICES=0,1,2,3
 build:ci_multi_gpu --strategy=TestRunner=local
 
-build:xla_sgpu -- \
+build:ci_rocm_cpu --run_under=//build_tools/rocm:sanitizer_wrapper
+build:ci_rocm_cpu --local_test_jobs=200
+build:ci_rocm_cpu --strategy=TestRunner=local
+
+test:xla_sgpu -- \
 //xla/... \
 -//xla/backends/gpu/collectives:gpu_clique_key_test \
 -//xla/backends/gpu/collectives:nccl_communicator_test \

--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -1,7 +1,7 @@
 # Test-related settings.
 
 build:rocm_dev --remote_upload_local_results=false
-build:rocm_dev --remote_cache="https://wardite.cluster.engflow.com"
+build:rocm_dev --remote_cache="grpcs://wardite.cluster.engflow.com"
 
 build:rocm_rbe --bes_backend="grpcs://wardite.cluster.engflow.com"
 build:rocm_rbe --bes_results_url="https://wardite.cluster.engflow.com/invocation/"
@@ -18,6 +18,10 @@ build:rocm_rbe --jobs=200
 build:rocm_rbe --remote_timeout=3600
 build:rocm_rbe --remote_download_minimal
 build:rocm_rbe --remote_upload_local_results
+build:rocm_rbe --grpc_keepalive_time=30s
+build:rocm_rbe --remote_cache_compression
+
+test:rocm_rbe --strategy=TestRunner=remote,local
 
 # Dynamic execution config for ROCm RBE - builds locally, tests use hybrid mode
 build:rocm_rbe_dynamic --config=rocm_rbe

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -45,7 +45,10 @@ for arg in "$@"; do
         TAG_FILTERS="" # in mgpu we have a standard set of tests
     fi
     if [[ "$arg" == "--config=ci_single_gpu" ]]; then
-        TAG_FILTERS="${TAG_FILTERS},gpu,-multi_gpu,-no_oss"
+         TAG_FILTERS="${TAG_FILTERS},requires-gpu-rocm,requires-gpu-amd,-multi_gpu"
+    fi
+    if [[ "$arg" == "--config=ci_rocm_cpu" ]]; then
+        TAG_FILTERS="${TAG_FILTERS},gpu,-requires-gpu-rocm,-requires-gpu-amd"
     fi
     if [[ "$arg" == "--config=rocm_ci_hermetic" ]]; then
         TEST_FILTER+=(

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -42,7 +42,7 @@ for arg in "$@"; do
         TAG_FILTERS="${TAG_FILTERS},-notsan"
     fi
     if [[ "$arg" == "--config=ci_multi_gpu" ]]; then
-        TAG_FILTERS="" # in mgpu we have a standard set of tests
+        TAG_FILTERS="${TAG_FILTERS},multi_gpu"
     fi
     if [[ "$arg" == "--config=ci_single_gpu" ]]; then
          TAG_FILTERS="${TAG_FILTERS},requires-gpu-rocm,requires-gpu-amd,-multi_gpu"

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -72,5 +72,7 @@ bazel --bazelrc="$SCRIPT_DIR/rocm_xla.bazelrc" test \
         IFS=:
         echo "${TEST_FILTER[*]}"
     ) \
-    --spawn_strategy=local \
+    --color=yes \
     "$@" \
+    -- \
+    //xla/... \

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -33,6 +33,11 @@ trap clean_up EXIT
 TEST_FILTER=(
     TritonGemmTest.SplitAndTransposeLhsExecutesCorrectly
     AutoShardingTest.MatMulWithAutosharding
+    RcclCommunicator.AbortSucceeds
+    # mGPU tests
+    DynamicSliceFusionTest.MultipleOffsetsAsFunctionOfInductionVariable
+    DynamicSliceFusionTest.OffsetAsFunctionOfInductionVariableShouldUseOffsetModulesWithCmdBuffer
+    CollectiveOpsCommandBufferTest.SendRecv_Simple
 )
 
 for arg in "$@"; do

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -32,6 +32,7 @@ trap clean_up EXIT
 
 TEST_FILTER=(
     TritonGemmTest.SplitAndTransposeLhsExecutesCorrectly
+    AutoShardingTest.MatMulWithAutosharding
 )
 
 for arg in "$@"; do


### PR DESCRIPTION
## Motivation

Backporting changes from https://github.com/ROCm/xla/pull/950 and https://github.com/ROCm/xla/pull/1069. 
Excluding failing tests.

v0.8.2 https://github.com/ROCm/xla/pull/1097
v0.9.0 https://github.com/ROCm/xla/pull/1096 (this PR)
v0.9.2 https://github.com/ROCm/xla/pull/1098
v0.11.0 https://github.com/ROCm/xla/pull/1099


