### PR TITLE
[rocm-jaxlib-v0.8.2] Clean up release branch 0.8.2

### DIFF
--- a/.github/workflows/check_contents.yml
+++ b/.github/workflows/check_contents.yml
@@ -22,13 +22,7 @@ name: Check Contents
 permissions:
   contents: read
 on:
-  pull_request:
-    branches-ignore:
-      - rocm-dev-infra
-      - rocm-jaxlib-v*
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 env:
   # A bit tricky here: this lets us invoke python files outside of `bazel run`

--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -59,6 +59,10 @@ build:ci_multi_gpu --test_env=HIP_VISIBLE_DEVICES=0,1,2,3
 build:ci_multi_gpu --strategy=TestRunner=local
 build:ci_multi_gpu --local_test_jobs=1
 
+build:ci_rocm_cpu --run_under=//build_tools/rocm:sanitizer_wrapper
+build:ci_rocm_cpu --local_test_jobs=200
+build:ci_rocm_cpu --strategy=TestRunner=local
+
 test:xla_sgpu -- \
 //xla/... \
 -//xla/backends/gpu/collectives:gpu_clique_key_test \

--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -12,7 +12,7 @@ build:rocm_rbe --platforms="@local_config_rocm//rocm:linux_x64"
 build:rocm_rbe --bes_timeout=600s
 build:rocm_rbe --tls_client_certificate="/tf/certificates/ci-cert.crt"
 build:rocm_rbe --tls_client_key="/tf/certificates/ci-cert.key"
-build:rocm_rbe --spawn_strategy=remote,local
+build:rocm_rbe --spawn_strategy=local
 build:rocm_rbe --grpc_keepalive_time=30s
 
 test:rocm_rbe --jobs=200

--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -1,8 +1,9 @@
 # Test-related settings.
 
 build:rocm_dev --remote_upload_local_results=false
-build:rocm_dev --remote_cache="https://wardite.cluster.engflow.com"
+build:rocm_dev --remote_cache="grpcs://wardite.cluster.engflow.com"
 
+build:rocm_rbe --remote_cache="grpcs://wardite.cluster.engflow.com"
 build:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1
 build:rocm_rbe --bes_backend="grpcs://wardite.cluster.engflow.com"
 build:rocm_rbe --bes_results_url="https://wardite.cluster.engflow.com/invocation/"
@@ -14,6 +15,7 @@ build:rocm_rbe --tls_client_certificate="/tf/certificates/ci-cert.crt"
 build:rocm_rbe --tls_client_key="/tf/certificates/ci-cert.key"
 build:rocm_rbe --spawn_strategy=local
 build:rocm_rbe --grpc_keepalive_time=30s
+build:rocm_rbe --remote_cache_compression
 
 test:rocm_rbe --jobs=200
 test:rocm_rbe --remote_executor=grpcs://wardite.cluster.engflow.com

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -42,7 +42,10 @@ for arg in "$@"; do
         TAG_FILTERS="${TAG_FILTERS},multi_gpu"
     fi
     if [[ "$arg" == "--config=ci_single_gpu" ]]; then
-        TAG_FILTERS="${TAG_FILTERS},gpu,-multi_gpu"
+         TAG_FILTERS="${TAG_FILTERS},requires-gpu-rocm,requires-gpu-amd,-multi_gpu"
+    fi
+    if [[ "$arg" == "--config=ci_rocm_cpu" ]]; then
+        TAG_FILTERS="${TAG_FILTERS},gpu,-requires-gpu-rocm,-requires-gpu-amd"
     fi
     if [[ "$arg" == "--config=rocm_ci_hermetic" ]]; then
         TEST_FILTER+=(

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -29,6 +29,10 @@ TEST_FILTER=(
     TritonGemmTest.SplitAndTransposeLhsExecutesCorrectly
     CommandBufferConversionPassTest.ConvertWhileThunk
     CommandBufferConversionPassTest.ConvertWhileThunkWithAsyncPair
+    AutoShardingTest.MatMulWithAutosharding
+    # mGPU tests
+    DynamicSliceFusionTest.MultipleOffsetsAsFunctionOfInductionVariable
+    DynamicSliceFusionTest.OffsetAsFunctionOfInductionVariableShouldUseOffsetModulesWithCmdBuffer
 )
 
 for arg in "$@"; do

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -59,7 +59,6 @@ for arg in "$@"; do
     fi
 done
 
-SCRIPT_DIR=$(dirname $0)
 bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \
     --build_tag_filters=$TAG_FILTERS \
     --test_tag_filters=$TAG_FILTERS \
@@ -74,4 +73,7 @@ bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \
         IFS=:
         echo "${TEST_FILTER[*]}"
     ) \
-    "$@"
+    --color=yes \
+    "$@" \
+    -- \
+    //xla/... \


### PR DESCRIPTION
## Motivation

Backporting changes from https://github.com/ROCm/xla/pull/950 and https://github.com/ROCm/xla/pull/1069.
Excluding failing tests.


v0.8.2 https://github.com/ROCm/xla/pull/1097 (this PR)
v0.9.0 https://github.com/ROCm/xla/pull/1096 
v0.9.2 https://github.com/ROCm/xla/pull/1098
v0.11.0 https://github.com/ROCm/xla/pull/1099
