### PR TITLE
[ROCm] Cache loaded modules by binary content

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -192,6 +192,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/hash",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/numeric:int128",

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -31,6 +31,7 @@ limitations under the License.
 
 #include "absl/base/casts.h"
 #include "absl/container/inlined_vector.h"
+#include "absl/hash/hash.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/numeric/int128.h"
@@ -489,6 +490,16 @@ void CollectiveMemoryDeallocate(Context* context, void* location) {
 
 }  // namespace
 
+namespace internal {
+
+ModuleHandle ModuleHandleFromImage(absl::Span<const uint8_t> image) {
+  size_t hash = absl::HashOf(absl::string_view(
+      reinterpret_cast<const char*>(image.data()), image.size()));
+  return ModuleHandle{reinterpret_cast<const void*>(hash | 1)};
+}
+
+}  // namespace internal
+
 RocmExecutor::~RocmExecutor() {
   for (auto& it : in_memory_modules_) {
     UnloadRocmModule(&rocm_context_, it.second);
@@ -661,10 +672,11 @@ absl::StatusOr<std::unique_ptr<Kernel>> RocmExecutor::LoadKernel(
   const std::string& kernel_name = spec.kernel_name();
 
   if (spec.has_cuda_cubin_in_memory()) {
-    const char* hsaco = reinterpret_cast<const char*>(
-        spec.cuda_cubin_in_memory()->cubin_bytes.data());
+    const auto image = spec.cuda_cubin_in_memory()->cubin_bytes;
+    const char* hsaco = reinterpret_cast<const char*>(image.data());
     absl::MutexLock lock{in_memory_modules_mu_};
-    ABSL_ASSIGN_OR_RETURN(ModuleHandle module_handle, LoadModuleFromHsaco(hsaco));
+    ABSL_ASSIGN_OR_RETURN(ModuleHandle module_handle,
+                          LoadModuleFromHsaco(hsaco, image.size()));
     hipModule_t module = gpu_binary_to_module_.at(module_handle).first;
     kernel_to_gpu_binary_[rocm_kernel.get()] = module_handle;
 
@@ -724,21 +736,21 @@ absl::StatusOr<std::unique_ptr<Kernel>> RocmExecutor::LoadKernel(
 
 absl::StatusOr<ModuleHandle> RocmExecutor::LoadModule(
     const MultiModuleLoaderSpec& spec) {
-  // We store the pointer to the HSACO binary as ModuleHandle::id().
-
   // TODO(ROCm): Need  generic term instead of cubin/cuda/ptx
   if (spec.has_cuda_cubin_in_memory()) {
     absl::MutexLock lock{in_memory_modules_mu_};
-    return LoadModuleFromHsaco(
-        reinterpret_cast<const char*>(spec.cuda_cubin_in_memory().data()));
+    const auto image = spec.cuda_cubin_in_memory();
+    return LoadModuleFromHsaco(reinterpret_cast<const char*>(image.data()),
+                               image.size());
   } else {
     return absl::InternalError("No HASCO binary found");
   }
 }
 
 absl::StatusOr<ModuleHandle> RocmExecutor::LoadModuleFromHsaco(
-    const char* hsaco) {
-  ModuleHandle module_handle{hsaco};
+    const char* hsaco, size_t size) {
+  ModuleHandle module_handle = internal::ModuleHandleFromImage(
+      absl::MakeConstSpan(reinterpret_cast<const uint8_t*>(hsaco), size));
   uint64_t module_refcount;
   hipModule_t module;
   std::tie(module, module_refcount) = gpu_binary_to_module_[module_handle];

--- a/xla/stream_executor/rocm/rocm_executor.h
+++ b/xla/stream_executor/rocm/rocm_executor.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_EXECUTOR_H_
 #define XLA_STREAM_EXECUTOR_ROCM_ROCM_EXECUTOR_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -56,6 +57,13 @@ limitations under the License.
 #include "xla/stream_executor/stream_executor.h"
 
 namespace stream_executor::gpu {
+
+namespace internal {
+
+// Returns the same module identity for byte-identical images.
+ModuleHandle ModuleHandleFromImage(absl::Span<const uint8_t> image);
+
+}  // namespace internal
 
 // This class implements GpuExecutor for AMD GPUs that use ROCm libraries.
 class RocmExecutor : public GpuExecutor {
@@ -140,7 +148,8 @@ class RocmExecutor : public GpuExecutor {
   absl::Status InitBlas();
 
   // Loads a module in HSACO format.
-  absl::StatusOr<ModuleHandle> LoadModuleFromHsaco(const char* hsaco)
+  absl::StatusOr<ModuleHandle> LoadModuleFromHsaco(const char* hsaco,
+                                                   size_t size)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
 
   bool UnloadGpuBinary(ModuleHandle module_handle)

--- a/xla/stream_executor/rocm/rocm_executor_test.cc
+++ b/xla/stream_executor/rocm/rocm_executor_test.cc
@@ -15,7 +15,9 @@ limitations under the License.
 
 #include "xla/stream_executor/rocm/rocm_executor.h"
 
+#include <cstdint>
 #include <memory>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -38,6 +40,17 @@ namespace stream_executor::gpu {
 namespace {
 using testing::IsEmpty;
 using testing::Not;
+
+TEST(RocmExecutorTest, ModuleHandleUsesContent) {
+  std::vector<uint8_t> first = {1, 2, 3, 4};
+  std::vector<uint8_t> same = first;
+  std::vector<uint8_t> different = {4, 3, 2, 1};
+
+  EXPECT_EQ(internal::ModuleHandleFromImage(first),
+            internal::ModuleHandleFromImage(same));
+  EXPECT_NE(internal::ModuleHandleFromImage(first),
+            internal::ModuleHandleFromImage(different));
+}
 
 TEST(RocmExecutorTest, CreateDeviceDescription) {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<DeviceDescription> result,


### PR DESCRIPTION
Serialized kernels can own identical binaries at different addresses, causing redundant module loads. Derive module identity from content while preserving existing reference counting and unload behavior.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
