### PR TITLE
[WIP][ROCm] Add a delay kernel for event-based timers

### DIFF
--- a/xla/stream_executor/gpu/gpu_semaphore.cc
+++ b/xla/stream_executor/gpu/gpu_semaphore.cc
@@ -15,13 +15,13 @@ limitations under the License.
 
 #include "xla/stream_executor/gpu/gpu_semaphore.h"
 
+#include <memory>
 #include <utility>
 
 #include "absl/status/status_macros.h"
 #include "absl/status/statusor.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/stream_executor.h"
-#include "tsl/platform/statusor.h"
 
 namespace stream_executor {
 absl::StatusOr<GpuSemaphore> GpuSemaphore::Create(StreamExecutor* executor) {
@@ -30,6 +30,11 @@ absl::StatusOr<GpuSemaphore> GpuSemaphore::Create(StreamExecutor* executor) {
   ABSL_ASSIGN_OR_RETURN(auto alloc,
                    executor->HostMemoryAllocate(sizeof(GpuSemaphoreState)));
   return GpuSemaphore{std::move(alloc)};
+}
+
+GpuSemaphore GpuSemaphore::Create(
+    std::unique_ptr<MemoryAllocation> allocation) {
+  return GpuSemaphore{std::move(allocation)};
 }
 
 DeviceAddress<GpuSemaphoreState> GpuSemaphore::device() {

--- a/xla/stream_executor/gpu/gpu_semaphore.h
+++ b/xla/stream_executor/gpu/gpu_semaphore.h
@@ -38,6 +38,12 @@ class GpuSemaphore {
   // `executor`.
   static absl::StatusOr<GpuSemaphore> Create(StreamExecutor* executor);
 
+  // Creates a semaphore backed by a caller-provided allocation. `allocation`
+  // must be host memory that the device can both read and write while a kernel
+  // is running; platforms whose default pinned allocation does not guarantee
+  // that use this to supply one that does.
+  static GpuSemaphore Create(std::unique_ptr<MemoryAllocation> allocation);
+
   // Returns true if this semaphore is valid, otherwise false.
   explicit operator bool() const { return bool{ptr_}; }
 

--- a/xla/stream_executor/gpu/gpu_semaphore.h
+++ b/xla/stream_executor/gpu/gpu_semaphore.h
@@ -39,9 +39,10 @@ class GpuSemaphore {
   static absl::StatusOr<GpuSemaphore> Create(StreamExecutor* executor);
 
   // Creates a semaphore backed by a caller-provided allocation. `allocation`
-  // must be host memory that the device can both read and write while a kernel
-  // is running; platforms whose default pinned allocation does not guarantee
-  // that use this to supply one that does.
+  // must be host memory that is directly accessible by the device at the same
+  // virtual address, and that the device can both read and write while a
+  // kernel is running; platforms whose default pinned allocation does not
+  // guarantee that use this to supply one that does.
   static GpuSemaphore Create(std::unique_ptr<MemoryAllocation> allocation);
 
   // Returns true if this semaphore is valid, otherwise false.

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -968,6 +968,34 @@ xla_test(
     ],
 )
 
+rocm_library(
+    name = "delay_kernel_rocm",
+    srcs = ["delay_kernel_rocm.cu.cc"],
+    hdrs = ["delay_kernel.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    visibility = internal_visibility([
+        "//xla/stream_executor:__subpackages__",
+    ]),
+    deps = [
+        ":rocm_status",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:generic_memory_allocation",
+        "//xla/stream_executor:launch_dim",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor:typed_kernel_factory",
+        "//xla/stream_executor/gpu:gpu_semaphore",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status:status_macros",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
 cc_library(
     name = "rocm_timer",
     srcs = ["rocm_timer.cc"],
@@ -977,12 +1005,14 @@ cc_library(
         "rocm-only",
     ],
     deps = [
+        ":delay_kernel_rocm",
         ":rocm_event",
         ":rocm_status",
         "//xla/stream_executor:activate_context",
         "//xla/stream_executor:event_based_timer",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/gpu:gpu_semaphore",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/log",

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -996,6 +996,30 @@ rocm_library(
     ],
 )
 
+xla_test(
+    name = "delay_kernel_test",
+    srcs = ["delay_kernel_test.cc"],
+    backends = ["gpu"],
+    tags = ["rocm-only"],
+    deps = [
+        ":delay_kernel_rocm",
+        ":rocm_event",
+        ":rocm_executor",
+        ":rocm_platform_id",
+        "//xla/stream_executor:event",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/gpu:gpu_semaphore",
+        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:test",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "rocm_timer",
     srcs = ["rocm_timer.cc"],

--- a/xla/stream_executor/rocm/delay_kernel.h
+++ b/xla/stream_executor/rocm/delay_kernel.h
@@ -1,0 +1,31 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_DELAY_KERNEL_H_
+#define XLA_STREAM_EXECUTOR_ROCM_DELAY_KERNEL_H_
+
+#include "absl/status/statusor.h"
+#include "xla/stream_executor/gpu/gpu_semaphore.h"
+#include "xla/stream_executor/stream.h"
+
+namespace stream_executor::gpu {
+
+// Launches the delay kernel on the given stream. The caller is responsible for
+// keeping the returned semaphore alive until the kernel finished executing.
+// Setting the semaphore to `kRelease` makes the kernel quit.
+absl::StatusOr<GpuSemaphore> LaunchDelayKernel(Stream* stream);
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_DELAY_KERNEL_H_

--- a/xla/stream_executor/rocm/delay_kernel_rocm.cu.cc
+++ b/xla/stream_executor/rocm/delay_kernel_rocm.cu.cc
@@ -1,0 +1,151 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+
+#include "absl/log/log.h"
+#include "absl/status/status_macros.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/generic_memory_allocation.h"
+#include "xla/stream_executor/gpu/gpu_semaphore.h"
+#include "xla/stream_executor/launch_dim.h"
+#include "xla/stream_executor/rocm/delay_kernel.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/typed_kernel_factory.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+// Allocates the semaphore in host memory the device can read and write while a
+// kernel is running.
+//
+// `hipHostMalloc(hipHostMallocPortable)`, which StreamExecutor's generic host
+// allocation uses, is coarse-grained, so the device may hold the value in an L2
+// that host writes do not invalidate. CDNA3/CDNA4 and RDNA4 lower `volatile` to
+// a system-scope access and are unaffected. On CDNA1, CDNA2 and RDNA1-3 it is
+// only an L1 bypass and the load is answered from the stale L2 line, and no
+// cache bit makes a load skip L2 there. SLC does not, despite the name "System
+// Level Coherent". It selects an L2 replacement policy, so a load carrying it
+// can still hit a stale line (RDNA2 ISA table 38). Only CDNA2 can repair this
+// from the kernel side, by invalidating L2 with BUFFER_INVL2, which CDNA1 and
+// RDNA1-3 do not have.
+//
+// Requesting coherent, i.e. fine-grained, memory sidesteps all of that. It is
+// not sufficient by itself, since a load carrying no cache bits at all still
+// fails even with it, so the `volatile` below is doing the other half.
+absl::StatusOr<GpuSemaphore> CreateCoherentSemaphore() {
+  void* ptr = nullptr;
+  ABSL_RETURN_IF_ERROR(
+      ToStatus(hipHostMalloc(&ptr, sizeof(GpuSemaphoreState),
+                             hipHostMallocPortable | hipHostMallocCoherent),
+               "Failed to allocate coherent host memory for the delay kernel "
+               "semaphore"));
+  return GpuSemaphore::Create(std::make_unique<GenericMemoryAllocation>(
+      ptr, sizeof(GpuSemaphoreState), [](void* location, uint64_t size) {
+        hipError_t result = hipHostFree(location);
+        if (result != hipSuccess) {
+          LOG(ERROR) << "Failed to free delay kernel semaphore: "
+                     << ToString(result);
+        }
+      }));
+}
+
+// Wait for the value pointed to by `semaphore` to have value `target`, timing
+// out after approximately `timeout_ticks` wall clock ticks if that value is
+// not reached. That happens when something stalls the host between launching
+// this kernel and releasing it, e.g. the first launch of a not-yet-loaded
+// kernel synchronising while its code object is loaded.
+//
+// Times with `wall_clock64()` rather than `clock64()`: only the former runs at
+// a constant rate, reported by `hipDeviceAttributeWallClockRate`, which is what
+// lets the host pass tick counts that mean the same duration on every device.
+// `clock64()` reads a counter whose rate differs per part, and on some targets
+// does not track the shader clock at all.
+__global__ void DelayKernel(volatile GpuSemaphoreState* semaphore,
+                            GpuSemaphoreState target, int64_t timeout_ticks,
+                            int64_t poll_interval_ticks) {
+  const int64_t tstart{wall_clock64()};
+  bool target_not_reached{true};
+  while ((target_not_reached = (*semaphore != target)) &&
+         (wall_clock64() - tstart) < timeout_ticks) {
+    int64_t elapsed{};
+    const int64_t t0{wall_clock64()};
+    do {
+      elapsed = wall_clock64() - t0;
+    } while (elapsed < poll_interval_ticks);
+  }
+  if (target_not_reached) {
+    // We are exiting due to the timeout. Signal this back to the host so that
+    // we can emit a warning, as it probably indicates suboptimal usage.
+    *semaphore = GpuSemaphoreState::kTimedOut;
+  }
+}
+
+// Used only when hipDeviceAttributeWallClockRate cannot be queried.
+constexpr int64_t kFallbackWallClockHz = 100'000'000;
+
+// Returns the frequency of the device's constant rate wall clock in Hz.
+int64_t WallClockHz(int device_ordinal) {
+  int rate_khz = 0;
+  hipError_t result = hipDeviceGetAttribute(
+      &rate_khz, hipDeviceAttributeWallClockRate, device_ordinal);
+  if (result != hipSuccess || rate_khz <= 0) {
+    LOG_FIRST_N(WARNING, 1)
+        << "Could not query the wall clock rate of device " << device_ordinal
+        << "; assuming " << kFallbackWallClockHz / 1'000'000
+        << "MHz. The delay kernel timeout may be wrong.";
+    return kFallbackWallClockHz;
+  }
+  return int64_t{rate_khz} * 1000;
+}
+}  // namespace
+
+absl::StatusOr<GpuSemaphore> LaunchDelayKernel(Stream* stream) {
+  StreamExecutor* executor = stream->parent();
+
+  // Allocate a semaphore value that will be used to signal to the delay
+  // kernel that it may exit. See CreateCoherentSemaphore for why this does not
+  // go through StreamExecutor::HostMemoryAllocate.
+  ABSL_ASSIGN_OR_RETURN(auto semaphore, CreateCoherentSemaphore());
+  *semaphore = GpuSemaphoreState::kHold;
+  ABSL_ASSIGN_OR_RETURN(
+      auto kernel,
+      (TypedKernelFactory<DeviceAddress<GpuSemaphoreState>, GpuSemaphoreState,
+                          int64_t, int64_t>::Create(executor, "DelayKernel",
+                                                    reinterpret_cast<void*>(
+                                                        DelayKernel))));
+  // This runs before the timer's start event is recorded, so the attribute
+  // query is off the timed path.
+  const int64_t wall_clock_hz = WallClockHz(executor->device_ordinal());
+  // Launch a delay kernel into this stream, which will spin until
+  // GetElapsedDuration() is called, the timer is destroyed, or the timeout
+  // in the kernel is reached.
+  ABSL_RETURN_IF_ERROR(
+      kernel.Launch(ThreadDim(1, 1, 1), BlockDim(1, 1, 1), stream,
+                    semaphore.device(), GpuSemaphoreState::kRelease,
+                    /*timeout_ticks=*/wall_clock_hz / 10,  // 100ms
+                    /*poll_interval_ticks=*/
+                    std::max<int64_t>(wall_clock_hz / 1'000'000, 1)));  // 1us
+
+  return semaphore;
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/delay_kernel_test.cc
+++ b/xla/stream_executor/rocm/delay_kernel_test.cc
@@ -1,0 +1,110 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/delay_kernel.h"
+
+#include <memory>
+#include <optional>
+
+#include <gtest/gtest.h>
+#include "absl/status/status_matchers.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "xla/stream_executor/event.h"
+#include "xla/stream_executor/gpu/gpu_semaphore.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/rocm/rocm_event.h"
+#include "xla/stream_executor/rocm/rocm_platform_id.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/test.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+// The kernel gives up on the host after 100ms; see LaunchDelayKernel.
+constexpr absl::Duration kKernelTimeout = absl::Milliseconds(100);
+
+class DelayKernelTest : public ::testing::Test {
+ public:
+  // Launches the delay kernel and immediately releases it again, so that the
+  // launch under test does not pay for loading the code object. That load
+  // synchronises, which can stall the host for longer than the kernel is
+  // willing to wait.
+  void WarmUp() {
+    TF_ASSERT_OK_AND_ASSIGN(GpuSemaphore semaphore,
+                            LaunchDelayKernel(stream_.get()));
+    *semaphore = GpuSemaphoreState::kRelease;
+    ASSERT_THAT(stream_->BlockHostUntilDone(), absl_testing::IsOk());
+  }
+
+  StreamExecutor* executor_;
+  std::unique_ptr<Stream> stream_;
+
+ private:
+  void SetUp() override {
+    TF_ASSERT_OK_AND_ASSIGN(
+        Platform * platform,
+        PlatformManager::PlatformWithId(rocm::kROCmPlatformId));
+    TF_ASSERT_OK_AND_ASSIGN(executor_, platform->ExecutorForDevice(0));
+    TF_ASSERT_OK_AND_ASSIGN(stream_, executor_->CreateStream(std::nullopt));
+  }
+};
+
+// The kernel must hold the stream until the host releases it, and it must stop
+// because of that release rather than because it timed out waiting for it.
+// Only then do the timer's start event and the timed work land back to back,
+// and it only happens if the device observes host writes to the semaphore at
+// all, which depends on the memory it lives in. See CreateCoherentSemaphore.
+TEST_F(DelayKernelTest, HostReleaseStopsTheKernelBeforeItTimesOut) {
+  WarmUp();
+
+  TF_ASSERT_OK_AND_ASSIGN(GpuSemaphore semaphore,
+                          LaunchDelayKernel(stream_.get()));
+  TF_ASSERT_OK_AND_ASSIGN(RocmEvent event,
+                          RocmEvent::Create(executor_, /*allow_timing=*/false));
+  ASSERT_THAT(stream_->RecordEvent(&event), absl_testing::IsOk());
+
+  // The kernel is still spinning, so nothing recorded behind it can have
+  // completed, and it has not given up yet either.
+  EXPECT_EQ(event.PollForStatus(), Event::Status::kPending);
+  ASSERT_EQ(*semaphore, GpuSemaphoreState::kHold);
+
+  *semaphore = GpuSemaphoreState::kRelease;
+  ASSERT_THAT(stream_->BlockHostUntilDone(), absl_testing::IsOk());
+
+  // A kernel that stopped for any other reason than the release above would
+  // have overwritten the semaphore with kTimedOut.
+  EXPECT_EQ(*semaphore, GpuSemaphoreState::kRelease);
+  EXPECT_EQ(event.PollForStatus(), Event::Status::kComplete);
+}
+
+// The other half of the contract. A host that never releases the kernel still
+// gets the stream back, and can tell that the measurement was compromised.
+TEST_F(DelayKernelTest, TimesOutWhenTheHostNeverReleasesIt) {
+  WarmUp();
+
+  TF_ASSERT_OK_AND_ASSIGN(GpuSemaphore semaphore,
+                          LaunchDelayKernel(stream_.get()));
+  absl::SleepFor(2 * kKernelTimeout);
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), absl_testing::IsOk());
+  EXPECT_EQ(*semaphore, GpuSemaphoreState::kTimedOut);
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -122,6 +123,22 @@ hipDeviceptr_t AsROCmDevicePtr(DeviceAddressBase* gpu_mem) {
 absl::uint128 Fingerprint128(const absl::string_view s) {
   auto fp = tsl::Fingerprint128(s);
   return absl::MakeUint128(fp.high64, fp.low64);
+}
+
+bool ShouldLaunchDelayKernel() {
+  // The delay kernel blocks the stream until the host releases it, so it
+  // deadlocks if the HIP runtime is configured to serialize launches.
+  static bool value = [] {
+    auto is_enabled = [](const char* name) {
+      const char* value = std::getenv(name);
+      return value != nullptr && !absl::string_view{value}.empty() &&
+             absl::string_view{value} != "0";
+    };
+    return !is_enabled("HIP_LAUNCH_BLOCKING") &&
+           !is_enabled("AMD_SERIALIZE_KERNEL") &&
+           !is_enabled("AMD_SERIALIZE_COPY");
+  }();
+  return value;
 }
 
 // Loads HSACO with the ROCM runtime and stores the resulting handle in
@@ -584,7 +601,13 @@ RocmExecutor::CreateOrShareConstant(Stream* stream,
 
 absl::StatusOr<std::unique_ptr<EventBasedTimer>>
 RocmExecutor::CreateEventBasedTimer(Stream* stream, bool use_delay_kernel) {
-  ABSL_ASSIGN_OR_RETURN(auto timer, RocmTimer::Create(this, stream));
+  const RocmTimer::TimerType timer_type =
+      (use_delay_kernel && ShouldLaunchDelayKernel())
+          ? RocmTimer::TimerType::kDelayKernel
+          : RocmTimer::TimerType::kEventBased;
+
+  ABSL_ASSIGN_OR_RETURN(auto timer,
+                        RocmTimer::Create(this, stream, timer_type));
   return std::make_unique<RocmTimer>(std::move(timer));
 }
 

--- a/xla/stream_executor/rocm/rocm_timer.cc
+++ b/xla/stream_executor/rocm/rocm_timer.cc
@@ -25,6 +25,8 @@ limitations under the License.
 #include "absl/time/time.h"
 #include "rocm/include/hip/hip_runtime.h"
 #include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/gpu/gpu_semaphore.h"
+#include "xla/stream_executor/rocm/delay_kernel.h"
 #include "xla/stream_executor/rocm/rocm_event.h"
 #include "xla/stream_executor/rocm/rocm_status.h"
 #include "xla/stream_executor/stream.h"
@@ -54,17 +56,43 @@ absl::StatusOr<float> GetEventElapsedTime(StreamExecutor* executor,
 }  // namespace
 
 RocmTimer::RocmTimer(StreamExecutor* executor, RocmEvent start_event,
-                     RocmEvent stop_event, Stream* stream)
-    : executor_(executor),
+                     RocmEvent stop_event, Stream* stream,
+                     GpuSemaphore semaphore)
+    : semaphore_(std::move(semaphore)),
+      executor_(executor),
       stream_(stream),
       start_event_(std::move(start_event)),
       stop_event_(std::move(stop_event)) {}
+
+RocmTimer::~RocmTimer() {
+  if (semaphore_ && !is_stopped_) {
+    // Signal the delay kernel that it can exit
+    *semaphore_ = GpuSemaphoreState::kRelease;
+    // Wait for the delay kernel to exit before destroying the value that it is
+    // watching.
+    absl::Status result = stream_->BlockHostUntilDone();
+    if (!result.ok()) {
+      LOG(ERROR) << result.message();
+    }
+  }
+}
 
 absl::StatusOr<absl::Duration> RocmTimer::GetElapsedDuration() {
   if (is_stopped_) {
     return absl::FailedPreconditionError("Measuring inactive timer");
   }
   ABSL_RETURN_IF_ERROR(stream_->RecordEvent(&stop_event_));
+  // If we launched the delay kernel then check if it already timed out.
+  if (semaphore_) {
+    if (*semaphore_ == GpuSemaphoreState::kTimedOut) {
+      // The delay kernel did not achieve the intended result.
+      LOG_FIRST_N(WARNING, 5)
+          << "Delay kernel timed out: measured time has sub-optimal accuracy.";
+    } else {
+      // Signal that the kernel can exit
+      *semaphore_ = GpuSemaphoreState::kRelease;
+    }
+  }
   ABSL_ASSIGN_OR_RETURN(float elapsed_milliseconds,
                    GetEventElapsedTime(executor_, start_event_.GetHandle(),
                                        stop_event_.GetHandle()));
@@ -73,13 +101,20 @@ absl::StatusOr<absl::Duration> RocmTimer::GetElapsedDuration() {
 }
 
 absl::StatusOr<RocmTimer> RocmTimer::Create(StreamExecutor* executor,
-                                            Stream* stream) {
+                                            Stream* stream,
+                                            TimerType timer_type) {
+  GpuSemaphore semaphore{};
+
+  if (timer_type == TimerType::kDelayKernel) {
+    ABSL_ASSIGN_OR_RETURN(semaphore, LaunchDelayKernel(stream));
+  }
+
   ABSL_ASSIGN_OR_RETURN(RocmEvent start_event,
                    RocmEvent::Create(executor, /*allow_timing=*/true));
   ABSL_ASSIGN_OR_RETURN(RocmEvent stop_event,
                    RocmEvent::Create(executor, /*allow_timing=*/true));
   ABSL_RETURN_IF_ERROR(stream->RecordEvent(&start_event));
   return RocmTimer(executor, std::move(start_event), std::move(stop_event),
-                   stream);
+                   stream, std::move(semaphore));
 }
 }  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_timer.h
+++ b/xla/stream_executor/rocm/rocm_timer.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 #include "xla/stream_executor/event_based_timer.h"
+#include "xla/stream_executor/gpu/gpu_semaphore.h"
 #include "xla/stream_executor/rocm/rocm_event.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
@@ -27,18 +28,24 @@ namespace stream_executor::gpu {
 
 class RocmTimer : public EventBasedTimer {
  public:
+  ~RocmTimer() override;
   RocmTimer(RocmTimer&&) = default;
   RocmTimer& operator=(RocmTimer&&) = default;
 
   absl::StatusOr<absl::Duration> GetElapsedDuration() override;
 
+  enum class TimerType {
+    kDelayKernel,
+    kEventBased,
+  };
   static absl::StatusOr<RocmTimer> Create(StreamExecutor* executor,
-                                          Stream* stream);
+                                          Stream* stream, TimerType timer_type);
 
  private:
   RocmTimer(StreamExecutor* executor, RocmEvent start_event,
-            RocmEvent stop_event, Stream* stream);
+            RocmEvent stop_event, Stream* stream, GpuSemaphore semaphore);
 
+  GpuSemaphore semaphore_;
   bool is_stopped_ = false;
   StreamExecutor* executor_;
   Stream* stream_;

--- a/xla/stream_executor/rocm/rocm_timer_test.cc
+++ b/xla/stream_executor/rocm/rocm_timer_test.cc
@@ -40,7 +40,7 @@ namespace stream_executor::gpu {
 namespace {
 using ::testing::Gt;
 
-class RocmTimerTest : public ::testing::Test {
+class RocmTimerTest : public ::testing::TestWithParam<RocmTimer::TimerType> {
  public:
   void LaunchSomeKernel(StreamExecutor* executor, Stream* stream) {
     TF_ASSERT_OK_AND_ASSIGN(auto add, LoadAddI32TestKernel(executor));
@@ -74,9 +74,9 @@ class RocmTimerTest : public ::testing::Test {
   }
 };
 
-TEST_F(RocmTimerTest, Create) {
-  TF_ASSERT_OK_AND_ASSIGN(RocmTimer timer,
-                          RocmTimer::Create(executor_, stream_.get()));
+TEST_P(RocmTimerTest, Create) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      RocmTimer timer, RocmTimer::Create(executor_, stream_.get(), GetParam()));
 
   // We don't really care what kernel we launch here as long as it takes a
   // non-zero amount of time.
@@ -88,6 +88,10 @@ TEST_F(RocmTimerTest, Create) {
   EXPECT_THAT(timer.GetElapsedDuration(),
               absl_testing::StatusIs(absl::StatusCode::kFailedPrecondition));
 }
+
+INSTANTIATE_TEST_SUITE_P(RocmTimerTest, RocmTimerTest,
+                         ::testing::Values(RocmTimer::TimerType::kEventBased,
+                                           RocmTimer::TimerType::kDelayKernel));
 
 }  // namespace
 }  // namespace stream_executor::gpu


### PR DESCRIPTION
## Motivation

To get review

## Technical Details

RocmTimer can now precede a measurement with a spin kernel that holds the stream until the host releases it, so the start event and the timed work execute back to back and launch overhead stays out of the interval. Not used when the HIP runtime is configured to serialize launches, which would deadlock the spin.

The semaphore is allocated with hipHostMallocCoherent rather than through StreamExecutor::HostMemoryAllocate: the default pinned allocation is coarse-grained, and on CDNA1/CDNA2 and RDNA1-3 the device then never observes the host's release. A new GpuSemaphore::Create(MemoryAllocation) overload keeps that scoped to the semaphore.


## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
