### PR TITLE
[ROCm] Use a square minimum output tile for Triton dots

### DIFF
--- a/xla/backends/gpu/autotuner/triton/dot_search_space.cc
+++ b/xla/backends/gpu/autotuner/triton/dot_search_space.cc
@@ -298,6 +298,30 @@ TritonDotFusionSearchSpace::GetMinOutputTile() const {
   // size is different).
   constexpr OutputTile kMinSupportedTile = {16, 8};
   constexpr OutputTile kMinWgmmaTile = {64, 8};
+  if (device_description_.gpu_compute_capability().IsRocm()) {
+    // The tiles above are more suitable for NVIDIA instruction shapes
+    // (mma.m16n8k*, wgmma.m64n8*). For AMD MFMA is 32x32, 16x16, 4x64 or 64x4,
+    // and Triton only considers a tile MFMA-eligible when
+    // min(block_m, block_n) >= 16 (see chooseMfmaInstruction() in
+    // third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp).
+    //
+    // A 16x8 floor straddles that threshold. Since the floor also overrides the
+    // max (see the constructor), block_m is always raised to 16 while block_n
+    // can stay at 8, so eligibility depends on N alone -- and a dot and its
+    // transpose swap which dimension is N. Making the floor square removes
+    // that. Capping it at the problem size keeps a small dot from being
+    // inflated onto a matrix core it cannot fill; the lower bound is there
+    // because Triton cannot legalize a dot with a 1-wide tile.
+    constexpr int64_t kMinTileDim = 2;
+    OutputTile tile = {16, 16};
+    tile.lhs_dim = std::clamp<int64_t>(NextPowerOfTwo(lhs_parallel_size_),
+                                       kMinTileDim, tile.lhs_dim);
+    tile.rhs_dim = std::clamp<int64_t>(NextPowerOfTwo(rhs_parallel_size_),
+                                       kMinTileDim, tile.rhs_dim);
+    VLOG(5) << "Computing output_tile: targeting AMD MFMA, so output_tile >= "
+            << tile.lhs_dim << "x" << tile.rhs_dim;
+    return tile;
+  }
   if (device_description_.cuda_compute_capability().IsAtLeastHopper() &&
       !should_optimize_for_occupancy_) {
     VLOG(5) << "Computing output_tile: Want to use wgmma, so output_tile >= "

--- a/xla/backends/gpu/autotuner/triton/dot_search_space_test.cc
+++ b/xla/backends/gpu/autotuner/triton/dot_search_space_test.cc
@@ -494,5 +494,50 @@ TEST_F(RocmDotSearchSpaceTest, GeneratesWavesPerEuConfigs) {
                              Each(WavesPerEuIs(AnyOf(0, 1, 2, 4)))));
 }
 
+TEST_F(RocmDotSearchSpaceTest, UsesSquareMinimumTile) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                          GetDefaultDotModule());
+  TritonDotFusionSearchSpace search_space = MakeSearchSpace(module.get());
+
+  EXPECT_THAT(
+      search_space.GenerateConfigs(),
+      AllOf(Not(IsEmpty()), Each(BlockMIs(Ge(16))), Each(BlockNIs(Ge(16)))));
+}
+
+// A tile can only use an MFMA instruction if min(block_m, block_n) >= 16, and
+// on gfx942 that also decides whether the dot runs in xf32. A dot and its
+// transpose must therefore not end up on opposite sides of the threshold.
+TEST_F(RocmDotSearchSpaceTest, TransposedDotsAgreeOnMfmaEligibility) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> tall,
+                          GetDefaultDotModule(/*lhs_parallel_dim=*/5,
+                                              /*rhs_parallel_dim=*/30,
+                                              /*contracting_dim=*/64,
+                                              /*type=*/"f32"));
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> wide,
+                          GetDefaultDotModule(/*lhs_parallel_dim=*/30,
+                                              /*rhs_parallel_dim=*/5,
+                                              /*contracting_dim=*/64,
+                                              /*type=*/"f32"));
+
+  // Tile sizes are powers of two, so "not MFMA-eligible" is min(...) <= 8.
+  auto not_mfma_eligible = AnyOf(BlockMIs(Le(8)), BlockNIs(Le(8)));
+  EXPECT_THAT(MakeSearchSpace(tall.get()).GenerateConfigs(),
+              AllOf(Not(IsEmpty()), Each(not_mfma_eligible)));
+  EXPECT_THAT(MakeSearchSpace(wide.get()).GenerateConfigs(),
+              AllOf(Not(IsEmpty()), Each(not_mfma_eligible)));
+}
+
+TEST_F(RocmDotSearchSpaceTest, DoesNotGenerateOneWideTiles) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                          GetDefaultDotModule(/*lhs_parallel_dim=*/4096,
+                                              /*rhs_parallel_dim=*/1,
+                                              /*contracting_dim=*/1024,
+                                              /*type=*/"f32"));
+  TritonDotFusionSearchSpace search_space = MakeSearchSpace(module.get());
+
+  EXPECT_THAT(search_space.GenerateConfigs(),
+              AllOf(Not(IsEmpty()), Each(BlockNIs(Ge(2)))));
+}
+
 }  // namespace
 }  // namespace xla::gpu


### PR DESCRIPTION
On gfx942 the precision of an f32 dot depends on how the dot is spelled. The same contraction, transposed, runs on a reduced-precision xf32 matrix instruction one way and on an exact FMA loop the other. The proximate cause is that the Triton autotuner's minimum output tile seems to be NVIDIA instruction shape which straddles AMD's MFMA eligibility threshold. This makes the floor square on ROCm, which removes the asymmetry.


## The failing test

`tests/lax_numpy_hijax_test.py::EinsumTest::test_vmap_ellipsis` in JAX compares `hijax.einsum` against `jnp.einsum` for the same contraction. Both are correct JAX; they simply lower differently. 

Under `vmap` the hijax side ends up as `dot(f32[4,5], f32[4,30])` and the jnp side as `dot(f32[30,4], f32[4,5])`, the
same math transposed, M=5/N=30 against M=30/N=5 , and the test asserts the two agree to `rtol=1e-5`.

It fails intermittently on gfx942 by ~1.06e-3, and passes on gfx950. Nothing is wrong on the JAX side: against a float64 reference the jnp result is accurate to 9.2e-8 while the hijax result is off by 1.06e-3, so only one of the two is
reduced precision, and which one depends on what the autotuner happens to pick.

## Why

An f32 dot with `precision=DEFAULT` is stamped `InputPrecision::TF32`, and Triton's AMD backend turns that into an xf32 MFMA when `mfmaVersion == 3`, i.e. gfx942 only. Whether it becomes a real instruction depends on the tile:
`chooseMfmaInstruction` needs `min(block_m, block_n) >= 16`, and the only xf32 shapes in Triton's table are 16x16 and 32x32, so anything narrower drops to the FMA loop, which is exact.

The tile comes from `GetMinOutputTile`, where `kMinSupportedTile = {16, 8}` is `mma.m16n8k*` and there is no ROCm branch. For AMD, MFMA is 32x32, 16x16, 4x64 or 64x4, so 16x8 is not one of the shapes — and it straddles the eligibility threshold. Because the floor also overrides the max in the constructor, `block_m` is raised to 16 whenever M is smaller, while `block_n` can stay at 8. Eligibility therefore reduces to a test on N alone, and transposing a dot swaps

which dimension is N:

| dot   | M  | N  | block_m | block_n  | min | instruction |
|-------|----|----|---------|----------|-----|-------------|
| hijax | 5  | 30 | 16      | up to 32 | 16  | `mfma…xf32` |
| jnp   | 30 | 5  | 16..32  | 8        | 8   | FMA         |

I think G also put TODO in the code (b/395572776) already says tile minimumsshould be computed from the target instruction.

## What this changes

The floor becomes square, so eligibility can no longer depend on which operand is the LHS and a dot and its transpose always agree. It is capped at the problem size, so a small dot is not inflated onto a matrix core it cannot fill, and clamped to 2 because Triton cannot legalize a dot with a 1-wide tile ( This is okay ? ).



##Some misc tests to check correctness

this fix works nicely with  delay kernel where we have consistency of backend picked by autotuner  #47065.

Timings are the best config reachable under each floor, forced with
`--xla_gpu_override_gemm_autotuner` and measured with rocprofv3 on MI300X
(median of 25 dispatches):

| dtype | canonical MxNxK | old floor        | new floor        |
|-------|-----------------|------------------|------------------|
| f32   | 4096x16x1024    | 41.5 us (exact)  | 11.3 us (xf32)   |
| f32   | 4096x32x1024    | 47.3 us (exact)  | 15.2 us (xf32)   |
| f32   | 1024x1024x1024  | 125 us (exact)   | 55 us (xf32)     |
| bf16  | 4096x16x1024    | 16.4 us          | 8.0 us           |
| f32   | 4096x4x1024     | 36.9 us          | 22.4 us          |
| f32   | 8x32x1024       | 9.7 us (xf32)    | 18.5 us (exact)  |
| bf16  | 8x32x1024       | 11.1 us          | 16.8 us          |

The first four rows are the square floor dropping `block_n=8` configs, which
were the ones falling back to FMA. The fifth is the cap letting a 4-wide
dimension use a 4-wide tile instead of an 8-wide one. The last two are the cap
keeping a narrow dot off the matrix core, which is the one regression.
when sizes are too small I think we have a penalty.

## Limitations

-This makes more dots use xf32, not fewer. 

-The cap costs performance where there is no precision to gain. `GetMinOutputTile`
sees neither the element type nor the specific architecture.

