### PR TITLE
[ROCm] Use __builtin_bit_cast in the float check device kernel

### DIFF
--- a/xla/stream_executor/rocm/buffer_debug_float_check_kernel_rocm.cu.cc
+++ b/xla/stream_executor/rocm/buffer_debug_float_check_kernel_rocm.cu.cc
@@ -37,12 +37,11 @@ namespace stream_executor::gpu {
 
 template <>
 __device__ constexpr hip_bfloat16 kInfinity<hip_bfloat16> =
-    absl::bit_cast<hip_bfloat16>(static_cast<uint16_t>(
-        absl::bit_cast<uint32_t>(kInfinity<float>) >> 16));
+    __builtin_bit_cast(hip_bfloat16, uint16_t{0x7F80});
 
 template <>
 __device__ constexpr _Float16 kInfinity<_Float16> =
-    absl::bit_cast<_Float16>(uint16_t{0x7C00});
+    __builtin_bit_cast(_Float16, uint16_t{0x7C00});
 
 template <>
 __device__ inline bool IsNan(hip_bfloat16 v) {
@@ -71,8 +70,9 @@ __device__ inline bool IsZero(_Float16 v) {
 
 template <>
 __device__ _Float16 WarpShuffleDown(_Float16 value, unsigned int offset) {
-  return absl::bit_cast<_Float16>(static_cast<uint16_t>(
-      __shfl_down(absl::bit_cast<uint16_t>(value), offset)));
+  return __builtin_bit_cast(
+      _Float16, static_cast<uint16_t>(
+                    __shfl_down(__builtin_bit_cast(uint16_t, value), offset)));
 }
 
 template <typename T>


### PR DESCRIPTION
## What breaks today

Every jaxlib build on `rocm-jaxlib-v0.10.1` fails compiling
`xla/stream_executor/rocm/buffer_debug_float_check_kernel_rocm.cu.cc`:

```
error: no matching function for call to '__or_fn'
note: in instantiation of template class 'std::is_trivially_copyable<_Float16>' requested here
note: candidate function not viable: call to __host__ function from __device__ function
    45 |     absl::bit_cast<_Float16>(uint16_t{0x7C00});
95 warnings and 2 errors generated when compiling for gfx1010.
```

`absl::bit_cast` constrains itself with `std::is_trivially_copyable<Dest>`, which
libstdc++ 14 implements through `__is_complete_or_unbounded` and `__or_fn`. Those
are host functions, so the device compiler rejects them inside the `__device__
constexpr` initializers. The manylinux build image uses gcc-toolset-14, so every
build on this branch hits it.

## The change

Cherry-pick of 600814673f (PR #45093), which replaces those casts with
`__builtin_bit_cast`. The builtin needs no type traits, so nothing host-only is
reachable from device code.

`rocm-jaxlib-v0.10.2` and `rocm-jaxlib-v0.11.0` already carry this; only this
branch was left behind.

## Test plan

* TheRock JAX release build for `rocm-jaxlib-v0.10.1`, which currently fails at
  this file, gets past it