### PR TITLE
Add build_tools/rocm/global_symbol_version.lds

### DIFF
--- a/build_tools/rocm/global_symbol_version.lds
+++ b/build_tools/rocm/global_symbol_version.lds
@@ -1,0 +1,6 @@
+# Assign a symbol version to every exported symbol.
+# This is the cheapest option to make sure exported
+# llvm symbols don't clash with those of ROCm's libLLVM.so
+XLA_TEST {
+  global: *;
+};


### PR DESCRIPTION
Used by https://github.com/openxla/xla/pull/47522. Instead of using `--dynamic-mode=off` we version all symbols in all executable artifacts built. This will prevent among other things us interposing with `libLLVM.so` symbols. This is not hermetic build safe (won't work for rbe build). So I decided to make this workaround CI specific (local build) and make this script live in rocm-dev-infra instead of upstream xla. All in all it is a hack which I don't wish to live in upstream xla for now.