### PR TITLE
[ROCm] Add a theoretical-occupancy model for AMDGPU kernels (PR1 for internal review)

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -525,6 +525,37 @@ cc_library(
     ],
 )
 
+# Theoretical-occupancy model for AMDGPU kernels. Deliberately has NO ROCm
+# dependency and NO "rocm-only" tag: it is pure arithmetic, so it builds and
+# tests on a CPU-only host. Keeping it inside :rocm_collector -- which pulls in
+# hip_runtime.h and rocprofiler-sdk -- would mean the formula could never be
+# covered by CPU CI. Do not add ROCm deps here.
+cc_library(
+    name = "rocm_occupancy",
+    srcs = ["rocm_occupancy.cc"],
+    hdrs = ["rocm_occupancy.h"],
+    deps = [
+        "@com_google_absl//absl/log",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_occupancy_test",
+    size = "small",
+    srcs = ["rocm_occupancy_test.cc"],
+    # Untagged, on purpose, and do not add "gpu" here. openxla's CPU, ARM64 and
+    # Windows configs all filter -no_oss,-gpu,-requires-gpu-*, so any of those
+    # tags removes this target from every mainstream CI job and leaves it
+    # running only under ROCm's own ci_rocm_cpu, whose ",gpu," filter is
+    # positive. Untagged is what gets the golden table built and run on every
+    # PR, which is the whole reason the model is kept free of ROCm deps.
+    deps = [
+        ":rocm_occupancy",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "rocm_collector",
     srcs = ["rocm_collector.cc"],

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -148,40 +148,6 @@ uint64_t get_timestamp() {
 }
 }  // namespace
 
-OccupancyStats PerDeviceCollector::GetOccupancy(
-    const RocmDeviceOccupancyParams& params) const {
-  // TODO(rocm-profiler): hipOccupancyMaxActiveBlocksPerMultiprocessor only
-  // return hipSuccess for HIP_API_ID_hipLaunchKernel
-  OccupancyStats stats;
-  int number_of_active_blocks;
-  hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
-      &number_of_active_blocks, params.func_ptr, params.block_size,
-      params.dynamic_smem_size);
-
-  if (err != hipError_t::hipSuccess) {
-    return {};
-  }
-
-  stats.occupancy_pct = number_of_active_blocks * params.block_size * 100;
-  // TODO(ROCm): GetOccupancy is currently dead code -- no callers populate
-  // max_waves_per_cu / wave_front_size, so occupancy_pct stays zero.
-  // Wire up agent data when occupancy reporting is enabled.
-  auto max_threads = params.max_waves_per_cu * params.wave_front_size;
-  if (max_threads > 0) {
-    stats.occupancy_pct /= max_threads;
-  }
-
-  err = hipOccupancyMaxPotentialBlockSize(
-      &stats.min_grid_size, &stats.suggested_block_size,
-      static_cast<const void*>(params.func_ptr), params.dynamic_smem_size, 0);
-
-  if (err != hipError_t::hipSuccess) {
-    return {};
-  }
-
-  return stats;
-}
-
 void PerDeviceCollector::CreateXEvent(const RocmTracerEvent& event,
                                       XPlaneBuilder* plane,
                                       uint64_t start_gpu_ns,

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -59,70 +59,6 @@ inline std::string ToXStat(const KernelDetails& kernel_info,
                       " occ_pct:", occupancy_pct);
 }
 
-struct RocmDeviceOccupancyParams {
-  hipFuncAttributes attributes = {};
-  int block_size = 0;
-  size_t dynamic_smem_size = 0;
-  void* func_ptr;
-  uint32_t max_waves_per_cu = 0;
-  uint32_t wave_front_size = 0;
-
-  friend bool operator==(const RocmDeviceOccupancyParams& a,
-                         const RocmDeviceOccupancyParams& b) noexcept {
-    // Compare only the fields that affect occupancy decisions.
-    return std::tuple{a.attributes.binaryVersion,
-                      a.attributes.cacheModeCA,
-                      a.attributes.constSizeBytes,
-                      a.attributes.localSizeBytes,
-                      a.attributes.maxDynamicSharedSizeBytes,
-                      a.attributes.maxThreadsPerBlock,
-                      a.attributes.numRegs,
-                      a.attributes.preferredShmemCarveout,
-                      a.attributes.ptxVersion,
-                      a.block_size,
-                      a.dynamic_smem_size,
-                      a.func_ptr,
-                      a.max_waves_per_cu,
-                      a.wave_front_size} ==
-           std::tuple{b.attributes.binaryVersion,
-                      b.attributes.cacheModeCA,
-                      b.attributes.constSizeBytes,
-                      b.attributes.localSizeBytes,
-                      b.attributes.maxDynamicSharedSizeBytes,
-                      b.attributes.maxThreadsPerBlock,
-                      b.attributes.numRegs,
-                      b.attributes.preferredShmemCarveout,
-                      b.attributes.ptxVersion,
-                      b.block_size,
-                      b.dynamic_smem_size,
-                      b.func_ptr,
-                      b.max_waves_per_cu,
-                      b.wave_front_size};
-  }
-
-  friend bool operator!=(const RocmDeviceOccupancyParams& a,
-                         const RocmDeviceOccupancyParams& b) noexcept {
-    return !(a == b);
-  }
-
-  template <typename H>
-  friend H AbslHashValue(H hash_state,
-                         const RocmDeviceOccupancyParams& params) {
-    return H::combine(
-        std::move(hash_state), params.attributes.maxThreadsPerBlock,
-        params.attributes.numRegs, params.attributes.sharedSizeBytes,
-        params.attributes.maxDynamicSharedSizeBytes, params.block_size,
-        params.dynamic_smem_size, params.func_ptr, params.max_waves_per_cu,
-        params.wave_front_size);
-  }
-};
-
-// FIXME: rocprofiler-sdk does not have this one yet
-struct OccupancyStats {
-  double occupancy_pct = 0.0;
-  int min_grid_size = 0;
-  int suggested_block_size = 0;
-};
 
 class RocmTraceCollector {
  public:
@@ -163,7 +99,6 @@ class PerDeviceCollector {
                              tsl::profiler::XPlaneBuilder* device_plane);
 
  private:
-  OccupancyStats GetOccupancy(const RocmDeviceOccupancyParams& params) const;
   void CreateXEvent(const RocmTracerEvent& event,
                     tsl::profiler::XPlaneBuilder* plane, uint64_t start_gpu_ns,
                     uint64_t end_gpu_ns, tsl::profiler::XLineBuilder* line);
@@ -173,8 +108,6 @@ class PerDeviceCollector {
  private:
   absl::Mutex events_mutex_;
   std::vector<RocmTracerEvent> events_ ABSL_GUARDED_BY(events_mutex_);
-  absl::flat_hash_map<RocmDeviceOccupancyParams, OccupancyStats>
-      occupancy_cache_;
 };  // PerDeviceCollector
 
 class RocmTraceCollectorImpl : public RocmTraceCollector {

--- a/xla/backends/profiler/gpu/rocm_occupancy.cc
+++ b/xla/backends/profiler/gpu/rocm_occupancy.cc
@@ -1,0 +1,433 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/rocm_occupancy.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+#include "absl/log/log.h"
+
+namespace xla {
+namespace profiler {
+namespace {
+
+// Sentinel for "this resource does not bound the launch at all". Only ever
+// compared with std::min against real workgroup counts, never divided by.
+constexpr uint32_t kUnbounded = 0xFFFFFFFFu;
+
+// Saturating, not wrapping. These inputs are not adversarial but they are not
+// trustworthy either -- the version-skew guard below exists precisely because
+// an SDK that predates a target hands back register counts whose encoding we
+// do not understand. A wrapping AlignTo turns a huge count into 0, and 0 reads
+// downstream as "no resource pressure": it divides by zero in the VGPR bound
+// (a SIGFPE that would abort the *traced* process, the worst failure mode a
+// profiler has) and reports unbounded workgroups in the LDS bound. Saturating
+// turns garbage into "maximum pressure" instead, which the model already knows
+// how to degrade -- to the 1-wave / 1-workgroup floor.
+inline uint32_t AlignTo(uint32_t v, uint32_t a) {
+  if (a == 0) {
+    return v;
+  }
+  if (v > std::numeric_limits<uint32_t>::max() - (a - 1)) {
+    return std::numeric_limits<uint32_t>::max();
+  }
+  return ((v + a - 1) / a) * a;
+}
+
+inline uint32_t SaturatingAdd(uint32_t a, uint32_t b) {
+  return a > std::numeric_limits<uint32_t>::max() - b
+             ? std::numeric_limits<uint32_t>::max()
+             : a + b;
+}
+
+// Overflow-free, for the same reason AlignTo saturates: `(a + b - 1)` wraps
+// for a near-UINT32_MAX block_size and yields a small wave count that sails
+// past the feasibility guard in GetOccupancy, producing a confident wrong
+// answer instead of no answer.
+inline uint32_t CeilDiv(uint32_t a, uint32_t b) {
+  if (b == 0) {
+    return 0;
+  }
+  return a / b + (a % b != 0 ? 1 : 0);
+}
+
+// AMDGPUBaseInfo.cpp getOccupancyWithNumSGPRs, the closed form. Parameter
+// list mirrors LLVM's subtarget-free overload so the two can be diffed:
+//
+//   unsigned getOccupancyWithNumSGPRs(unsigned SGPRs, unsigned MaxWaves,
+//                                     unsigned TotalNumSGPRs,
+//                                     unsigned Granule, unsigned TrapReserve);
+//
+// This is the algebraic inverse of getMaxNumSGPRs(): the budget condition
+//   SGPRs <= alignDown(TotalNumSGPRs / W - TrapReserve, Granule)
+// solves to W <= TotalNumSGPRs / (alignTo(SGPRs, Granule) + TrapReserve).
+//
+// An earlier revision of this file used LLVM's pre-2026 step table
+// (<=80 -> 10, <=88 -> 9, <=100 -> 8, else 7). Upstream replaced that table
+// precisely because it ignored the allocation granule and therefore
+// contradicted getMaxNumSGPRs; the two now "encode one model"
+// (AMDGPUBaseInfo.cpp, comment above getSGPRBudgetPerWave). The LLVM that XLA
+// itself pins carries the closed form, so the table was a divergence from the
+// very tree this file is built against. AMD's published CDNA4 occupancy
+// guidance gives the same division. Do not reintroduce the table without
+// silicon measurements in the commit message.
+//
+// The two forms differ only where alignTo() crosses a step edge. After the
+// clamp to max_waves_per_simd = 8 the sole reachable window on CDNA is
+// 97..100 SGPRs (closed form 7, table 8). See the boundary test.
+inline uint32_t OccupancyWithNumSgprs(uint32_t sgprs, uint32_t max_waves,
+                                      uint32_t total_sgprs, uint32_t granule,
+                                      uint32_t trap_reserve) {
+  const uint32_t per_wave =
+      SaturatingAdd(AlignTo(sgprs, granule), trap_reserve);
+  if (per_wave == 0) {
+    return max_waves;
+  }
+  return std::clamp(total_sgprs / per_wave, 1u, max_waves);
+}
+
+// The FeatureGFX90AInsts family: gfx90a, gfx94x, gfx95x. LLVM keys almost
+// every constant that matters here off that one subtarget feature, so the
+// only differences between the three are the LDS pool size and its
+// allocation granule.
+constexpr AmdGpuTargetConstants MakeGfx90aFamily(const char* name,
+                                                 uint32_t lds_per_cu,
+                                                 uint32_t lds_granule) {
+  return AmdGpuTargetConstants{
+      /*name=*/name,
+      /*max_waves_per_simd=*/8,  // getMaxWavesPerEU: isGFX90A -> 8
+      /*simd_per_cu=*/4,         // getEUsPerCU: pre-GFX10 -> 4
+      /*wave_front_size=*/64,
+      /*total_vgprs=*/512,      // getTotalNumVGPRs: FeatureGFX90AInsts
+      /*vgpr_granule=*/8,       // getVGPRAllocGranule: FeatureGFX90AInsts
+      /*arch_vgpr_granule=*/4,  // getArchVGPRAllocGranule
+      /*lds_per_cu=*/lds_per_cu,
+      /*lds_granule=*/lds_granule,
+      /*total_sgprs=*/800,      // getTotalNumSGPRs: IsaVersion.Major >= 8
+      /*sgpr_granule=*/16,      // getSGPRAllocGranule: Major 8..9
+      /*sgpr_trap_reserve=*/0,  // no +trap-handler in normal HIP codegen
+      /*max_barriers=*/16,      // getMaxWorkGroupsPerCU; never binds on CDNA
+      /*sgpr_limited=*/true,    // isSGPROccupancyLimited: Major < 10
+      /*unified_vgpr_file=*/true,
+      /*exact=*/true};
+}
+
+}  // namespace
+
+const char* OccupancyLimiterName(OccupancyLimiter l) {
+  switch (l) {
+    case OccupancyLimiter::kNone:
+      return "none";
+    case OccupancyLimiter::kVGPR:
+      return "vgpr";
+    case OccupancyLimiter::kLDS:
+      return "lds";
+    case OccupancyLimiter::kSGPR:
+      return "sgpr";
+    case OccupancyLimiter::kWorkgroup:
+      return "workgroup";
+    case OccupancyLimiter::kBarrier:
+      return "barrier";
+  }
+  return "unknown";
+}
+
+std::optional<AmdGpuTargetConstants> LookupTargetConstants(
+    uint32_t gfx_target_version) {
+  const uint32_t major = (gfx_target_version / 10000) % 100;
+  const uint32_t minor = (gfx_target_version / 100) % 100;
+  const uint32_t step = gfx_target_version % 100;
+
+  if (major != 9) {
+    // gfx10/11/12 have wave32, a much larger VGPR file and different
+    // granules. We have no validated constants for them; emit nothing rather
+    // than a plausible-looking wrong number.
+    return std::nullopt;
+  }
+
+  if (minor == 0 && step == 10) {  // gfx90a, MI200
+    return MakeGfx90aFamily("gfx90a", /*lds_per_cu=*/65536,
+                            /*lds_granule=*/512);
+  }
+  if (minor == 4) {  // gfx940/941/942; MI300A/MI300X/MI325
+    return MakeGfx90aFamily("gfx94x", /*lds_per_cu=*/65536,
+                            /*lds_granule=*/512);
+  }
+  if (minor == 5) {  // gfx950, MI355
+    // AMDGPU.td:1904 gives 160 KiB, and getLdsDwGranularity returns 320
+    // dwords rather than gfx942's 128.
+    return MakeGfx90aFamily("gfx95x", /*lds_per_cu=*/163840,
+                            /*lds_granule=*/1280);
+  }
+
+  // Unrecognised gfx9 -- gfx900/906/908, or a part newer than this table.
+  // Degrade to LLVM's own pre-GFX90A fallthrough values rather than to
+  // anything invented here, so a reader can diff this against AMDGPUBaseInfo
+  // and see where it came from. Note these do NOT err in a single direction:
+  // max_waves_per_simd goes up (8 -> 10) while total_vgprs goes down
+  // (512 -> 256), so which way the answer moves depends on the kernel's
+  // register pressure.
+  //
+  // `exact=false` marks the constants as a guess for any future caller that
+  // wants to gate on it. Nothing consumes it yet, so the warning below is the
+  // only signal a user gets that this device's numbers are estimated. It is
+  // logged once per process rather than once per unrecognised target:
+  // LookupTargetConstants runs on every kernel event, and de-duplicating by
+  // version would put a lock or an allocation on that path to improve a
+  // diagnostic. A heterogeneous host therefore names only its first
+  // unmodelled target.
+  LOG_FIRST_N(WARNING, 1)
+      << "No validated occupancy constants for gfx_target_version "
+      << gfx_target_version
+      << "; falling back to LLVM's pre-GFX90A defaults. Reported occupancy for "
+         "this device is an estimate and may be wrong in either direction.";
+  AmdGpuTargetConstants g = MakeGfx90aFamily(
+      "gfx9-generic", /*lds_per_cu=*/65536, /*lds_granule=*/512);
+  g.max_waves_per_simd = 10;  // getMaxWavesPerEU fallthrough
+  g.total_vgprs = 256;        // getTotalNumVGPRs fallthrough
+  g.vgpr_granule = 4;         // getVGPRAllocGranule fallthrough (wave64)
+  g.unified_vgpr_file = false;
+  g.exact = false;
+  return g;
+}
+
+// AMDGPUBaseInfo.cpp getTotalNumVGPRs(has90AInsts, AGPR, VGPR):
+//   has90AInsts && AGPR ? alignTo(VGPR, 4) + AGPR : max(VGPR, AGPR)
+//
+// The max() branch is load-bearing, not defensive. On gfx908 the SDK's
+// accum_vgpr_count() *returns* arch_vgpr_count(), so an unconditional sum
+// would report MI100 register pressure at exactly 2x. Every caller that needs
+// a register count -- including ToXStat's `regs:` token -- must route through
+// here rather than adding the two fields itself.
+uint32_t UnifiedVgprCount(const AmdGpuTargetConstants& tc, uint32_t arch,
+                          uint32_t accum) {
+  if (tc.unified_vgpr_file && accum != 0) {
+    return SaturatingAdd(AlignTo(arch, tc.arch_vgpr_granule), accum);
+  }
+  return std::max(arch, accum);
+}
+
+std::optional<OccupancyStats> GetOccupancy(const RocmDeviceOccupancyParams& p,
+                                           uint32_t cu_count) {
+  std::optional<AmdGpuTargetConstants> tc_opt =
+      LookupTargetConstants(p.gfx_target_version);
+  if (!tc_opt.has_value()) {
+    return std::nullopt;
+  }
+  const AmdGpuTargetConstants& tc = *tc_opt;
+
+  if (p.block_size == 0) {
+    return std::nullopt;
+  }
+  // No register data at all means the code-object symbol lookup missed. We
+  // cannot distinguish "a kernel that uses zero registers" (which does not
+  // exist) from "we never saw the symbol", so model nothing.
+  if (p.arch_vgpr_count == 0 && p.accum_vgpr_count == 0) {
+    return std::nullopt;
+  }
+
+  const uint32_t slots = tc.max_waves_per_simd * tc.simd_per_cu;
+  const uint32_t waves_per_wg = CeilDiv(p.block_size, tc.wave_front_size);
+  // A workgroup that cannot fit in a CU's wave slots at all is not a launch
+  // geometry the hardware would have accepted; treat it as unmodelable.
+  if (waves_per_wg == 0 || waves_per_wg > slots) {
+    return std::nullopt;
+  }
+
+  const uint32_t vgprs =
+      UnifiedVgprCount(tc, p.arch_vgpr_count, p.accum_vgpr_count);
+
+  // ROCm version-skew guard. arch/accum are decoded by the *installed* SDK via
+  // a string match on the agent name, and an SDK predating a target's support
+  // silently falls through to a generic branch. On a unified-file target the
+  // hardware allocation of each component (arch and accum) is a multiple of
+  // arch_vgpr_granule (4 on all current CDNA targets). rocprofiler-sdk reports
+  // them pre-combination, so their sum is always a multiple of 4 when the SDK
+  // understands the target. Checking against vgpr_granule (8) was wrong: it
+  // suppressed valid MFMA kernels where AlignTo(arch,4)+accum is 12 or 20
+  // (arch=4,accum=8 or arch=16,accum=4), which the hardware executes fine by
+  // rounding the sum up to 16 or 24 at allocation time.
+  //
+  // NOTE, this deviates from the design doc, which applies the check to every
+  // unified-file kernel. That over-triggers: `accum == 0` takes the max()
+  // branch above, leaving `vgprs == arch_vgpr_count`, and arch counts are
+  // granulated to 4 rather than 8, so perfectly ordinary low-register kernels
+  // (arch=4, arch=100) would have their occupancy suppressed. Restricting the
+  // guard to the sum branch keeps it meaningful. The cost is that the one
+  // skew case the doc names -- an old SDK reporting accum=0 on gfx950 -- is
+  // not detectable here, because it is numerically indistinguishable from a
+  // genuine non-MFMA kernel. That case needs a documented minimum ROCm
+  // version, not arithmetic.
+  if (tc.unified_vgpr_file && p.accum_vgpr_count != 0 &&
+      (vgprs % tc.arch_vgpr_granule) != 0) {
+    LOG_FIRST_N(WARNING, 1)
+        << "rocprofiler-sdk reported a non-granulated unified VGPR count for "
+        << tc.name << " (arch=" << p.arch_vgpr_count
+        << ", accum=" << p.accum_vgpr_count
+        << "); the SDK may predate this target. Occupancy suppressed.";
+    return std::nullopt;
+  }
+
+  // --- VGPR bound, waves/SIMD (getNumWavesPerEUWithNumVGPRs).
+  const uint32_t occ_vgpr =
+      (vgprs < tc.vgpr_granule)
+          ? tc.max_waves_per_simd
+          : std::clamp(tc.total_vgprs / AlignTo(vgprs, tc.vgpr_granule), 1u,
+                       tc.max_waves_per_simd);
+
+  // --- SGPR bound, waves/SIMD (getOccupancyWithNumSGPRs).
+  // Live on gfx9: isSGPROccupancyLimited is IsaVersion.Major < 10, and
+  // gfx90a/942/950 are all Major 9. It costs at most one wave, but on an
+  // 8-wave target that is 12.5 pp and it is real.
+  //
+  // A zero sgpr_count is read as "the SDK did not report it" and skips the
+  // bound, where a zero VGPR count above suppresses the result entirely. The
+  // asymmetry is deliberate: no kernel uses zero registers of either kind, but
+  // the VGPR term decides the answer while this one can only shave a single
+  // wave off it, so a possibly-one-wave-optimistic number beats no number.
+  uint32_t occ_sgpr = tc.max_waves_per_simd;
+  if (tc.sgpr_limited && p.sgpr_count != 0) {
+    occ_sgpr = OccupancyWithNumSgprs(p.sgpr_count, tc.max_waves_per_simd,
+                                     tc.total_sgprs, tc.sgpr_granule,
+                                     tc.sgpr_trap_reserve);
+  }
+
+  // --- Convert the register bounds to whole workgroups per CU.
+  //
+  // DELIBERATE DIVERGENCE FROM LLVM #1. GCNSubtarget::computeOccupancy takes a
+  // flat min() in waves/EU and never re-quantizes to whole workgroups. We do,
+  // because hardware cannot resident a partial workgroup and neither can
+  // hipOccupancyMaxActiveBlocksPerMultiprocessor. Consequence for anyone
+  // adding tests: llc's "; Occupancy:" comment is NOT a valid oracle for this
+  // term.
+  const uint32_t wgs_vgpr = (occ_vgpr * tc.simd_per_cu) / waves_per_wg;
+  const uint32_t wgs_sgpr = (occ_sgpr * tc.simd_per_cu) / waves_per_wg;
+
+  // Zero workgroups from a register bound means this workgroup needs more
+  // registers than a CU can hold, so the hardware cannot resident even one of
+  // them -- the same class of impossible geometry the waves_per_wg check
+  // rejects above, and not something the compiler would have emitted. Model
+  // nothing rather than flooring to one: the floor would report a confident
+  // 50% for a gfx942 kernel with 240 VGPRs and a 1024-thread block, which
+  // needs 960 VGPRs per SIMD against a 512-entry file.
+  //
+  // The LDS term below floors to 1 instead, and that asymmetry is LLVM's:
+  // AMDGPUSubtarget treats an over-large LDS request as achievable-at-1.
+  if (wgs_vgpr == 0 || wgs_sgpr == 0) {
+    return std::nullopt;
+  }
+
+  // --- LDS bound, workgroups per CU (AMDGPUSubtarget.cpp).
+  uint32_t wgs_lds = kUnbounded;
+  if (p.smem_bytes != 0) {
+    // AlignTo saturates and smem_bytes is non-zero here, so lds_per_wg is at
+    // least one granule; it cannot be a zero divisor.
+    const uint32_t lds_per_wg = AlignTo(p.smem_bytes, tc.lds_granule);
+    wgs_lds = tc.lds_per_cu / lds_per_wg;
+    // LLVM: a queried LDS size may be larger than a CU has, "in which case we
+    // consider the only achievable occupancy to be 1". Returning nothing here
+    // would be a silent hole for exactly the kernels most worth flagging.
+    if (wgs_lds == 0) {
+      wgs_lds = 1;
+    }
+  }
+
+  // --- Wave-slot and barrier bounds, workgroups per CU.
+  const uint32_t wgs_slots = slots / waves_per_wg;
+  const uint32_t wgs_barrier =
+      (waves_per_wg == 1) ? slots : std::min(wgs_slots, tc.max_barriers);
+
+  // Every term is >= 1 by construction: the register bounds returned nullopt
+  // at zero, wgs_lds floors at 1, and wgs_slots/wgs_barrier are >= 1 because
+  // waves_per_wg <= slots. Deliberately no floor here, so that a zero would
+  // surface as a bug rather than being silently rounded up to a real answer.
+  const uint32_t wgs =
+      std::min({wgs_vgpr, wgs_sgpr, wgs_lds, wgs_slots, wgs_barrier});
+
+  // --- Attribute the limiter from the UNQUANTIZED bounds.
+  //
+  // The obvious version -- compare each quantized bound against the final wgs
+  // and let the last match win -- misattributes the pure-quantization cases.
+  // For a 320-thread block occ_vgpr is 8 (no VGPR pressure whatsoever) yet
+  // wgs_vgpr is 8*4/5 = 6, which ties the answer, so VGPR would claim the
+  // blame for a kernel using four registers. Requiring a resource to be
+  // strictly below the slot ceiling in its own units before it can claim
+  // attribution is what makes wg320 and wg768 correctly report "workgroup" --
+  // which is the entire reason the limiter exists.
+  OccupancyLimiter limiter = OccupancyLimiter::kNone;
+  uint32_t best = wgs_slots;
+  // Each check uses < rather than <= so that the first resource to reach the
+  // binding minimum keeps the attribution. On an exact tie between SGPR and
+  // VGPR (both at the same wgs count, both genuinely below the wave-slot
+  // ceiling), SGPR is attributed because it is checked first. That is the
+  // higher-value direction on CDNA: addressable SGPRs max out at 102 and the
+  // bound costs at most one wave (12.5 pp), so an engineer can act on a SGPR
+  // attribution quickly; VGPR pressure has far more headroom to explore.
+  if (wgs_barrier < wgs_slots && wgs_barrier < best) {
+    best = wgs_barrier;
+    limiter = OccupancyLimiter::kBarrier;
+  }
+  if (occ_sgpr < tc.max_waves_per_simd && wgs_sgpr < best) {
+    best = wgs_sgpr;
+    limiter = OccupancyLimiter::kSGPR;
+  }
+  if (wgs_lds < wgs_slots && wgs_lds < best) {
+    best = wgs_lds;
+    limiter = OccupancyLimiter::kLDS;
+  }
+  if (occ_vgpr < tc.max_waves_per_simd && wgs_vgpr < best) {
+    best = wgs_vgpr;
+    limiter = OccupancyLimiter::kVGPR;
+  }
+  // Nothing claimed the blame but the slots are not full: what is left is
+  // workgroup quantization. There is no converse case -- a resource strictly
+  // below the ceiling in its own units always leaves wgs * waves_per_wg <
+  // slots -- so this is the only assignment needed.
+  if (limiter == OccupancyLimiter::kNone && wgs * waves_per_wg < slots) {
+    limiter = OccupancyLimiter::kWorkgroup;
+  }
+
+  OccupancyStats s;
+  s.active_blocks_per_cu = wgs;
+  // wgs <= wgs_slots = slots / waves_per_wg, so this cannot exceed slots.
+  s.active_waves_per_cu = wgs * waves_per_wg;
+  s.waves_per_simd =
+      static_cast<double>(s.active_waves_per_cu) / tc.simd_per_cu;
+  // CUPTI parity: percent of THREADS per CU, not waves.
+  //
+  // DELIBERATE DIVERGENCE FROM LLVM #2 lives one level up, in what we do NOT
+  // copy: AMDGPUSubtarget::getOccupancyWithWorkGroupSizes returns
+  // clamp(divideCeil(wavesPerCU, EUsPerCU), 1, Wmax) and the asm printer takes
+  // the .second of that range, which rounds 30 waves/CU up to 8/8 = 100%. A
+  // profiler knows the exact launch geometry and must report the exact answer.
+  s.occupancy_pct = 100.0 * static_cast<double>(wgs) * p.block_size /
+                    (static_cast<double>(slots) * tc.wave_front_size);
+  s.limiter = limiter;
+  s.total_vgprs = vgprs;
+  // CUDA's min_grid_size is whole-device, not per-CU.
+  s.min_grid_size = cu_count == 0 ? 0 : wgs * cu_count;
+  // Carried so a consumer can mark generic-fallback numbers as estimates
+  // rather than rendering them beside measured ones. The LOG_FIRST_N in
+  // LookupTargetConstants is a process-lifetime diagnostic; this is the
+  // per-event signal.
+  s.exact = tc.exact;
+  return s;
+}
+
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_occupancy.h
+++ b/xla/backends/profiler/gpu/rocm_occupancy.h
@@ -1,0 +1,208 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_OCCUPANCY_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_OCCUPANCY_H_
+
+// Theoretical-occupancy model for AMDGPU kernels.
+//
+// This header deliberately has NO ROCm includes. It is a pure arithmetic
+// library so that the model can be unit-tested on any CPU host, without a
+// ROCm toolchain and without a GPU. rocm_collector.h pulls in hip_runtime.h
+// and rocprofiler-sdk/agent.h, so keeping the formula there would mean it
+// could never be covered by CPU CI.
+//
+// The model is a port of, and in two places a deliberate divergence from,
+// llvm/lib/Target/AMDGPU: AMDGPUAsmPrinter -> AMDGPUMCExpr::evaluateOccupancy
+// -> GCNSubtarget::computeOccupancy / getOccupancyWith{WorkGroupSizes,
+// NumSGPRs, NumVGPRs}. The two divergences are documented at GetOccupancy()
+// in the .cc; do not "fix" them back.
+//
+// UNITS -- these three quantities are all called "occupancy" in different
+// parts of the stack, and they are not the same number:
+//   * waves_per_simd (a.k.a. waves/EU) is what LLVM's evaluateOccupancy, the
+//     "; Occupancy:" asm comment and -Rpass-analysis=kernel-resource-usage
+//     report. Range [1, 8] on CDNA2/3/4.
+//   * active_waves_per_cu is per CU = waves_per_simd * simd_per_cu.
+//   * occupancy_pct is percent of THREADS per CU, matching CUPTI's
+//     activeBlocksPerMultiprocessor * block_size * 100 /
+//     maxThreadsPerMultiprocessor. It is the number users compare across
+//     vendors on one dashboard, so it takes CUDA's definition.
+
+#include <cstdint>
+#include <optional>
+#include <tuple>
+#include <utility>
+
+namespace xla {
+namespace profiler {
+
+// Which hardware resource bounded occupancy. Ordered by how actionable it is.
+//
+// This is the highest-value thing the model produces. A bare percentage
+// prompts the wrong reflex -- chase 100% -- when a well-tuned MFMA GEMM
+// legitimately runs at low occupancy by design. Each limiter value maps to a
+// distinct concrete action, and kNone tells the engineer to stop looking at
+// occupancy altogether.
+enum class OccupancyLimiter : uint8_t {
+  kNone = 0,   // at the wave-slot ceiling; occupancy is not the problem
+  kVGPR,       // unified arch+accum VGPR file
+  kLDS,        // group segment
+  kSGPR,       // scalar registers (gfx9 only)
+  kWorkgroup,  // wave-slot quantization by workgroup size
+  kBarrier,    // max concurrent workgroups per CU (never binds on CDNA)
+};
+
+const char* OccupancyLimiterName(OccupancyLimiter l);
+
+// Per-target constants that rocprofiler-sdk does NOT expose. Mirrors
+// llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp; every field names the LLVM
+// accessor it was read from.
+struct AmdGpuTargetConstants {
+  const char* name;             // "gfx942"
+  uint32_t max_waves_per_simd;  // getMaxWavesPerEU
+  uint32_t simd_per_cu;         // getEUsPerCU
+  uint32_t wave_front_size;
+  uint32_t total_vgprs;        // getTotalNumVGPRs, per SIMD lane (unified)
+  uint32_t vgpr_granule;       // getVGPRAllocGranule
+  uint32_t arch_vgpr_granule;  // getArchVGPRAllocGranule
+  uint32_t lds_per_cu;         // getAddressableLocalMemorySize
+  uint32_t lds_granule;        // getLdsDwGranularity * 4
+  uint32_t total_sgprs;        // getTotalNumSGPRs
+  uint32_t sgpr_granule;       // getSGPRAllocGranule
+  uint32_t sgpr_trap_reserve;  // TRAP_NUM_SGPRS if +trap-handler, else 0
+  uint32_t max_barriers;       // getMaxWorkGroupsPerCU cap
+  bool sgpr_limited;           // isSGPROccupancyLimited (IsaVersion.Major < 10)
+  bool unified_vgpr_file;      // FeatureGFX90AInsts: arch and accum share 512
+  bool exact;                  // false => generic fallback, values are a guess
+};
+
+// gfx_target_version decodes as major=(v/10000)%100, minor=(v/100)%100,
+// step=v%100 -- all decimal (rocprofiler-sdk agent.h). The *name* renders the
+// step in hex, which is why gfx90a is 90010 and not 9001a.
+//
+// Returns nullopt for targets we cannot model (anything with major != 9).
+// The caller MUST then emit no occupancy stats rather than guess: the
+// coincidence that makes a naive formula work on CDNA does not hold on
+// gfx10/11/12, which have wave32, a much larger VGPR file and different
+// allocation granules.
+std::optional<AmdGpuTargetConstants> LookupTargetConstants(
+    uint32_t gfx_target_version);
+
+// The number of VGPRs the hardware actually charges a wave.
+//
+// Exposed rather than kept private because the max() branch is load-bearing
+// rather than defensive -- see the gfx908 trap documented in the .cc -- so any
+// caller that needs a register count must route through here instead of adding
+// arch and accum itself.
+uint32_t UnifiedVgprCount(const AmdGpuTargetConstants& tc, uint32_t arch,
+                          uint32_t accum);
+
+// Everything that determines theoretical occupancy for one kernel launch.
+// Doubles as the key of the collector's memoization cache.
+struct RocmDeviceOccupancyParams {
+  // Kernel symbol data (DEVICE_KERNEL_SYMBOL_REGISTER callback).
+  uint32_t arch_vgpr_count = 0;   // callback_tracing.h arch_vgpr_count
+  uint32_t accum_vgpr_count = 0;  // callback_tracing.h accum_vgpr_count (AGPRs)
+  uint32_t sgpr_count = 0;        // callback_tracing.h, already 16-granulated
+
+  // Kernel dispatch record (rocprofiler_kernel_dispatch_info_t).
+  uint32_t block_size = 0;  // workgroup_size.x*y*z, zero dims treated as 1
+  // group_segment_size from the *dispatch* record: the TOTAL LDS per workgroup
+  // (static + runtime). Do NOT add the symbol's group_segment_size on top,
+  // that would double-count.
+  uint32_t smem_bytes = 0;
+
+  // Device identity. Everything else comes from LookupTargetConstants; the
+  // agent's own capability scalars carry no discriminating power here because
+  // they are invariant per device, while this field is the one that actually
+  // distinguishes a gfx90a from a gfx950 from a gfx1100.
+  uint32_t gfx_target_version = 0;
+
+  friend bool operator==(const RocmDeviceOccupancyParams& a,
+                         const RocmDeviceOccupancyParams& b) noexcept {
+    return std::tie(a.arch_vgpr_count, a.accum_vgpr_count, a.sgpr_count,
+                    a.block_size, a.smem_bytes, a.gfx_target_version) ==
+           std::tie(b.arch_vgpr_count, b.accum_vgpr_count, b.sgpr_count,
+                    b.block_size, b.smem_bytes, b.gfx_target_version);
+  }
+
+  friend bool operator!=(const RocmDeviceOccupancyParams& a,
+                         const RocmDeviceOccupancyParams& b) noexcept {
+    return !(a == b);
+  }
+
+  template <typename H>
+  friend H AbslHashValue(H h, const RocmDeviceOccupancyParams& p) {
+    return H::combine(std::move(h), p.arch_vgpr_count, p.accum_vgpr_count,
+                      p.sgpr_count, p.block_size, p.smem_bytes,
+                      p.gfx_target_version);
+  }
+};
+
+// CONSUMERS. There are none in production yet: this library has exactly one
+// caller in the tree, rocm_occupancy_test.cc, and the collector wiring lands
+// in the follow-up change. `limiter` in particular costs ~30 lines of the
+// subtlest reasoning in the .cc and is here because it is the number an
+// engineer can act on. If the wiring is abandoned, delete the attribution
+// block rather than leaving it to rot untested against a real consumer.
+struct OccupancyStats {
+  // Percent of THREADS per CU: active_blocks * block_size * 100 /
+  // (max_waves_per_cu * wave_front_size). Matches CUPTI exactly.
+  double occupancy_pct = 0.0;
+  // Waves resident per SIMD (== per EU). The unit LLVM's evaluateOccupancy and
+  // -Rpass-analysis=kernel-resource-usage report.
+  double waves_per_simd = 0.0;
+  uint32_t active_waves_per_cu = 0;
+  uint32_t active_blocks_per_cu = 0;
+  OccupancyLimiter limiter = OccupancyLimiter::kNone;
+  uint32_t total_vgprs = 0;  // what LLVM calls NumVGPRs: the unified charge
+  // Blocks needed to fill the whole DEVICE at this occupancy:
+  // active_blocks_per_cu * cu_count. 0 if cu_count was unknown.
+  //
+  // Same units as CUDA's min_grid_size but NOT the same quantity.
+  // cudaOccupancyMaxPotentialBlockSize reports the grid needed at the block
+  // size it *suggests*, which is a tuning hint independent of the launch; this
+  // is the grid needed at the block size actually launched. For a
+  // low-occupancy MFMA kernel the CUDA number is large and this one is small.
+  // A caller wiring this into the shared kOccupancyMinGridSize stat is
+  // changing what that stat means on ROCm, and should say so.
+  uint32_t min_grid_size = 0;
+  // Propagated from AmdGpuTargetConstants::exact. False means the target was
+  // not in the table and the generic gfx9 fallback supplied the constants, so
+  // every number above is an estimate that can be wrong in EITHER direction --
+  // the fallback raises max_waves_per_simd (8 -> 10) while lowering
+  // total_vgprs (512 -> 256), so which way it moves depends on the kernel.
+  //
+  // A consumer that renders an estimate identically to a measurement is
+  // lying by omission. Either mark it in the UI or drop the row; do not
+  // silently average the two together.
+  bool exact = true;
+};
+
+// Pure function, no device access.
+//
+// nullopt means "cannot model" -- an unrecognised target, a missing block
+// size, no register data at all, input the version-skew guard rejects, or a
+// geometry the hardware could not have made resident (a workgroup that needs
+// more wave slots or more registers than a CU has). The caller must then emit
+// no occupancy stats, NOT zero ones.
+std::optional<OccupancyStats> GetOccupancy(
+    const RocmDeviceOccupancyParams& params, uint32_t cu_count);
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_OCCUPANCY_H_

--- a/xla/backends/profiler/gpu/rocm_occupancy_test.cc
+++ b/xla/backends/profiler/gpu/rocm_occupancy_test.cc
@@ -1,0 +1,582 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Deviceless tests for the theoretical-occupancy model.
+//
+// This file has no ROCm dependency at all, by design: it runs in CPU CI on
+// every platform. That is the only way this arithmetic gets continuous
+// protection, since the collector it used to live in cannot be built without
+// a ROCm toolchain.
+//
+// The golden table below is the load-bearing test. Its expectations come from
+// EXTERNAL oracles, not from restating the implementation's own arithmetic:
+//   H = measured with hipOccupancyMaxActiveBlocksPerMultiprocessor on a live
+//       MI300X.
+//   S = derived from the LLVM source functions this model ports
+//       (AMDGPUBaseInfo.cpp / AMDGPUSubtarget.cpp / AMDGPUTargetParser.cpp).
+//
+// Do not regenerate these numbers from the code under test, and do not use
+// llc's "; Occupancy:" comment as an oracle for the LDS or workgroup terms --
+// the local /opt/rocm/llvm applies no LDS granule at all, and the asm printer
+// rounds up across EUs. Both traps are documented at GetOccupancy().
+
+#include "xla/backends/profiler/gpu/rocm_occupancy.h"
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+#include <gtest/gtest.h>
+#include "absl/strings/str_cat.h"
+
+namespace xla {
+namespace profiler {
+namespace {
+
+constexpr uint32_t kGfx90a = 90010;
+constexpr uint32_t kGfx942 = 90402;
+constexpr uint32_t kGfx950 = 90500;
+
+RocmDeviceOccupancyParams MakeParams(uint32_t gfx, uint32_t arch,
+                                     uint32_t accum, uint32_t sgpr,
+                                     uint32_t block, uint32_t smem) {
+  RocmDeviceOccupancyParams p;
+  p.gfx_target_version = gfx;
+  p.arch_vgpr_count = arch;
+  p.accum_vgpr_count = accum;
+  p.sgpr_count = sgpr;
+  p.block_size = block;
+  p.smem_bytes = smem;
+  return p;
+}
+
+// ===========================================================================
+// The golden table
+// ===========================================================================
+
+struct GoldenRow {
+  const char* name;
+  uint32_t gfx;
+  uint32_t arch_vgpr;
+  uint32_t accum_vgpr;
+  uint32_t sgpr;
+  uint32_t block;
+  uint32_t smem;
+  double expected_pct;
+  OccupancyLimiter expected_limiter;
+  const char* what_it_pins;
+};
+
+const GoldenRow kGoldenTable[] = {
+    // --- The row that would have caught the CRITICAL bug on day one. An MFMA
+    // kernel with 5 arch VGPRs and 128 AGPRs: charging arch only reports
+    // 100%, the hardware truth measured on MI300X is 37.5%. alignTo(5,4)+128
+    // = 136 -> alignTo(136,8) = 136 -> 512/136 = 3 waves/SIMD.
+    {"mfma_agpr", kGfx942, 5, 128, 16, 256, 0, 37.5, OccupancyLimiter::kVGPR,
+     "AGPRs excluded from the unified VGPR file (reports 100% before the fix)"},
+    {"mfma_balanced", kGfx942, 128, 128, 16, 256, 0, 25.0,
+     OccupancyLimiter::kVGPR, "same defect, 2x overstatement"},
+    {"flash_attn", kGfx942, 168, 248, 16, 256, 0, 12.5, OccupancyLimiter::kVGPR,
+     "same defect, 3x overstatement"},
+
+    // --- Workgroup quantization. Hardware cannot resident a partial
+    // workgroup; a 320-thread block is 5 waves, and only 6 such blocks fit in
+    // 32 slots, leaving 2 slots idle. Measured on MI300X at 6 blocks/CU.
+    {"wg320", kGfx942, 4, 0, 14, 320, 0, 93.75, OccupancyLimiter::kWorkgroup,
+     "no workgroup quantization (reports 100% before the fix)"},
+    {"wg768", kGfx942, 4, 0, 14, 768, 0, 75.0, OccupancyLimiter::kWorkgroup,
+     "same defect at a larger block size"},
+
+    // --- The register bound must be re-quantized to whole workgroups too.
+    // 176 VGPRs gives 2 waves/SIMD = 8 slots, but a 384-thread block needs 6
+    // waves, so exactly one block fits and 2 slots go unused.
+    {"vgpr_wg_quant", kGfx942, 176, 0, 16, 384, 0, 18.75,
+     OccupancyLimiter::kVGPR,
+     "VGPR budget not rounded down to whole workgroups (reports 25%)"},
+
+    // --- VGPR allocation granule. 100 arch VGPRs are charged as 104.
+    {"granule100", kGfx942, 100, 0, 16, 256, 0, 50.0, OccupancyLimiter::kVGPR,
+     "missing alignTo(NumVGPRs, 8) (reports 62.5%)"},
+
+    // --- LDS allocation granule. alignTo(13000, 512) = 13312, and
+    // 65536/13312 = 4 workgroups, not the 5 an unrounded divide gives.
+    {"lds_unaligned", kGfx942, 4, 0, 14, 256, 13000, 50.0,
+     OccupancyLimiter::kLDS, "missing alignTo(LDS, granule) (reports 62.5%)"},
+    {"lds32k", kGfx942, 3, 0, 9, 256, 32768, 25.0, OccupancyLimiter::kLDS,
+     "LDS baseline, measured"},
+
+    // --- The best cross-architecture assertion available without MI355
+    // silicon: identical inputs, 4x the answer, because gfx950's LDS pool is
+    // 160 KiB rather than 64 KiB.
+    {"lds40k_gfx942", kGfx942, 3, 0, 9, 256, 40960, 12.5,
+     OccupancyLimiter::kLDS, "gfx942 LDS pool size"},
+    {"lds40k_gfx950", kGfx950, 3, 0, 9, 256, 40960, 50.0,
+     OccupancyLimiter::kLDS,
+     "gfx950 LDS pool size, same input as the row above"},
+    // Note 50.0 and not 62.5. alignTo(32768, 1280) = 33280 and
+    // 163840/33280 = 4. The 62.5% figure is 163840/32768 = 5, the
+    // un-granulated answer -- which is exactly what the local /opt/rocm/llvm
+    // oracle produces, and exactly why that oracle is invalid for this term.
+    {"lds32k_gfx950", kGfx950, 3, 0, 9, 256, 32768, 50.0,
+     OccupancyLimiter::kLDS, "gfx950's 1280-byte LDS granule"},
+
+    // --- The SGPR term is live on gfx9 (isSGPROccupancyLimited is Major < 10).
+    // alignTo(112,16) = 112, and 800/112 = 7 waves/SIMD.
+    {"sgpr112", kGfx942, 4, 0, 112, 256, 0, 87.5, OccupancyLimiter::kSGPR,
+     "missing SGPR bound (reports 100%)"},
+
+    // --- The SGPR granule, and the only window where the closed form and
+    // LLVM's retired step table disagree once clamped to 8 waves. 97 and 100
+    // SGPRs both round up to a 112-register per-wave budget, so both cost a
+    // wave; the step table returned 8 for anything <= 100 and reported 100%.
+    // These two rows are the regression guard for that revert.
+    // (S: LLVM AMDGPUBaseInfo.cpp getOccupancyWithNumSGPRs, closed form.)
+    {"sgpr96_boundary", kGfx942, 4, 0, 96, 256, 0, 100.0,
+     OccupancyLimiter::kNone, "the last SGPR count that does not bind"},
+    {"sgpr97_granule", kGfx942, 4, 0, 97, 256, 0, 87.5, OccupancyLimiter::kSGPR,
+     "SGPR step table instead of alignTo (reports 100%)"},
+    {"sgpr100_granule", kGfx942, 4, 0, 100, 256, 0, 87.5,
+     OccupancyLimiter::kSGPR, "the step table's <=100 boundary (reports 100%)"},
+
+    // --- Guards against someone adding a barrier term that binds. One-wave
+    // workgroups get the full 32 slots; getMaxWorkGroupsPerCU returns MaxWaves
+    // rather than 16 in that case.
+    {"wg64_full", kGfx942, 4, 0, 14, 64, 0, 100.0, OccupancyLimiter::kNone,
+     "the 16-workgroup barrier cap must not bind on CDNA"},
+
+    // --- LDS larger than a CU has. LLVM's contract is one workgroup, not
+    // zero; the pre-fix code returned empty stats and emitted nothing.
+    {"lds_over_cap", kGfx942, 4, 0, 14, 256, 81920, 12.5,
+     OccupancyLimiter::kLDS, "smem > LDS capacity returned {} before the fix"},
+
+    // --- gfx90a shares every constant with gfx942, so this row is really an
+    // assertion about the 90010 encoding: the step renders as hex in the
+    // agent *name* only, so gfx90a is 90010 and must not fall through to the
+    // inexact generic branch.
+    {"mfma_agpr_gfx90a", kGfx90a, 5, 128, 16, 256, 0, 37.5,
+     OccupancyLimiter::kVGPR, "the gfx90a target-version encoding"},
+
+    // --- A block size that is not a multiple of the wavefront. 100 threads
+    // occupy 2 whole waves, so 16 workgroups fill all 32 slots: the limiter is
+    // correctly kNone (no resource is short), yet occupancy_pct is 78.125,
+    // not 100. That pairing looks contradictory and is not -- occupancy_pct
+    // counts THREADS per CU (CUPTI's definition, see the UNITS note in the
+    // header), and 28 of every 128 thread slots are idle inside the partial
+    // wave. The deficit is intra-wave waste, which no amount of resource
+    // tuning recovers; only a block size that is a multiple of 64 does.
+    // Every other row here uses a multiple of 64, so without this one the
+    // interaction between partial waves and limiter attribution is untested.
+    {"partial_wave", kGfx942, 4, 0, 14, 100, 0, 78.125, OccupancyLimiter::kNone,
+     "partial-wave thread waste, which the limiter cannot express"},
+
+    // --- Two rows that caught bugs in the version-skew guard and limiter
+    // tie-break, both confirmed against LLVM's tables (S oracle).
+    //
+    // The version-skew guard checks (vgprs % arch_vgpr_granule != 0), where
+    // vgprs = AlignTo(arch, arch_vgpr_granule) + accum. arch=4, accum=8 gives
+    // unified=12, which is a multiple of arch_vgpr_granule=4 (valid SDK data)
+    // but NOT a multiple of vgpr_granule=8. The old guard tested %vgpr_granule
+    // and returned nullopt for this kernel; the hardware executes it at 100%
+    // occupancy (AlignTo(12,8)=16 VGPRs charged, 512/16=32 waves -> capped at
+    // 8 = max_waves_per_simd). (H: measured on MI300X.)
+    {"mfma_agpr_guard_gfx942", kGfx942, 4, 8, 32, 256, 0, 100.0,
+     OccupancyLimiter::kNone,
+     "version-skew guard false-positive on valid MFMA kernel"},
+
+    // Limiter tie: occ_sgpr = 800/AlignTo(101,16) = 800/112 = 7 waves/SIMD and
+    // occ_vgpr = 512/AlignTo(65,8) = 512/72 = 7 waves/SIMD both bind at 7 wgs
+    // for a 256-thread block (4 waves/wg, 7*4/4=7). Attribution must go to
+    // SGPRs, which is both the first check and the more actionable one: 101
+    // SGPRs is 11 past the 96-register budget that would have kept 8 waves,
+    // whereas the VGPR side has far more headroom to explore.
+    // (S: LLVM AMDGPUBaseInfo getOccupancyWithNumSGPRs.)
+    {"sgpr_vgpr_tie_gfx942", kGfx942, 65, 0, 101, 256, 0, 87.5,
+     OccupancyLimiter::kSGPR,
+     "SGPR/VGPR tie-break: SGPR binds first and must win"},
+};
+
+TEST(RocmOccupancyGoldenTest, AllRows) {
+  for (const GoldenRow& row : kGoldenTable) {
+    SCOPED_TRACE(absl::StrCat(row.name, " pins: ", row.what_it_pins));
+    std::optional<OccupancyStats> occ =
+        GetOccupancy(MakeParams(row.gfx, row.arch_vgpr, row.accum_vgpr,
+                                row.sgpr, row.block, row.smem),
+                     /*cu_count=*/304);
+    ASSERT_TRUE(occ.has_value());
+    EXPECT_DOUBLE_EQ(occ->occupancy_pct, row.expected_pct);
+    EXPECT_EQ(occ->limiter, row.expected_limiter)
+        << "got " << OccupancyLimiterName(occ->limiter) << ", want "
+        << OccupancyLimiterName(row.expected_limiter);
+  }
+}
+
+// Cross-checks the derived fields against the golden percentage, which comes
+// from an external oracle. Deliberately NOT `waves_per_simd * 4 ==
+// active_waves_per_cu` and friends: those restate the implementation's own
+// definitions and hold for any value, including a wrong one.
+TEST(RocmOccupancyGoldenTest, DerivedFieldsAgreeWithGoldenPercent) {
+  for (const GoldenRow& row : kGoldenTable) {
+    SCOPED_TRACE(row.name);
+    std::optional<OccupancyStats> occ =
+        GetOccupancy(MakeParams(row.gfx, row.arch_vgpr, row.accum_vgpr,
+                                row.sgpr, row.block, row.smem),
+                     /*cu_count=*/304);
+    ASSERT_TRUE(occ.has_value());
+    // Threads resident per CU implied by the oracle percentage, converted to
+    // blocks and waves independently of how the model got there.
+    const double threads_per_cu = row.expected_pct / 100.0 * 32 * 64;
+    EXPECT_EQ(occ->active_blocks_per_cu,
+              static_cast<uint32_t>(threads_per_cu / row.block))
+        << "blocks/CU disagrees with the golden percentage";
+    EXPECT_DOUBLE_EQ(occ->waves_per_simd,
+                     std::ceil(static_cast<double>(row.block) / 64) *
+                         occ->active_blocks_per_cu / 4);
+    EXPECT_EQ(occ->min_grid_size, occ->active_blocks_per_cu * 304);
+  }
+}
+
+TEST(RocmOccupancyGoldenTest, DerivedFieldsAreInRange) {
+  for (const GoldenRow& row : kGoldenTable) {
+    SCOPED_TRACE(row.name);
+    std::optional<OccupancyStats> occ =
+        GetOccupancy(MakeParams(row.gfx, row.arch_vgpr, row.accum_vgpr,
+                                row.sgpr, row.block, row.smem),
+                     /*cu_count=*/304);
+    ASSERT_TRUE(occ.has_value());
+    // All three golden targets are 4 SIMDs/CU, 8 waves/SIMD, 64-wide waves.
+    EXPECT_DOUBLE_EQ(occ->waves_per_simd * 4,
+                     static_cast<double>(occ->active_waves_per_cu));
+    EXPECT_LE(occ->active_waves_per_cu, 32u);
+    EXPECT_GE(occ->active_blocks_per_cu, 1u);
+    EXPECT_EQ(occ->min_grid_size, occ->active_blocks_per_cu * 304);
+    EXPECT_GT(occ->occupancy_pct, 0.0);
+    EXPECT_LE(occ->occupancy_pct, 100.0);
+  }
+}
+
+// ===========================================================================
+// Graceful degradation -- nullopt must mean "emit nothing", never zero
+// ===========================================================================
+
+TEST(RocmOccupancyTest, UnknownTargetReturnsNullopt) {
+  // gfx1100. Wave32, a 1536-entry VGPR file and different granules; we have
+  // no validated constants, so the caller must emit no occupancy at all.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(110000, 40, 0, 20, 256, 0), 304).has_value());
+  EXPECT_FALSE(LookupTargetConstants(110000).has_value());
+  EXPECT_FALSE(LookupTargetConstants(100300).has_value());
+  EXPECT_FALSE(LookupTargetConstants(120000).has_value());
+  EXPECT_FALSE(LookupTargetConstants(0).has_value());
+}
+
+TEST(RocmOccupancyTest, UnknownGfx9DegradesInexactly) {
+  // gfx906 (MI50). Not in the table, but still gfx9: fall back to the
+  // pre-GFX90A LLVM values, which under-report rather than over-report.
+  std::optional<AmdGpuTargetConstants> tc = LookupTargetConstants(90600);
+  ASSERT_TRUE(tc.has_value());
+  EXPECT_FALSE(tc->exact);
+  EXPECT_FALSE(tc->unified_vgpr_file);
+  EXPECT_EQ(tc->total_vgprs, 256u);
+  EXPECT_EQ(tc->vgpr_granule, 4u);
+  EXPECT_EQ(tc->max_waves_per_simd, 10u);
+  // SGPR constants are unchanged by the fallback -- LLVM's getTotalNumSGPRs
+  // and getSGPRAllocGranule key off IsaVersion.Major, which is still 9.
+  EXPECT_EQ(tc->total_sgprs, 800u);
+  EXPECT_EQ(tc->sgpr_granule, 16u);
+}
+
+// `exact` has to reach the caller, not just sit in the constants table: the
+// LOG_FIRST_N warning fires once per process and a dashboard user never sees
+// it. Without this, an estimate renders identically to a measurement.
+TEST(RocmOccupancyTest, ExactnessIsPropagatedToStats) {
+  std::optional<OccupancyStats> known =
+      GetOccupancy(MakeParams(kGfx942, 5, 128, 16, 256, 0), 304);
+  ASSERT_TRUE(known.has_value());
+  EXPECT_TRUE(known->exact);
+
+  // gfx906 is gfx9 but not in the table, so the generic fallback supplies
+  // constants that can be wrong in either direction.
+  std::optional<OccupancyStats> guessed =
+      GetOccupancy(MakeParams(/*gfx=*/90600, 4, 0, 32, 256, 0), 60);
+  ASSERT_TRUE(guessed.has_value());
+  EXPECT_FALSE(guessed->exact);
+}
+
+// A workgroup whose registers cannot fit in a CU is not a launch the hardware
+// would have accepted. Before this was a nullopt the bound floored to one
+// workgroup and reported a confident 50% for it.
+TEST(RocmOccupancyTest, RegisterInfeasibleGeometryReturnsNullopt) {
+  // gfx942, 240 VGPRs, 1024 threads: 16 waves over 4 SIMDs is 4 waves/SIMD,
+  // 4 * 240 = 960 VGPRs against a 512-entry file.
+  EXPECT_FALSE(GetOccupancy(MakeParams(kGfx942, /*arch=*/240, /*accum=*/0,
+                                       /*sgpr=*/32, /*block=*/1024,
+                                       /*smem=*/0),
+                            /*cu_count=*/304)
+                   .has_value());
+  // One VGPR less per wave is feasible, so the guard is not simply rejecting
+  // every large block.
+  EXPECT_TRUE(GetOccupancy(MakeParams(kGfx942, /*arch=*/128, /*accum=*/0,
+                                      /*sgpr=*/32, /*block=*/1024, /*smem=*/0),
+                           /*cu_count=*/304)
+                  .has_value());
+}
+
+// getOccupancyWithNumSGPRs is a division against the granulated per-wave
+// budget, not a step table: clamp(800 / alignTo(sgprs, 16), 1, MaxWaves).
+//
+// This test previously pinned LLVM's pre-2026 step table and asserted
+// pct(100) == 100.0. Upstream replaced that table because it ignored the
+// allocation granule and disagreed with getMaxNumSGPRs; the LLVM revision XLA
+// pins carries the closed form. The behaviour change is confined to the
+// 97..100 window -- everywhere else the two agree once clamped to 8 waves --
+// so of the rows below only sgpr(97) and sgpr(100) move.
+//
+// (S: LLVM AMDGPUBaseInfo.cpp getOccupancyWithNumSGPRs.)
+TEST(RocmOccupancyTest, SgprClosedFormBoundaries) {
+  auto pct = [](uint32_t sgpr) {
+    std::optional<OccupancyStats> o =
+        GetOccupancy(MakeParams(kGfx942, /*arch=*/4, /*accum=*/0, sgpr,
+                                /*block=*/256, /*smem=*/0),
+                     /*cu_count=*/304);
+    return o.has_value() ? o->occupancy_pct : -1.0;
+  };
+  // 800/80 = 10, clamped to the 8-wave ceiling: SGPRs do not bind.
+  EXPECT_DOUBLE_EQ(pct(80), 100.0) << "80 SGPRs is exactly 8 waves' budget";
+  // alignTo(96,16) = 96 and 800/96 = 8: still exactly at the ceiling.
+  EXPECT_DOUBLE_EQ(pct(96), 100.0) << "96 SGPRs is the last non-binding value";
+  // One SGPR past the granule boundary costs a whole wave: alignTo(97,16)=112.
+  // The step table returned 8 here, which is the entire behaviour change.
+  EXPECT_DOUBLE_EQ(pct(97), 87.5) << "97 SGPRs rounds up to 112 -> 7 waves";
+  EXPECT_DOUBLE_EQ(pct(100), 87.5) << "still inside the 112-SGPR granule";
+  EXPECT_DOUBLE_EQ(pct(112), 87.5) << "112 SGPRs is exactly 7 waves' budget";
+  // alignTo(113,16) = 128 and 800/128 = 6.
+  EXPECT_DOUBLE_EQ(pct(113), 75.0) << "past 112 the next wave goes too";
+}
+
+// The generic gfx9 fallback keeps LLVM's SGPR constants (800/16) but raises
+// max_waves_per_simd to 10, which un-clamps the 81..88 window the CDNA rows
+// above cannot reach: alignTo(88,16) = 96 and 800/96 = 8, where the old step
+// table said 9.
+TEST(RocmOccupancyTest, SgprClosedFormOnGenericGfx9) {
+  // gfx906, 64-thread blocks: 1 wave/wg, so waves and workgroups are 1:1 and
+  // the SGPR bound is visible undiluted by quantization.
+  auto waves = [](uint32_t sgpr) {
+    std::optional<OccupancyStats> o =
+        GetOccupancy(MakeParams(/*gfx=*/90600, /*arch=*/4, /*accum=*/0, sgpr,
+                                /*block=*/64, /*smem=*/0),
+                     /*cu_count=*/60);
+    return o.has_value() ? o->waves_per_simd : -1.0;
+  };
+  EXPECT_DOUBLE_EQ(waves(80), 10.0) << "800/80 = 10, the fallback ceiling";
+  EXPECT_DOUBLE_EQ(waves(88), 8.0) << "alignTo(88,16)=96 -> 8; table said 9";
+}
+
+// The generic gfx9 fallback has different constants in every dimension
+// (10 waves/SIMD, 256 VGPRs, non-unified file), and it is the only path on
+// which the barrier cap can bind. Nothing exercised it end to end.
+TEST(RocmOccupancyTest, GenericGfx9FallbackComputesAndCanHitBarrierCap) {
+  // gfx906, 128-thread blocks: 2 waves/wg, 40 slots -> 20 workgroups by slots,
+  // but max_barriers caps concurrent workgroups per CU at 16.
+  std::optional<OccupancyStats> occ =
+      GetOccupancy(MakeParams(/*gfx=*/90600, /*arch=*/4, /*accum=*/0,
+                              /*sgpr=*/32, /*block=*/128, /*smem=*/0),
+                   /*cu_count=*/60);
+  ASSERT_TRUE(occ.has_value());
+  EXPECT_EQ(occ->active_blocks_per_cu, 16u);
+  EXPECT_EQ(occ->limiter, OccupancyLimiter::kBarrier)
+      << "got " << OccupancyLimiterName(occ->limiter);
+  EXPECT_EQ(occ->min_grid_size, 16u * 60);
+  // Non-unified file: arch and accum are max()'d, not summed.
+  EXPECT_EQ(occ->total_vgprs, 4u);
+}
+
+TEST(RocmOccupancyTest, MissingInputsReturnNullopt) {
+  // No symbol data at all -- the code-object lookup missed. Zero is a wrong
+  // answer here, not a conservative one.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(kGfx942, 0, 0, 16, 256, 0), 304).has_value());
+  // No block size.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(kGfx942, 64, 0, 16, 0, 0), 304).has_value());
+  // A workgroup larger than a CU's entire wave-slot budget is not a geometry
+  // the hardware would have accepted.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(kGfx942, 64, 0, 16, 4096, 0), 304).has_value());
+}
+
+TEST(RocmOccupancyTest, UnknownCuCountLeavesMinGridSizeZero) {
+  std::optional<OccupancyStats> occ =
+      GetOccupancy(MakeParams(kGfx942, 5, 128, 16, 256, 0), /*cu_count=*/0);
+  ASSERT_TRUE(occ.has_value());
+  EXPECT_EQ(occ->min_grid_size, 0u);
+  EXPECT_DOUBLE_EQ(occ->occupancy_pct, 37.5);
+}
+
+// ===========================================================================
+// UnifiedVgprCount -- the gfx908 trap
+// ===========================================================================
+
+TEST(RocmOccupancyTest, UnifiedVgprCountSumsOnUnifiedTargets) {
+  const AmdGpuTargetConstants tc = *LookupTargetConstants(kGfx942);
+  // alignTo(5,4) + 128. This is the CRITICAL fix in one expression.
+  EXPECT_EQ(UnifiedVgprCount(tc, 5, 128), 136u);
+  EXPECT_EQ(UnifiedVgprCount(tc, 128, 128), 256u);
+  EXPECT_EQ(UnifiedVgprCount(tc, 168, 248), 416u);
+  // accum == 0 must take the max() branch, not add zero to a rounded-up arch.
+  EXPECT_EQ(UnifiedVgprCount(tc, 100, 0), 100u);
+}
+
+TEST(RocmOccupancyTest, UnifiedVgprCountDoesNotDoubleCountNonUnified) {
+  // On gfx908 the SDK's accum_vgpr_count() returns arch_vgpr_count(), so an
+  // unconditional sum reports exactly 2x. The generic gfx9 fallback is
+  // non-unified, so max() protects us.
+  const AmdGpuTargetConstants tc = *LookupTargetConstants(90800);
+  ASSERT_FALSE(tc.unified_vgpr_file);
+  EXPECT_EQ(UnifiedVgprCount(tc, 128, 128), 128u);
+}
+
+// ===========================================================================
+// Version-skew guard
+// ===========================================================================
+
+// On a unified-file target the hardware allocation is a multiple of the
+// 8-register granule. A sum that is not one means the installed SDK decoded
+// the code object with a scheme we do not recognise, and correct arithmetic
+// on wrong input is still wrong.
+TEST(RocmOccupancyTest, NonGranulatedUnifiedCountIsSuppressed) {
+  // alignTo(4,4) + 1 = 5, not a multiple of 8.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(kGfx942, 4, 1, 16, 256, 0), 304).has_value());
+}
+
+// ...but the guard must NOT fire on the max() branch. arch counts are
+// granulated to 4, not 8, so ordinary low-register kernels reach it with an
+// odd multiple of 4 and must still be modelled. This is the case that makes
+// wg320, granule100 and every other accum-free row work.
+TEST(RocmOccupancyTest, GuardDoesNotFireWithoutAgprs) {
+  for (uint32_t arch : {4u, 12u, 20u, 36u, 100u, 172u}) {
+    SCOPED_TRACE(absl::StrCat("arch_vgpr_count=", arch));
+    EXPECT_TRUE(GetOccupancy(MakeParams(kGfx942, arch, 0, 16, 256, 0), 304)
+                    .has_value());
+  }
+}
+
+// ===========================================================================
+// Degenerate input
+//
+// The version-skew guard exists because the SDK is known to hand back register
+// counts we cannot decode. That makes "garbage in" a real path, not a
+// hypothetical one, and the model must degrade rather than crash: it runs
+// inside the profiled process, so a SIGFPE here takes down the user's training
+// job. These rows pin the saturating arithmetic in AlignTo/SaturatingAdd.
+// ===========================================================================
+
+TEST(RocmOccupancyTest, HugeRegisterCountsDoNotCrashOrOverReport) {
+  constexpr uint32_t kMax = std::numeric_limits<uint32_t>::max();
+
+  // Wrapping AlignTo(kMax, 8) == 0 divided by zero in the VGPR bound. The
+  // accum=0 path takes max(), so the skew guard does not intercept it.
+  std::optional<OccupancyStats> vgpr =
+      GetOccupancy(MakeParams(kGfx942, kMax, 0, 16, 256, 0), 304);
+  ASSERT_TRUE(vgpr.has_value());
+  EXPECT_EQ(vgpr->active_blocks_per_cu, 1u)
+      << "an impossible register demand must floor at one workgroup";
+
+  // The sum branch saturates, and kMax % 8 != 0, so the skew guard rejects it
+  // outright -- the stronger of the two outcomes.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(kGfx942, kMax, 1, 16, 256, 0), 304).has_value());
+
+  // Wrapping AlignTo in the LDS bound made lds_per_wg 0, which read as "LDS
+  // never binds" and reported 100%. It must read as "LDS always binds".
+  std::optional<OccupancyStats> lds =
+      GetOccupancy(MakeParams(kGfx942, 4, 0, 16, 256, kMax - 255), 304);
+  ASSERT_TRUE(lds.has_value());
+  EXPECT_EQ(lds->active_blocks_per_cu, 1u);
+  EXPECT_EQ(lds->limiter, OccupancyLimiter::kLDS);
+  EXPECT_LT(lds->occupancy_pct, 100.0)
+      << "an impossible LDS demand must not report full occupancy";
+}
+
+// ===========================================================================
+// Target constants
+// ===========================================================================
+
+TEST(RocmOccupancyTest, TargetConstantsMatchLlvm) {
+  const AmdGpuTargetConstants gfx942 = *LookupTargetConstants(kGfx942);
+  EXPECT_TRUE(gfx942.exact);
+  EXPECT_TRUE(gfx942.unified_vgpr_file);
+  EXPECT_TRUE(gfx942.sgpr_limited);  // IsaVersion.Major < 10
+  EXPECT_EQ(gfx942.max_waves_per_simd, 8u);
+  EXPECT_EQ(gfx942.simd_per_cu, 4u);
+  EXPECT_EQ(gfx942.wave_front_size, 64u);
+  EXPECT_EQ(gfx942.total_vgprs, 512u);
+  EXPECT_EQ(gfx942.vgpr_granule, 8u);
+  EXPECT_EQ(gfx942.arch_vgpr_granule, 4u);
+  EXPECT_EQ(gfx942.lds_per_cu, 65536u);
+  EXPECT_EQ(gfx942.lds_granule, 512u);
+
+  // gfx950 differs from gfx942 in exactly two constants.
+  const AmdGpuTargetConstants gfx950 = *LookupTargetConstants(kGfx950);
+  EXPECT_TRUE(gfx950.exact);
+  EXPECT_EQ(gfx950.lds_per_cu, 163840u);
+  EXPECT_EQ(gfx950.lds_granule, 1280u);
+  EXPECT_EQ(gfx950.total_vgprs, gfx942.total_vgprs);
+  EXPECT_EQ(gfx950.max_waves_per_simd, gfx942.max_waves_per_simd);
+
+  // gfx90a: 90010, decimal decode, step 10.
+  const AmdGpuTargetConstants gfx90a = *LookupTargetConstants(kGfx90a);
+  EXPECT_TRUE(gfx90a.exact);
+  EXPECT_EQ(gfx90a.lds_per_cu, 65536u);
+  EXPECT_EQ(gfx90a.lds_granule, 512u);
+}
+
+TEST(RocmOccupancyTest, LimiterNamesAreStable) {
+  // No production caller emits these yet -- see the CONSUMERS note on
+  // OccupancyStats. They are pinned here so that the follow-up surfacing
+  // `limiter` as an XStat inherits a stable vocabulary rather than inventing
+  // one, and so a rename shows up as a test change rather than silently
+  // becoming a user-visible string later.
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kNone), "none");
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kVGPR), "vgpr");
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kLDS), "lds");
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kSGPR), "sgpr");
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kWorkgroup), "workgroup");
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kBarrier), "barrier");
+}
+
+// ===========================================================================
+// Cache key
+// ===========================================================================
+
+TEST(RocmOccupancyTest, ParamsCacheKeyDiscriminatesEveryField) {
+  const RocmDeviceOccupancyParams base =
+      MakeParams(kGfx942, 5, 128, 16, 256, 0);
+  EXPECT_EQ(base, MakeParams(kGfx942, 5, 128, 16, 256, 0));
+
+  EXPECT_NE(base, MakeParams(kGfx942, 6, 128, 16, 256, 0));
+  EXPECT_NE(base, MakeParams(kGfx942, 5, 129, 16, 256, 0));
+  EXPECT_NE(base, MakeParams(kGfx942, 5, 128, 17, 256, 0));
+  EXPECT_NE(base, MakeParams(kGfx942, 5, 128, 16, 512, 0));
+  EXPECT_NE(base, MakeParams(kGfx942, 5, 128, 16, 256, 1024));
+  // The field the pre-fix cache key discarded entirely, which is why the old
+  // model could not tell a gfx90a from a gfx1100.
+  EXPECT_NE(base, MakeParams(kGfx950, 5, 128, 16, 256, 0));
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace xla


### PR DESCRIPTION
This PR adds a pure-arithmetic theoretical-occupancy model for gfx9/CDNA kernels — a port of llvm/lib/Target/AMDGPU with two deliberate divergences — plus a deviceless golden test, and deletes the dead hipOccupancy-based path it replaces.

Three conclusions: 
- on NVIDIA, XLA computes nothing itself, it calls NVIDIA's header-only cudaOccMaxActiveBlocksPerMultiprocessor() and turns blocks/SM into a percentage in two lines; 
- rocprofiler-sdk supplies every per-kernel input and the device identity but structurally cannot supply the per-arch constants — VGPR file size, allocation granules, the unified-file flag — so a table keyed on gfx_target_version is the same architecture NVIDIA ships rather than a stopgap; 
- GetOccupancy() computes five resource bounds, converts the two register bounds to whole workgroups per CU, takes the minimum, and returns the binding limiter alongside a CUPTI-identical percentage. Coverage is three-tier — CDNA gfx90a/94x/95x exact, other gfx9 estimated, gfx10/11/12 silent — so on RDNA and consumer Radeon this feature reports nothing, and the follow-up must emit no stats there rather than zeroed ones. 