### PR TITLE
[ROCm] Fix ROCm library lookup in runfiles under Bazel 9

### DIFF
--- a/build_tools/rocm/parallel_gpu_execute.sh
+++ b/build_tools/rocm/parallel_gpu_execute.sh
@@ -22,13 +22,35 @@
 #     TF_GPU_COUNT = Number of GPUs available.
 
 ROCMINFO=$(find -L "${TEST_SRCDIR:-.}" -name "rocminfo" -path "*/bin/rocminfo" | head -n 1)
-TF_GPU_COUNT=$($ROCMINFO | grep "Name: *gfx*" | wc -l)
+
+# A missing rocminfo is a runfiles wiring bug, not a GPU-less host. Fail here
+# rather than falling through to the no-GPU path below, which would run the
+# test without a GPU lock and without HIP_VISIBLE_DEVICES pinning, silently
+# piling every concurrent test onto GPU 0.
+if [[ -z "$ROCMINFO" ]]; then
+    echo "ERROR: rocminfo was not found in the runfiles tree under" >&2
+    echo "       TEST_SRCDIR=${TEST_SRCDIR:-.}" >&2
+    echo "       Check that the --run_under target still depends on" >&2
+    echo "       @local_config_rocm//rocm:rocminfo." >&2
+    exit 1
+fi
+
+ROCMINFO_OUT=$("$ROCMINFO" 2>&1)
+ROCMINFO_STATUS=$?
+TF_GPU_COUNT=$(echo "$ROCMINFO_OUT" | grep "Name: *gfx*" | wc -l)
 TF_TESTS_PER_GPU=${TF_TESTS_PER_GPU:-8}
 
 # There are certain tests in xla that do not require any gpu in order to be executed
 # here we allow executing these tests on a machine without gpu support.
 # if there are no GPUs on that system e.g rbe default pool then execute the test without lock
 if [[ $TF_GPU_COUNT == 0 ]];then
+    # A pool with no GPU and a rocminfo that could not reach the driver look
+    # identical from here, so make the latter visible in the test log.
+    if [[ $ROCMINFO_STATUS -ne 0 ]]; then
+        echo "WARNING: $ROCMINFO exited with status $ROCMINFO_STATUS; treating this host" >&2
+        echo "         as having no GPU. Its output was:" >&2
+        echo "$ROCMINFO_OUT" >&2
+    fi
     echo "Execute with no GPU support"
     exec "$@"
 fi

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -127,18 +127,33 @@ cc_library(
 
 cc_library(
     name = "rocm_rpath",
+    # These RUNPATH entries are relative, so the loader resolves them against
+    # the process CWD. Two layouts have to be covered:
+    #   * build actions run with CWD = execroot/<main repo>, where external
+    #     repositories live under external/.
+    #   * tests run with CWD = <runfiles>/$TEST_WORKSPACE. Since Bazel 8
+    #     (--legacy_external_runfiles defaulting to false, and a no-op in
+    #     Bazel 9) external repositories are siblings of $TEST_WORKSPACE in
+    #     the runfiles tree rather than nested under external/.
+    # $ORIGIN is not usable here: runfiles entries are symlinks into bazel-out,
+    # and glibc expands $ORIGIN from the object's real path, which lands in the
+    # execroot rather than the runfiles tree. The loader skips RUNPATH entries
+    # whose directories do not exist, so carrying both is harmless.
     linkopts = select({
         ":build_hermetic": [
             "-Wl,-rpath,external/%{rocm_repo_name}/rocm/%{rocm_root}/lib",
+            "-Wl,-rpath,../%{rocm_repo_name}/rocm/%{rocm_root}/lib",
         ],
         ":link_only": [
         ],
         ":multiple_rocm_paths": [
             "-Wl,-rpath,external/%{rocm_repo_name}/rocm/%{rocm_root}/lib",
+            "-Wl,-rpath,../%{rocm_repo_name}/rocm/%{rocm_root}/lib",
             "-Wl,-rpath=%{rocm_lib_paths}",
         ],
         "//conditions:default": [
             "-Wl,-rpath,external/%{rocm_repo_name}/rocm/%{rocm_root}/lib",
+            "-Wl,-rpath,../%{rocm_repo_name}/rocm/%{rocm_root}/lib",
             "-Wl,-rpath,/opt/rocm/lib",
         ],
     }),


### PR DESCRIPTION
## Motivation

JAX moved to Bazel 9.2.0 and its ROCm RBE tests stopped finding the hermetic ROCm libraries. `--legacy_external_runfiles` defaulted to `false` in Bazel 8 and is a **no-op** in Bazel 9 (`bazel help flags-as-proto` reports the option as literally `"No-op"`), so `<runfiles>/$TEST_WORKSPACE/external/<repo>/` no longer exists — external repositories now appear only as siblings of `$TEST_WORKSPACE`. `rocm_rpath` emits a single CWD-relative RUNPATH entry pointing into that vanished directory, and under `:build_hermetic` it is the *only* entry, so nothing resolves `libamdhip64.so` at test time.

Builds are unaffected because the execroot always has `external/`, which is why this surfaces as a test-only failure.

## Technical Details

- `third_party/gpus/rocm/BUILD.tpl`: add a sibling-layout RUNPATH entry `../<rocm repo>/rocm/<rocm root>/lib` next to each existing `external/<rocm repo>/...` entry, covering both the execroot layout (build actions, CWD = `execroot/<main repo>`) and the runfiles layout (tests, CWD = `<runfiles>/$TEST_WORKSPACE`). The loader skips RUNPATH entries whose directories do not exist, so carrying both is harmless. `:link_only` is left empty — wheel builds supply their own `$ORIGIN`-based RPATHs.
- `$ORIGIN` is deliberately not used: runfiles entries are symlinks into `bazel-out`, and glibc expands `$ORIGIN` from the object's real path, which lands in the execroot rather than the runfiles tree.
- `build_tools/rocm/parallel_gpu_execute.sh`: a missing `rocminfo` previously set `TF_GPU_COUNT=0` and ran the test with no GPU lock and no `HIP_VISIBLE_DEVICES` pinning, piling every concurrent test onto GPU 0 and surfacing as hipBLASLt OOM flakes rather than as a missing file. It is now fatal. A `rocminfo` that runs but cannot reach the driver logs a warning and still takes the no-GPU passthrough that CPU-only RBE pools rely on.

Note this change does **not** touch XLA's own `.bazelrc`, which still sets `--legacy_external_runfiles=true`. XLA is on Bazel 8.7.0 where that flag is still live, and its comment says the Bazel 8 default "broke some tests". Removing it is a separate change for whenever XLA moves to Bazel 9.

## Test Plan

Ran JAX's ROCm single-GPU CI suite on gfx950 against the XLA pin JAX currently uses (`3abee12b`), with `--override_repository=xla=... --override_module=xla=...` so this branch is what gets built.

## Test Result

69 of 69 tests pass, exit 0, no build errors.

`ldd` from the test's actual CWD (`<test>.runfiles/_main`) confirms the added entry is the one doing the work — the pre-existing `external/...` entry and Bazel's own `$ORIGIN/../../_solib_x86_64/...` entries do not resolve, and `runfiles/_main/external` does not exist:

```
libamdhip64.so.7 => ../xla++rocm_configure_ext+local_config_rocm/rocm/rocm_dist/lib/libamdhip64.so.7
```

The loader behaviour was also reproduced in isolation: a binary linked with only `-Wl,-rpath,external/extrepo/lib` fails with `cannot open shared object file` when `external/` is absent from the CWD and succeeds when present; adding the `../extrepo/lib` entry makes it work in both layouts.