### PR TITLE
[ROCm] Replace rocm-smi CLI with amd-smi in test runner scripts

### DIFF
--- a/build_tools/rocm/run_xla.sh
+++ b/build_tools/rocm/run_xla.sh
@@ -22,12 +22,12 @@ set -e
 set -x
 
 N_BUILD_JOBS=$(grep -c ^processor /proc/cpuinfo)
-# If rocm-smi exists locally (it should) use it to find
+# If amd-smi exists locally (it should) use it to find
 # out how many GPUs we have to test with.
-rocm-smi -i
+amd-smi list
 STATUS=$?
 if [ $STATUS -ne 0 ]; then TF_GPU_COUNT=1; else
-   TF_GPU_COUNT=$(rocm-smi -i|grep 'Device ID' |grep 'GPU' |wc -l)
+   TF_GPU_COUNT=$(amd-smi list|grep -c '^GPU:')
 fi
 TF_TESTS_PER_GPU=1
 N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})

--- a/build_tools/rocm/run_xla_multi_gpu.sh
+++ b/build_tools/rocm/run_xla_multi_gpu.sh
@@ -33,12 +33,12 @@ set -e
 set -x
 
 N_BUILD_JOBS=$(grep -c ^processor /proc/cpuinfo)
-# If rocm-smi exists locally (it should) use it to find
+# If amd-smi exists locally (it should) use it to find
 # out how many GPUs we have to test with.
-rocm-smi -i
+amd-smi list
 STATUS=$?
 if [ $STATUS -ne 0 ]; then TF_GPU_COUNT=1; else
-   TF_GPU_COUNT=$(rocm-smi -i|grep 'Device ID' |grep 'GPU' |wc -l)
+   TF_GPU_COUNT=$(amd-smi list|grep -c '^GPU:')
 fi
 if [[ $TF_GPU_COUNT -lt 4 ]]; then
     echo "Found only ${TF_GPU_COUNT} gpus, multi-gpu tests need atleast 4 gpus."


### PR DESCRIPTION
## Summary
- Replace `rocm-smi -i` GPU counting with `amd-smi list` in `run_xla.sh` and `run_xla_multi_gpu.sh`.

## Scope
CLI/test-script only. Does **not** overlap with #1113 (stream-executor `librocm_smi64` → `libamd_smi` migration).

## Test plan
- [x] `amd-smi list | grep -c ^GPU:` matches GPU count on ROCm 7.14
- [x] `bash -n` on both scripts passes