### PR TITLE
[ROCm] Gate collective kernels on has_peer_visible_atomics() (v0.10.1)

### DIFF
--- a/xla/backends/gpu/runtime/all_reduce.cc
+++ b/xla/backends/gpu/runtime/all_reduce.cc
@@ -254,14 +254,23 @@ absl::Status IsAllReduceKernelSupported(
   }
   // Check if the device supports Triton collective codegen:
   // CUDA: Requires compute capability 9.0+ (Hopper or newer)
-  // ROCm: All versions with Triton support are enabled
   if (!device_info.cuda_compute_capability().IsAtLeastHopper() &&
       !device_info.gpu_compute_capability().IsRocm()) {
     return absl::UnimplementedError(absl::StrCat(
         "Triton collective codegen requires CUDA compute capability >= 9.0 "
-        "(Hopper or newer) or a ROCm device with Triton support. "
+        "(Hopper or newer) or a supported ROCm device. "
         "Got: ",
         device_info.gpu_compute_capability().ToString(), "."));
+  }
+  // ROCm: the cross-device barrier relies on a system-scope release store
+  // becoming visible to peers without extra cache maintenance, which gfx90a
+  // does not guarantee.
+  if (const auto* rocm_cc =
+          device_info.gpu_compute_capability().rocm_compute_capability();
+      rocm_cc != nullptr && !rocm_cc->has_peer_visible_atomics()) {
+    return absl::UnimplementedError(
+        absl::StrCat("Collective kernels are not supported on ",
+                     rocm_cc->gfx_version(), "."));
   }
   // TODO(b/383125489): Support variadic arguments.
   if (num_operands != 1) {

--- a/xla/stream_executor/device_description_test.cc
+++ b/xla/stream_executor/device_description_test.cc
@@ -143,6 +143,13 @@ TEST(RocmComputeCapability, Accessors) {
   EXPECT_TRUE(RocmComputeCapability{"gfx1250"}.has_tdm_support());
   EXPECT_FALSE(RocmComputeCapability{"gfx942"}.has_tdm_support());
   EXPECT_FALSE(RocmComputeCapability{"gfx1201"}.has_tdm_support());
+
+  EXPECT_TRUE(RocmComputeCapability{"gfx942"}.has_peer_visible_atomics());
+  EXPECT_TRUE(RocmComputeCapability{"gfx950"}.has_peer_visible_atomics());
+  EXPECT_FALSE(RocmComputeCapability{"gfx90a"}.has_peer_visible_atomics());
+  EXPECT_FALSE(RocmComputeCapability{"gfx908"}.has_peer_visible_atomics());
+  EXPECT_FALSE(RocmComputeCapability{"gfx1201"}.has_peer_visible_atomics());
+  EXPECT_FALSE(RocmComputeCapability{"gfx1250"}.has_peer_visible_atomics());
 }
 
 TEST(GpuComputeCapability, ProtoConversion) {

--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -188,6 +188,12 @@ class RocmComputeCapability {
     return !IsThisGfxInAnyList(kList);
   }
 
+  // Whether a system-scope release store to a peer's memory becomes visible to
+  // that peer without extra cache maintenance. gfx90a does not guarantee it.
+  // TODO(magaonka-amd): Evaluate upcoming hardware for hand-written collective
+  // kernel support and enable it accordingly.
+  bool has_peer_visible_atomics() const { return gfx9_mi300_series(); }
+
   bool has_hipblaslt() const {
     return IsThisGfxInAnyList(kMI300Series, kMI200Series, kGfx12Discrete,
                               kGfx11Discrete, kGfx11Apu) ||


### PR DESCRIPTION
This is a cherry-pick from upstream openxla/xla#48069 (commit 49ad908e1f).

📝 Summary of Changes
XLA's hand-written collective kernels (one-shot / two-shot all-reduce and all-gather) rely on the cross-device barrier's system-scope release store becoming visible to peers without extra cache maintenance. gfx90a (MI200) does not guarantee this, so the kernels hang there, taking down multi-GPU workloads and JAX CI. Add a has_peer_visible_atomics() predicate and gate both collectives on it so unsupported devices fall back to the library collective.

🎯 Justification
On MI200 these kernels hang, which takes down multi-GPU workloads and JAX CI on
those devices and added TODO to myself to evaluate upcoming HW and check the support.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
Extended RocmComputeCapability.Accessors in device_description_test.cc to
assert the predicate is true for gfx942/gfx950 and false for
gfx90a/gfx908/gfx1201.

🔀 Backport note
Two hunks of the upstream commit are intentionally omitted on this branch:

1. The all-gather collective kernel (`xla/backends/gpu/runtime/all_gather.cc`)
   does not exist here, so only the all-reduce gate is applied. The
   corresponding BUILD dependency addition is dropped with it.
2. The upstream commit also removes the fine-grained device allocation path in
   RocmExecutor as dead code. **It is not dead on this branch.**
   `MemorySpace::kP2P` is still present and still calls
   `DeviceAllocate(..., /*is_fine_grained*/ true)`. Removing it here would
   reintroduce the exact MI200 coherence bug it was written to work around, so
   the path is kept as-is. That cleanup should ride along with the kP2P removal
   whenever that is backported, not with this fix.

✅ Local Verification
Built on gfx942 with `--config=rocm`:
`//xla/backends/gpu/runtime:all_reduce`, `//xla/stream_executor/rocm:rocm_executor`
— both pass. `//xla/stream_executor:device_description_test` passes.
