### PR TITLE
[ROCm] Gate collective kernels on has_peer_visible_atomics() (v0.11.0)

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -4126,6 +4126,7 @@ cc_library(
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@llvm-project//llvm:Support",
     ],

--- a/xla/backends/gpu/runtime/all_gather.cc
+++ b/xla/backends/gpu/runtime/all_gather.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "absl/algorithm/container.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "llvm/ADT/bit.h"
@@ -84,13 +85,22 @@ absl::Status IsAllGatherKernelSupported(
   }
   // Check if the device supports Triton collective codegen:
   // CUDA: Requires compute capability 9.0+ (Hopper or newer)
-  // ROCm: All versions with Triton support are enabled
   if (!device_info.cuda_compute_capability().IsAtLeastHopper() &&
       !device_info.gpu_compute_capability().IsRocm()) {
     return absl::UnimplementedError(absl::StrFormat(
         "Triton collective codegen requires CUDA compute capability >= 9.0 "
-        "(Hopper or newer) or a ROCm device with Triton support. Got: %s.",
+        "(Hopper or newer) or a supported ROCm device. Got: %s.",
         device_info.gpu_compute_capability().ToString()));
+  }
+  // ROCm: the cross-device barrier relies on a system-scope release store
+  // becoming visible to peers without extra cache maintenance, which gfx90a
+  // does not guarantee.
+  if (const auto* rocm_cc =
+          device_info.gpu_compute_capability().rocm_compute_capability();
+      rocm_cc != nullptr && !rocm_cc->has_peer_visible_atomics()) {
+    return absl::UnimplementedError(
+        absl::StrCat("Collective kernels are not supported on ",
+                     rocm_cc->gfx_version(), "."));
   }
   // TODO(b/383125489): Support variadic arguments.
   if (num_operands != 1) {

--- a/xla/backends/gpu/runtime/all_reduce.cc
+++ b/xla/backends/gpu/runtime/all_reduce.cc
@@ -270,14 +270,23 @@ absl::Status IsAllReduceKernelSupported(
   }
   // Check if the device supports Triton collective codegen:
   // CUDA: Requires compute capability 9.0+ (Hopper or newer)
-  // ROCm: All versions with Triton support are enabled
   if (!device_info.cuda_compute_capability().IsAtLeastHopper() &&
       !device_info.gpu_compute_capability().IsRocm()) {
     return absl::UnimplementedError(absl::StrCat(
         "Triton collective codegen requires CUDA compute capability >= 9.0 "
-        "(Hopper or newer) or a ROCm device with Triton support. "
+        "(Hopper or newer) or a supported ROCm device. "
         "Got: ",
         device_info.gpu_compute_capability().ToString(), "."));
+  }
+  // ROCm: the cross-device barrier relies on a system-scope release store
+  // becoming visible to peers without extra cache maintenance, which gfx90a
+  // does not guarantee.
+  if (const auto* rocm_cc =
+          device_info.gpu_compute_capability().rocm_compute_capability();
+      rocm_cc != nullptr && !rocm_cc->has_peer_visible_atomics()) {
+    return absl::UnimplementedError(
+        absl::StrCat("Collective kernels are not supported on ",
+                     rocm_cc->gfx_version(), "."));
   }
   // TODO(b/383125489): Support variadic arguments.
   if (num_operands != 1) {

--- a/xla/stream_executor/device_description_test.cc
+++ b/xla/stream_executor/device_description_test.cc
@@ -138,6 +138,13 @@ TEST(RocmComputeCapability, Accessors) {
   EXPECT_TRUE(RocmComputeCapability{"gfx1250"}.has_tdm_support());
   EXPECT_FALSE(RocmComputeCapability{"gfx942"}.has_tdm_support());
   EXPECT_FALSE(RocmComputeCapability{"gfx1201"}.has_tdm_support());
+
+  EXPECT_TRUE(RocmComputeCapability{"gfx942"}.has_peer_visible_atomics());
+  EXPECT_TRUE(RocmComputeCapability{"gfx950"}.has_peer_visible_atomics());
+  EXPECT_FALSE(RocmComputeCapability{"gfx90a"}.has_peer_visible_atomics());
+  EXPECT_FALSE(RocmComputeCapability{"gfx908"}.has_peer_visible_atomics());
+  EXPECT_FALSE(RocmComputeCapability{"gfx1201"}.has_peer_visible_atomics());
+  EXPECT_FALSE(RocmComputeCapability{"gfx1250"}.has_peer_visible_atomics());
 }
 
 TEST(GpuComputeCapability, ProtoConversion) {

--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -181,6 +181,12 @@ class RocmComputeCapability {
     return gfx9_mi300_series() || gfx12();
   }
 
+  // Whether a system-scope release store to a peer's memory becomes visible to
+  // that peer without extra cache maintenance. gfx90a does not guarantee it.
+  // TODO(magaonka-amd): Evaluate upcoming hardware for hand-written collective
+  // kernel support and enable it accordingly.
+  bool has_peer_visible_atomics() const { return gfx9_mi300_series(); }
+
   bool has_hipblaslt() const {
     return IsThisGfxInAnyList(kMI300Series, kMI200Series, kGfx12Discrete,
                               kGfx11Discrete, kGfx11Apu) ||

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -410,24 +410,14 @@ bool GetDeviceProperties(hipDeviceProp_t* device_properties,
 }
 
 // Allocates memory on the GPU device.
-void* DeviceAllocate(Context* context, uint64_t bytes,
-                     bool is_fine_grained = false) {
+void* DeviceAllocate(Context* context, uint64_t bytes) {
   if (bytes == 0) {
     return nullptr;
   }
 
   ScopedActivateContext activated(context);
   hipDeviceptr_t device_mem = nullptr;
-  hipError_t res;
-  if (is_fine_grained) {
-    // Fine-grained memory, which has better coherence during the kernel
-    // execution. This type of memory is only used in P2P communication to solve
-    // the cache coherence issue for some archs (e.g., MI200); most of the time,
-    // you don't have to use it.
-    res = hipExtMallocWithFlags(&device_mem, bytes, hipDeviceMallocFinegrained);
-  } else {
-    res = hipMalloc(&device_mem, bytes);
-  }
+  hipError_t res = hipMalloc(&device_mem, bytes);
   if (res != hipSuccess) {
     // LOG(INFO) because this isn't always important to users (e.g. BFCAllocator
     // implements a retry if the first allocation fails).
@@ -760,9 +750,7 @@ DeviceAddressBase RocmExecutor::Allocate(uint64_t size, int64_t memory_space) {
   switch (static_cast<MemorySpace>(memory_space)) {
     case MemorySpace::kCollective:
     case MemorySpace::kDevice:
-      return DeviceAddressBase(
-          DeviceAllocate(&rocm_context_, size, /*is_fine_grained*/ false),
-          size);
+      return DeviceAddressBase(DeviceAllocate(&rocm_context_, size), size);
     case MemorySpace::kHost:
       if (auto result = HostAllocate(&rocm_context_, size); result.ok()) {
         return DeviceAddressBase(*result, size);


### PR DESCRIPTION
This is a cherry-pick from upstream openxla/xla#48069 (commit 49ad908e1f).

📝 Summary of Changes
XLA's hand-written collective kernels (one-shot / two-shot all-reduce and all-gather) rely on the cross-device barrier's system-scope release store becoming visible to peers without extra cache maintenance. gfx90a (MI200) does not guarantee this, so the kernels hang there, taking down multi-GPU workloads and JAX CI. Add a has_peer_visible_atomics() predicate and gate both collectives on it so unsupported devices fall back to the library collective.

Also drop the now-dead fine-grained device allocation path in RocmExecutor. It was the earlier workaround for this same MI200 coherence issue and became unreachable once the kP2P memory space was removed (openxla/xla#43295, openxla/xla#43310); its only remaining caller passed is_fine_grained=false.

🎯 Justification
On MI200 these kernels hang, which takes down multi-GPU workloads and JAX CI on
those devices and added TODO to myself to evaluate upcoming HW and check the support.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
Extended RocmComputeCapability.Accessors in device_description_test.cc to
assert the predicate is true for gfx942/gfx950 and false for
gfx90a/gfx908/gfx1201.

🔀 Backport note
One conflict, resolved without changing behaviour. On this branch DeviceAllocate
still returns `void*` and logs on failure, rather than the `absl::StatusOr<void*>`
it returns upstream. The fine-grained branch and the `is_fine_grained` parameter
are removed exactly as upstream does, but this branch's return convention is kept:

```c++
void* DeviceAllocate(Context* context, uint64_t bytes) { ... }
...
case MemorySpace::kDevice:
  return DeviceAddressBase(DeviceAllocate(&rocm_context_, size), size);
```

MemorySpace::kP2P is already gone on this branch, so no caller requested
fine-grained memory and the removal is safe.

✅ Local Verification
Built on gfx942 with `--config=rocm`:
`//xla/backends/gpu/runtime:all_gather`, `//xla/backends/gpu/runtime:all_reduce`,
`//xla/stream_executor/rocm:rocm_executor` — all pass.
`//xla/stream_executor:device_description_test` passes.
