### PR TITLE
[DOC] fix local-XLA build override for bzlmod

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ python build/build.py build \
   --rocm_path=/opt/rocm \
   --rocm_amdgpu_targets=gfx942 \
   --rocm_version=7 \
-  --bazel_options=--override_repository=xla=/tf/xla \
+  --bazel_options=--override_module=xla=/tf/xla \
   --bazel_options=--config=rocm_clang_hermetic \
   --bazel_startup_options="--bazelrc=build/rocm/rocm.bazelrc"
 
@@ -78,7 +78,7 @@ pip install dist/*.whl
 
 Notes:
 
-- `--bazel_options=--override_repository=xla=/tf/xla` redirects the `@xla` repository to your local checkout, replacing the upstream-pinned commit in JAX's `WORKSPACE`.
+- **Use `--override_module=xla=/tf/xla`, NOT `--override_repository=xla=...`.** Current JAX builds run under **bzlmod** (`.bazelrc` sets `--enable_bzlmod --noenable_workspace`), where XLA is a Bazel *module* whose canonical repo name is **`xla+`** (note the trailing `+`). The legacy `--override_repository=xla=...` targets a repo literally named `xla`, which does not exist under bzlmod, so it is **silently ignored** — Bazel then builds XLA from the bzlmod-pinned commit and your local checkout is never compiled.
 - Adjust `--rocm_amdgpu_targets` to match your hardware (e.g. `gfx90a`, `gfx942`, `gfx950`, `gfx1100`). Multiple targets can be passed comma-separated.
 - The `--wheels=jax,jaxlib,jax-rocm-plugin,jax-rocm-pjrt` list produces all four required wheels in `dist/`; `pip install dist/*.whl` installs the matching set.
 


### PR DESCRIPTION
Readme update: Use `--override_module=xla=<path>` instead of `--override_repository=xla=<path>`. Under bzlmod (--enable_bzlmod --noenable_workspace) XLA is the module 'xla+' so `--override_repository=xla=...` is silently ignored and the build falls back to the pinned XLA, meaning local checkouts were never compiled into the ROCm pjrt plugin.