### PR TITLE
Add rocm infra monitoring workflow

### DIFF
--- a/.github/workflows/rocm_infra_monitor.yml
+++ b/.github/workflows/rocm_infra_monitor.yml
@@ -1,0 +1,167 @@
+# Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+name: ROCm Infrastructure Error Monitor
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+on:
+  schedule:
+    # Run every hour to check failed runs from last 2 hours
+    - cron: '0 * * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/rocm_infra_monitor.yml'
+      - 'build_tools/rocm/analyze_bep_infra_errors.py'
+      - 'build_tools/rocm/monitor_bep_artifacts.sh'
+      - 'build_tools/rocm/create_infra_error_issue.sh'
+
+jobs:
+  monitor:
+    name: Monitor ROCm CI Infrastructure Errors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || 'rocm-dev-infra' }}
+          persist-credentials: false
+
+      - name: Fetch recent ROCm CI workflow runs
+        id: fetch_runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Monitor openxla/xla repository for failed ROCm CI runs
+          # Always monitor openxla/xla (the upstream repository)
+          MONITORED_REPO="openxla/xla"
+          echo "Monitoring repository: $MONITORED_REPO"
+
+          # Get current time from GitHub API (no dependency on runner's clock)
+          GITHUB_TIME=$(gh api /rate_limit | jq -r '.resources.core.reset' | xargs -I {} date -u -d '@{}' '+%Y-%m-%dT%H:%M:%SZ')
+          echo "GitHub API time: $GITHUB_TIME"
+
+          # Calculate cutoff: 6 hours before GitHub's current time (temporary for testing)
+          CUTOFF_TIME=$(date -u -d "$GITHUB_TIME - 6 hours" '+%Y-%m-%dT%H:%M:%SZ')
+          echo "Checking for failed runs after: $CUTOFF_TIME"
+
+          # First, let's see what runs are actually available (debug)
+          echo "All recent runs (any status):"
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${MONITORED_REPO}/actions/workflows/rocm_ci.yml/runs?per_page=10" \
+            | jq -r '.workflow_runs[] | "\(.id) - status: \(.status) - conclusion: \(.conclusion) - updated: \(.updated_at)"'
+
+          echo ""
+          echo "Checking specific run 34116809661:"
+          gh api "/repos/${MONITORED_REPO}/actions/runs/34116809661" 2>&1 | jq -r '{id: .id, status: .status, conclusion: .conclusion, workflow_path: .path, updated_at: .updated_at}' || echo "Run not found or error"
+
+          echo ""
+          echo "Recent failed runs:"
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${MONITORED_REPO}/actions/workflows/rocm_ci.yml/runs?status=completed&conclusion=failure&per_page=10" \
+            | jq -r '.workflow_runs[] | "\(.id) - updated: \(.updated_at) - created: \(.created_at)"'
+
+          # Get failed ROCm CI workflow runs from the last 2 hours
+          # Using updated_at (when run completed) instead of created_at
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${MONITORED_REPO}/actions/workflows/rocm_ci.yml/runs?status=completed&conclusion=failure&per_page=100" \
+            | jq -r --arg cutoff "$CUTOFF_TIME" '.workflow_runs[] | select(.updated_at > $cutoff) | .id' \
+            > run_ids.txt
+
+          echo "Found $(wc -l < run_ids.txt) failed runs from last 2 hours in ${MONITORED_REPO}"
+          cat run_ids.txt
+
+      - name: Download BEP artifacts
+        if: hashFiles('run_ids.txt') != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Always monitor openxla/xla (the upstream repository)
+          MONITORED_REPO="openxla/xla"
+
+          if [ ! -s run_ids.txt ]; then
+            echo "No failed runs to check, exiting early"
+            exit 0
+          fi
+
+          build_tools/rocm/monitor_bep_artifacts.sh run_ids.txt "${MONITORED_REPO}" || echo "no bep files found"
+
+      - name: Analyze BEP files for infrastructure errors
+        id: analyze
+        run: |
+          if [ ! -d "bep-files" ]; then
+            echo "No BEP files downloaded"
+            echo "has_infra_errors=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          HAS_INFRA_ERRORS=false
+          rm -f failed_runs.txt
+          touch failed_runs.txt
+
+          for run_dir in bep-files/run-*; do
+            [ ! -d "$run_dir" ] && continue
+
+            RUN_ID=$(basename "$run_dir" | sed 's/run-//')
+            FOUND_ERROR=false
+
+            for bep_file in "$run_dir"/*.json; do
+              [ ! -f "$bep_file" ] && continue
+
+              echo "Analyzing $bep_file"
+              set +e
+              OUTPUT=$(python3 build_tools/rocm/analyze_bep_infra_errors.py "$bep_file" 2>&1)
+              EXIT_CODE=$?
+              set -e
+
+              if [ $EXIT_CODE -ne 0 ]; then
+                echo "  -> Infrastructure error detected: $OUTPUT"
+                FOUND_ERROR=true
+                break
+              else
+                echo "  -> No infrastructure errors"
+              fi
+            done
+
+            if [ "$FOUND_ERROR" = true ]; then
+              echo "https://github.com/openxla/xla/actions/runs/${RUN_ID}" >> failed_runs.txt
+              HAS_INFRA_ERRORS=true
+            fi
+          done
+
+          if [ "$HAS_INFRA_ERRORS" = true ]; then
+            echo "has_infra_errors=true" >> "$GITHUB_OUTPUT"
+            echo "Runs with infrastructure errors:"
+            cat failed_runs.txt
+          else
+            echo "has_infra_errors=false" >> "$GITHUB_OUTPUT"
+            echo "No infrastructure errors found in BEP files"
+          fi
+
+      - name: Create or update issue for failed runs
+        if: steps.analyze.outputs.has_infra_errors == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          build_tools/rocm/create_infra_error_issue.sh \
+            failed_runs.txt \
+            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ GitHub Actions workflows and PR labels that drive automation in this fork.
 | `sync_upstream.yml`          | Every 3h (weekdays), daily (weekends)                             | Syncs `main` with `openxla/xla:main` via the GitHub merge-upstream API                                                                                                                                |
 | `claude_auto_review.yml`     | Every PR opened against a branch that has `pr_event_dispatch.yml` | Automatically runs Claude Opus 4.6-powered code review on every pull request                                                                                                                          |
 | `therock_xla_ci_nightly.yml` | Nightly at 5 AM UTC                                               | Runs the latest XLA (openxla/xla) and latest JAX (jax-ml/jax) unit tests suite and sanitizers TSAN, ASAN (using `therock_xla_ci_sanitizers.yml` script) on the latest [theRock nightlies](https://rocm.nightlies.amd.com/whl-multi-arch/rocm-sdk-devel/). Currently pinned to version 10.1 nightly |
+| `rocm_infra_monitor.yml`     | Every 1h                                                          | Analyzes xla upstream PRs to detect infrastructure problems. If infra problem is detected then new issue is created.                                                                                                                                |
 
 ### Opt-in PR labels
 

--- a/build_tools/rocm/analyze_bep_infra_errors.py
+++ b/build_tools/rocm/analyze_bep_infra_errors.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Check BEP JSON for infrastructure error events."""
+
+import json
+import re
+import sys
+
+if len(sys.argv) != 2:
+    sys.exit(2)
+
+bep_file = sys.argv[1]
+
+try:
+    with open(bep_file, "r") as f:
+        events = [json.loads(line) for line in f if line.strip()]
+except:
+    sys.exit(0)
+
+# Infrastructure failure reasons in aborted events
+INFRA_REASONS = [
+    "REMOTE_FAILURE",
+    "OUT_OF_MEMORY",
+    "INTERNAL",
+    "LOADING_FAILURE",
+    "NO_ANALYZE",
+    "NO_BUILD",
+]
+
+# Infrastructure error patterns in stderr/error messages
+INFRA_ERROR_PATTERNS = [
+    # Remote execution / RBE errors
+    r"Failed to query remote execution",
+    r"UNAVAILABLE.*Unable to resolve host",
+    r"remote cache.*failed",
+    r"remote execution.*failed",
+    r"Connection refused.*remote",
+
+    # Memory errors
+    r"out of memory",
+    r"cannot allocate memory",
+    r"OOM",
+    r"MemoryError",
+
+    # Disk errors
+    r"no space left on device",
+    r"disk.*full",
+    r"I/O error",
+
+    # Network errors
+    r"network.*unreachable",
+    r"connection.*timed out",
+    r"DNS.*failed",
+
+    # Bazel internal errors
+    r"internal error",
+    r"IllegalStateException",
+    r"NullPointerException",
+    r"bazel.*crashed",
+]
+
+found = False
+
+for e in events:
+    # Check for aborted events with infrastructure failure reasons
+    if "aborted" in e:
+        reason = e["aborted"].get("reason", "")
+        if reason in INFRA_REASONS:
+            print(f"INFRA_ERROR: aborted.reason={reason}")  # DISABLE_DEBUG_PRINT_CHECK
+            found = True
+
+    # Check stderr in progress events
+    if "progress" in e and "stderr" in e["progress"]:
+        stderr = e["progress"]["stderr"]
+        if isinstance(stderr, str):
+            for pattern in INFRA_ERROR_PATTERNS:
+                if re.search(pattern, stderr, re.IGNORECASE):
+                    print(f"INFRA_ERROR: {pattern}")  # DISABLE_DEBUG_PRINT_CHECK
+                    found = True
+                    break
+
+    # Check action events for failures (but skip test actions - those are test failures, not infra)
+    if "action" in e:
+        action = e["action"]
+        # Skip if this is a test action (test failures are not infrastructure errors)
+        action_type = action.get("type", "")
+        if action_type == "TestRunner":
+            continue
+
+        # Non-zero exit codes from non-test actions
+        if "exitCode" in action and action["exitCode"] != 0:
+            # Check if failure message indicates infrastructure issue
+            if "stderr" in action and isinstance(action["stderr"], str):
+                for pattern in INFRA_ERROR_PATTERNS:
+                    if re.search(pattern, action["stderr"], re.IGNORECASE):
+                        print(f"INFRA_ERROR: Action failure - {pattern}")  # DISABLE_DEBUG_PRINT_CHECK
+                        found = True
+                        break
+            if "stdout" in action and isinstance(action["stdout"], str):
+                for pattern in INFRA_ERROR_PATTERNS:
+                    if re.search(pattern, action["stdout"], re.IGNORECASE):
+                        print(f"INFRA_ERROR: Action failure - {pattern}")  # DISABLE_DEBUG_PRINT_CHECK
+                        found = True
+                        break
+
+sys.exit(1 if found else 0)

--- a/build_tools/rocm/create_infra_error_issue.sh
+++ b/build_tools/rocm/create_infra_error_issue.sh
@@ -43,23 +43,26 @@ fi
 
 TITLE="ROCm CI Infrastructure Errors Detected"
 
-# Get team members to assign
-TEAM_SLUG="ai-fw-openxla"
-ORG="ROCm"
-ASSIGNEES=""
+# Repository where issues should be created (ROCm fork, where the team has access)
+ISSUE_REPO="ROCm/xla"
 
-echo "Fetching team members from @${ORG}/${TEAM_SLUG}..."
-if MEMBERS=$(gh api "/orgs/${ORG}/teams/${TEAM_SLUG}/members" --jq '.[].login' 2>/dev/null); then
-    for member in $MEMBERS; do
-        ASSIGNEES="$ASSIGNEES --assignee $member"
-    done
-    echo "Will assign to: $MEMBERS"
-else
-    echo "Warning: Could not fetch team members, will create issue without assignees"
-fi
+# Team members to assign to infrastructure error issues
+# Adjust this list as needed
+TEAM_MEMBERS=(
+    alekstheod
+    i-chaochen
+    hsharsha
+)
+
+# Build assignee flags
+ASSIGNEES=""
+for member in "${TEAM_MEMBERS[@]}"; do
+    ASSIGNEES="$ASSIGNEES --assignee $member"
+done
+echo "Will assign to: ${TEAM_MEMBERS[*]}"
 
 # Check if an open issue already exists (search by title, not label)
-ISSUE_NUMBER=$(gh issue list --state open --search "in:title $TITLE" --json number --jq '.[0].number')
+ISSUE_NUMBER=$(gh issue list --repo "$ISSUE_REPO" --state open --search "in:title $TITLE" --json number --jq '.[0].number')
 
 BODY="## Failed ROCm CI Runs Detected
 
@@ -77,13 +80,14 @@ cc @ROCm/ai-fw-openxla
 *Last updated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*"
 
 if [ -n "$ISSUE_NUMBER" ]; then
-    echo "Updating existing issue #$ISSUE_NUMBER"
-    gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+    echo "Updating existing issue #$ISSUE_NUMBER in $ISSUE_REPO"
+    gh issue comment "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --body "$BODY"
     echo "Issue updated: #$ISSUE_NUMBER"
 else
-    echo "Creating new issue"
+    echo "Creating new issue in $ISSUE_REPO"
     # Try with label and assignees first, fallback if it fails
     if NEW_ISSUE=$(gh issue create \
+        --repo "$ISSUE_REPO" \
         --title "$TITLE" \
         --body "$BODY" \
         --label "rocm-infra-error" \
@@ -93,6 +97,7 @@ else
         echo "Warning: Could not create with label/assignees, trying without label"
         if [ -n "$ASSIGNEES" ]; then
             if NEW_ISSUE=$(gh issue create \
+                --repo "$ISSUE_REPO" \
                 --title "$TITLE" \
                 --body "$BODY" \
                 $ASSIGNEES 2>&1); then
@@ -100,12 +105,14 @@ else
             else
                 echo "Warning: Could not assign members, creating issue without assignees"
                 NEW_ISSUE=$(gh issue create \
+                    --repo "$ISSUE_REPO" \
                     --title "$TITLE" \
                     --body "$BODY")
                 echo "Issue created: $NEW_ISSUE"
             fi
         else
             NEW_ISSUE=$(gh issue create \
+                --repo "$ISSUE_REPO" \
                 --title "$TITLE" \
                 --body "$BODY")
             echo "Issue created: $NEW_ISSUE"

--- a/build_tools/rocm/create_infra_error_issue.sh
+++ b/build_tools/rocm/create_infra_error_issue.sh
@@ -52,6 +52,7 @@ TEAM_MEMBERS=(
     alekstheod
     i-chaochen
     hsharsha
+    charleshofer
 )
 
 # Build assignee flags

--- a/build_tools/rocm/create_infra_error_issue.sh
+++ b/build_tools/rocm/create_infra_error_issue.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Create or update GitHub issue for ROCm CI infrastructure errors.
+#
+# Usage: create_infra_error_issue.sh <errors_file> <workflow_run_url>
+#
+# Args:
+#   errors_file: File containing error details
+#   workflow_run_url: URL to the monitoring workflow run
+#
+# Exit codes:
+#   0: Success
+#   1: Error
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <errors_file> <workflow_run_url>" >&2
+    exit 1
+fi
+
+ERRORS_FILE="$1"
+WORKFLOW_URL="$2"
+
+if [ ! -f "$ERRORS_FILE" ]; then
+    echo "Error: Errors file not found: $ERRORS_FILE" >&2
+    exit 1
+fi
+
+TITLE="ROCm CI Infrastructure Errors Detected"
+
+# Check if an open issue already exists (search by title, not label)
+ISSUE_NUMBER=$(gh issue list --state open --search "in:title $TITLE" --json number --jq '.[0].number')
+
+BODY="## Failed ROCm CI Runs Detected
+
+Monitoring run: ${WORKFLOW_URL}
+
+The following runs failed and have BEP files for analysis:
+
+$(cat "$ERRORS_FILE")
+
+Review the BEP files in the workflow artifacts to determine if failures are infrastructure-related.
+
+cc @ROCm/ai-fw-openxla
+
+---
+*Last updated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*"
+
+if [ -n "$ISSUE_NUMBER" ]; then
+    echo "Updating existing issue #$ISSUE_NUMBER"
+    gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+    echo "Issue updated: #$ISSUE_NUMBER"
+else
+    echo "Creating new issue"
+    # Try with label first, fallback to no label if it fails
+    if NEW_ISSUE=$(gh issue create \
+        --title "$TITLE" \
+        --body "$BODY" \
+        --label "rocm-infra-error" 2>&1); then
+        echo "Issue created: $NEW_ISSUE"
+    else
+        echo "Warning: Could not create with label, creating without label"
+        NEW_ISSUE=$(gh issue create \
+            --title "$TITLE" \
+            --body "$BODY")
+        echo "Issue created: $NEW_ISSUE"
+    fi
+fi

--- a/build_tools/rocm/create_infra_error_issue.sh
+++ b/build_tools/rocm/create_infra_error_issue.sh
@@ -43,6 +43,21 @@ fi
 
 TITLE="ROCm CI Infrastructure Errors Detected"
 
+# Get team members to assign
+TEAM_SLUG="ai-fw-openxla"
+ORG="ROCm"
+ASSIGNEES=""
+
+echo "Fetching team members from @${ORG}/${TEAM_SLUG}..."
+if MEMBERS=$(gh api "/orgs/${ORG}/teams/${TEAM_SLUG}/members" --jq '.[].login' 2>/dev/null); then
+    for member in $MEMBERS; do
+        ASSIGNEES="$ASSIGNEES --assignee $member"
+    done
+    echo "Will assign to: $MEMBERS"
+else
+    echo "Warning: Could not fetch team members, will create issue without assignees"
+fi
+
 # Check if an open issue already exists (search by title, not label)
 ISSUE_NUMBER=$(gh issue list --state open --search "in:title $TITLE" --json number --jq '.[0].number')
 
@@ -67,17 +82,33 @@ if [ -n "$ISSUE_NUMBER" ]; then
     echo "Issue updated: #$ISSUE_NUMBER"
 else
     echo "Creating new issue"
-    # Try with label first, fallback to no label if it fails
+    # Try with label and assignees first, fallback if it fails
     if NEW_ISSUE=$(gh issue create \
         --title "$TITLE" \
         --body "$BODY" \
-        --label "rocm-infra-error" 2>&1); then
+        --label "rocm-infra-error" \
+        $ASSIGNEES 2>&1); then
         echo "Issue created: $NEW_ISSUE"
     else
-        echo "Warning: Could not create with label, creating without label"
-        NEW_ISSUE=$(gh issue create \
-            --title "$TITLE" \
-            --body "$BODY")
-        echo "Issue created: $NEW_ISSUE"
+        echo "Warning: Could not create with label/assignees, trying without label"
+        if [ -n "$ASSIGNEES" ]; then
+            if NEW_ISSUE=$(gh issue create \
+                --title "$TITLE" \
+                --body "$BODY" \
+                $ASSIGNEES 2>&1); then
+                echo "Issue created: $NEW_ISSUE"
+            else
+                echo "Warning: Could not assign members, creating issue without assignees"
+                NEW_ISSUE=$(gh issue create \
+                    --title "$TITLE" \
+                    --body "$BODY")
+                echo "Issue created: $NEW_ISSUE"
+            fi
+        else
+            NEW_ISSUE=$(gh issue create \
+                --title "$TITLE" \
+                --body "$BODY")
+            echo "Issue created: $NEW_ISSUE"
+        fi
     fi
 fi

--- a/build_tools/rocm/monitor_bep_artifacts.sh
+++ b/build_tools/rocm/monitor_bep_artifacts.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Download ROCm CI BEP artifacts from failed runs.
+#
+# Usage: monitor_bep_artifacts.sh <run_ids_file> <repository>
+#
+# Args:
+#   run_ids_file: File containing workflow run IDs (one per line)
+#   repository: GitHub repository in format "owner/repo"
+#
+# Exit codes:
+#   0: No runs with BEP files found
+#   1: Runs with BEP files found
+#   2: Script error
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <run_ids_file> <repository>" >&2
+    exit 2
+fi
+
+RUN_IDS_FILE="$1"
+REPOSITORY="$2"
+
+if [ ! -f "$RUN_IDS_FILE" ]; then
+    echo "Error: Run IDs file not found: $RUN_IDS_FILE" >&2
+    exit 2
+fi
+
+mkdir -p bep-files
+HAS_BEPS=false
+
+while read -r RUN_ID; do
+    [ -z "$RUN_ID" ] && continue
+
+    echo "========================================="
+    echo "Downloading BEP artifacts for run: $RUN_ID"
+    echo "========================================="
+
+    # Download JAX BEP artifact
+    if gh run download "$RUN_ID" -n jax-bep -D "bep-files/run-${RUN_ID}" -R "$REPOSITORY" 2>/dev/null; then
+        echo "Downloaded JAX BEP for run $RUN_ID from $REPOSITORY"
+        HAS_BEPS=true
+    fi
+
+    # Download XLA BEP artifacts
+    if gh run download "$RUN_ID" -n xla-bep -D "bep-files/run-${RUN_ID}" -R "$REPOSITORY" 2>/dev/null; then
+        echo "Downloaded XLA BEP for run $RUN_ID from $REPOSITORY"
+        HAS_BEPS=true
+    fi
+done < "$RUN_IDS_FILE"
+
+echo "========================================="
+if [ "$HAS_BEPS" = true ]; then
+    echo "Downloaded BEP files from failed runs"
+    echo "========================================="
+    exit 1
+else
+    echo "✓ No BEP files found in the checked runs"
+    echo "========================================="
+    exit 0
+fi


### PR DESCRIPTION
Adding rocm-infra validation pipeline. This pipeline will be executed periodically "period 1h" take all prs created on xla upstream for the last 2hrs and analyze their bep files. If infra error is detected this pipeline will create an issue with the links of all failed PRs due to the infrastructure issue. This will allow us to monitor our infra failures an react faster.